### PR TITLE
Add runtime check for installed vllm version

### DIFF
--- a/arctic_inference/utils.py
+++ b/arctic_inference/utils.py
@@ -1,0 +1,25 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from importlib.metadata import requires
+
+
+def get_compatible_vllm_version():
+    reqs = requires("arctic_inference")
+    for req in reqs:
+        match = re.match("vllm==(\d+\.\d+\.\d+);", req)
+        if match is not None:
+            return match.groups()[0]


### PR DESCRIPTION
- Add a utility function for getting the required vllm version required by ArcticInference
- Skip loading plugin if the vllm version does not match