### PR TITLE
Fix ParallelLMHead quantization

### DIFF
--- a/arctic_inference/vllm/spec_dec/vocab_parallel_embedding.py
+++ b/arctic_inference/vllm/spec_dec/vocab_parallel_embedding.py
@@ -28,6 +28,12 @@ class UnquantizedEmbeddingMethod(QuantizeMethodBase):
                        output_size: int, params_dtype: torch.dtype,
                        **extra_weight_attrs):
         """Create weights for embedding layer."""
+        output_size_per_partition = sum(output_partition_sizes)
+        layer.logical_widths = output_partition_sizes
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = output_size_per_partition
+        layer.orig_dtype = params_dtype
+        
         weight = Parameter(torch.empty(sum(output_partition_sizes),
                                        input_size_per_partition,
                                        dtype=params_dtype),


### PR DESCRIPTION
This PR addresses the quantization issue of the Spec model, as described in #37. The root cause was that certain fields in  `ParallelLMHead` were not properly set, leading to errors like `AttributeError: 'ParallelLMHead' object has no attribute 'logical_widths'` during the VLLM quantization process. The PR adopts the approach from [`create_weights` in VLLM](https://github.com/vllm-project/vllm/blob/a83a0f92b56b71855dc38e8e3d9809619e58bcd1/vllm/model_executor/layers/quantization/fp8.py#L190), initializing the required attributes. It offers an alternative to #38 and likely directly resolves #37 (works fine on my end).
