### PR TITLE
Reclaim `speculator_config` by  `vllm_config` before initializing the drafter.

### DIFF
--- a/arctic_inference/vllm/spec_dec/arctic_proposer.py
+++ b/arctic_inference/vllm/spec_dec/arctic_proposer.py
@@ -31,10 +31,9 @@ class ArcticProposer:
     def __init__(
         self,
         vllm_config: VllmConfig,
-        speculative_config: SpeculativeConfig,
     ):
         self.vllm_config = vllm_config
-        self.speculative_config = speculative_config
+        self.speculative_config = vllm_config.speculative_config
         self.num_predict_tokens = self.speculative_config.num_speculative_tokens
 
         self.model = None


### PR DESCRIPTION
Noticed this error when creating the n-gram based speculative decoding inference server.

I assume that you delay the creation of the `self.drafter` by setting the `vllm_config.speculative_config` to `None` just before running `self._orig_init(vllm_config, *args, **kwargs)`, so that you can implement the drafter choice logic yourself (so you can e.g. add your custom drafter).

However, to properly initialise drafters, such as `NgramProposer` or `EagleProposer`, the `vllm_config` needs to eventually reclaim its original `speculative_config`, so that the drafters can be properly initialised within `GPUModelRunnerPatch`.

## Before this fix:
```bash
uv venv .venv
source .venv/bin/activate
uv pip install arctic-inference[vllm]
uv pip install setuptools 
vllm serve facebook/opt-125m --speculative-config '{"model": "
ngram", "prompt_lookup_max": 4, "prompt_lookup_min": 2, "num_speculative_tokens":8}`
```

```bash
ERROR 05-13 12:15:31 [core.py:387]   File "/home/damian/grazie-ml/libs/grazie_inference/grazie/inference/new_benchmarking/.venv/lib/python3.10/site-packages/vllm/v1/spec_decode/ngram_proposer.py", line 14, in __init__
ERROR 05-13 12:15:31 [core.py:387]     self.min_n = vllm_config.speculative_config.prompt_lookup_min
ERROR 05-13 12:15:31 [core.py:387] AttributeError: 'NoneType' object has no attribute 'prompt_lookup_min'
```
