### PR TITLE
capture only the required shapes of the SP_TP model

### DIFF
--- a/arctic_inference/vllm/model_runner.py
+++ b/arctic_inference/vllm/model_runner.py
@@ -785,7 +785,7 @@ class GPUModelRunnerPatch(ArcticPatch[GPUModelRunner]):
             sp_size = self.parallel_config.ulysses_sequence_parallel_size
             for num_tokens in reversed(self.cudagraph_batch_sizes):
                 if (num_tokens * sp_size > self.shift_parallel_threshold and
-                        num_tokens * sp_size <= self.max_num_tokens):
+                    num_tokens * sp_size <= self.max_num_tokens):
                     for _ in range(self.vllm_config.compilation_config.
                                    cudagraph_num_of_warmups):
                         self._dummy_run(num_tokens * sp_size,
@@ -795,7 +795,8 @@ class GPUModelRunnerPatch(ArcticPatch[GPUModelRunner]):
             if self.shift_model is not None:
                 orig_model, self.model = self.model, self.shift_model
                 for num_tokens in reversed(self.cudagraph_batch_sizes):
-                    if num_tokens <= sp_tp_threshold:
+                    if (num_tokens <= sp_tp_threshold or 
+                        "SwiftKV" in self.model.__class__.__name__):
                         with set_shift_parallel_mode(True):
                             for _ in range(self.vllm_config.compilation_config.
                                             cudagraph_num_of_warmups):

--- a/arctic_inference/vllm/model_runner.py
+++ b/arctic_inference/vllm/model_runner.py
@@ -795,11 +795,12 @@ class GPUModelRunnerPatch(ArcticPatch[GPUModelRunner]):
             if self.shift_model is not None:
                 orig_model, self.model = self.model, self.shift_model
                 for num_tokens in reversed(self.cudagraph_batch_sizes):
-                    with set_shift_parallel_mode(True):
-                        for _ in range(self.vllm_config.compilation_config.
-                                        cudagraph_num_of_warmups):
+                    if num_tokens <= sp_tp_threshold:
+                        with set_shift_parallel_mode(True):
+                            for _ in range(self.vllm_config.compilation_config.
+                                            cudagraph_num_of_warmups):
+                                self._dummy_run(num_tokens, skip_attn=skip_attn)
                             self._dummy_run(num_tokens, skip_attn=skip_attn)
-                        self._dummy_run(num_tokens, skip_attn=skip_attn)
                 self.model = orig_model
 
         end_time = time.perf_counter()


### PR DESCRIPTION
include a conditional to invoke dummy_run only when num_tokens <= sp_tp_threshold so that the redundant shapes will not be captured.