### PR TITLE
compiler patch for fixing issue 72

### DIFF
--- a/arctic_inference/vllm/swiftkv/llama_swiftkv.py
+++ b/arctic_inference/vllm/swiftkv/llama_swiftkv.py
@@ -291,8 +291,7 @@ class LlamaSwiftKVDecodeRunner(nn.Module):
     ) -> torch.Tensor:
         # This is a hint for the compiler that v_states and k_states have
         # the same shape so that a single symbolic shape is inferred.
-        torch._check(v_states.shape[0] == k_states.shape[0],
-                     "k_states and v_states must have the same batch size")
+        torch._check(v_states.shape[0] != k_states.shape[0])
         num_layers = (self.config.num_hidden_layers -
                       self.config.num_key_value_layers)
         k_split = torch.chunk(k_states, num_layers, dim=-1)

--- a/arctic_inference/vllm/swiftkv/llama_swiftkv.py
+++ b/arctic_inference/vllm/swiftkv/llama_swiftkv.py
@@ -289,6 +289,10 @@ class LlamaSwiftKVDecodeRunner(nn.Module):
         k_states: torch.Tensor,
         v_states: torch.Tensor,
     ) -> torch.Tensor:
+        # This is a hint for the compiler that v_states and k_states have
+        # the same shape so that a single symbolic shape is inferred.
+        torch._check(v_states.shape[0] == k_states.shape[0],
+                     "k_states and v_states must have the same batch size")
         num_layers = (self.config.num_hidden_layers -
                       self.config.num_key_value_layers)
         k_split = torch.chunk(k_states, num_layers, dim=-1)

--- a/arctic_inference/vllm/swiftkv/llama_swiftkv.py
+++ b/arctic_inference/vllm/swiftkv/llama_swiftkv.py
@@ -292,7 +292,7 @@ class LlamaSwiftKVDecodeRunner(nn.Module):
         # This is a hint for the compiler that v_states and k_states have
         # the same shape so that a single symbolic shape is inferred.
         torch._check(v_states.shape[0] == k_states.shape[0],
-                     "k_states and v_states must have the same batch size")
+                     lambda: "k_states and v_states must have the same batch size")
         num_layers = (self.config.num_hidden_layers -
                       self.config.num_key_value_layers)
         k_split = torch.chunk(k_states, num_layers, dim=-1)

--- a/arctic_inference/vllm/swiftkv/llama_swiftkv.py
+++ b/arctic_inference/vllm/swiftkv/llama_swiftkv.py
@@ -292,7 +292,7 @@ class LlamaSwiftKVDecodeRunner(nn.Module):
         # This is a hint for the compiler that v_states and k_states have
         # the same shape so that a single symbolic shape is inferred.
         torch._check(v_states.shape[0] == k_states.shape[0],
-                     lambda: "k_states and v_states must have the same batch size")
+                     "k_states and v_states must have the same batch size")
         num_layers = (self.config.num_hidden_layers -
                       self.config.num_key_value_layers)
         k_split = torch.chunk(k_states, num_layers, dim=-1)

--- a/arctic_inference/vllm/ulysses.py
+++ b/arctic_inference/vllm/ulysses.py
@@ -430,34 +430,32 @@ class PiecewiseCompileInterpreterPatch(ArcticPatch[PiecewiseCompileInterpreter])
                     args: tuple[torch.fx.node.Argument,
                                 ...], kwargs: dict[str, Any]) -> Any:
         assert isinstance(target, str)
-        """ [Arctic Inference]
-        Since the patch class inherits the original class
-        through ArcticPatch class, we lose the access to the original class'
-        super() function. Instead of using super(), we directly invoke call_module
-        from the super of class PiecewiseCompileInterpreter(torch.fx.Interpreter).
-        """
+        # [Arctic Inference]
+        # Since the patch class inherits the original class
+        # through ArcticPatch class, we lose the access to the original class'
+        # super() function. Instead of using super(), we directly invoke call_module
+        # from the super of class PiecewiseCompileInterpreter(torch.fx.Interpreter).
         output = torch.fx.Interpreter.call_module(self, target, args, kwargs)
 
         if target in self.compile_submod_names:
             index = self.compile_submod_names.index(target)
             submod = self.fetch_attr(target)
-            """[Arctic Inference]
-            Compiling multiple models may yield subgraphs with certain symbolic
-            integer values that violates vllm's assumption here:
-            - v0.9.0.1/compilation/base_piecewise_backend.py#L64
-            The index of the significant symbol determines the runtime shape here:
-            - v0.9.0.1/compilation/cuda_piecewise_backend.py#L112
+            # [Arctic Inference]
+            # Compiling multiple models may yield subgraphs with certain symbolic
+            # integer values that violates vllm's assumption here:
+            # - v0.9.0.1/compilation/base_piecewise_backend.py#L64
+            # The index of the significant symbol determines the runtime shape here:
+            # - v0.9.0.1/compilation/cuda_piecewise_backend.py#L112
 
-            In the original model, the shape to be captured corresponds to the first
-            symbolic integer in the compiled function arguments as expected.
-            Apparently, this is not the case in the shift model. The compiler yields
-            additional symbolic integers that comes before the shape of the subgraph.
-            Therefore the assumed logic causes a crash at the end of the CUDA capture process.
+            # In vLLM's assumption the shape to be captured corresponds to the first
+            # symbolic integer in the compiled function arguments as expected.
+            # Apparently, this is not the case in the shift model. The compiler yields
+            # additional symbolic integers that comes before the shape of the subgraph.
+            # Therefore the assumed logic causes a crash at the end of the CUDA capture process.
             
-            The fix is relaxing vllm's original assumption that the first symbol
-            corresponds to the shape. Instead, we determine the symbol by looking at
-            the first fake tensor's shape, and find the matching symbol index.
-            """
+            # The fix is relaxing vllm's original assumption that the first symbol
+            # corresponds to the shape. Instead, we determine the symbol by looking at
+            # the first fake tensor's shape, and find the matching symbol index.
             sym_shape = self.find_symbolic_shape(args)
             sym_shape_indices = []
             for i, x in enumerate(args):

--- a/arctic_inference/vllm/ulysses.py
+++ b/arctic_inference/vllm/ulysses.py
@@ -415,9 +415,10 @@ class UlyssesFlashAttentionImplPatch(ArcticPatch[FlashAttentionImpl]):
 class PiecewiseCompileInterpreterPatch(ArcticPatch[PiecewiseCompileInterpreter]):
 
     # find the symbolic shape of the subgraph
-    def find_symbolic_shape(self, args):
+    def find_symbolic_shape(self, args: tuple[torch.fx.node.Argument,
+                                ...]) -> torch.SymInt:
         symbols = set()
-        for i, x in enumerate(args):
+        for x in args:
             if isinstance(x, torch._subclasses.fake_tensor.FakeTensor):
                 for dim in x.shape:
                     if isinstance(dim, torch.SymInt):

--- a/arctic_inference/vllm/ulysses.py
+++ b/arctic_inference/vllm/ulysses.py
@@ -459,7 +459,11 @@ class PiecewiseCompileInterpreterPatch(ArcticPatch[PiecewiseCompileInterpreter])
             the first fake tensor's shape, and find the matching symbol index.
             """
             sym_shape = self.find_symbolic_shape(args)
-            sym_shape_indices = [i for i, x in enumerate(args) if x == sym_shape]
+            sym_shape_indices = []
+            for i, x in enumerate(args):
+                if isinstance(x, torch.SymInt):
+                    if sym_shape == x:
+                        sym_shape_indices.append(i)
 
             global compilation_start_time
             compiled_graph_for_general_shape = self.vllm_backend.\

--- a/arctic_inference/vllm/ulysses.py
+++ b/arctic_inference/vllm/ulysses.py
@@ -16,7 +16,7 @@
 import threading
 import weakref
 from concurrent.futures import ThreadPoolExecutor
-from typing import Optional
+from typing import Optional, Any
 
 import torch
 import vllm.distributed.parallel_state as parallel_state

--- a/tests/benchmarks/benchmark_utils.py
+++ b/tests/benchmarks/benchmark_utils.py
@@ -25,6 +25,7 @@ VLLM_CONFIGS = {
         "tensor_parallel_size": 2,
         "ulysses_sequence_parallel_size": 2,
         "enable_shift_parallel": True,
+        "shift_parallel_threshold": 256,
         "enable_prefix_caching": False,
     },
     "llama_8b_swiftkv": {

--- a/tests/benchmarks/benchmark_utils.py
+++ b/tests/benchmarks/benchmark_utils.py
@@ -18,10 +18,12 @@ VLLM_CONFIGS = {
     "llama_8b": {
         "model": "RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic",
         "tensor_parallel_size": 2,
+        "ulysses_sequence_parallel_size": 2,
         "enable_prefix_caching": False,
     },
     "llama_8b_shift": {
         "model": "RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic",
+        "tensor_parallel_size": 2,
         "ulysses_sequence_parallel_size": 2,
         "enable_shift_parallel": True,
         "enable_prefix_caching": False,
@@ -29,11 +31,13 @@ VLLM_CONFIGS = {
     "llama_8b_swiftkv": {
         "model": "Snowflake/Llama-3.1-SwiftKV-8B-Instruct-FP8",
         "tensor_parallel_size": 2,
+        "ulysses_sequence_parallel_size": 2,
         "enable_prefix_caching": False,
     },
     "llama_8b_suffix": {
         "model": "RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic",
         "tensor_parallel_size": 2,
+        "ulysses_sequence_parallel_size": 2,
         "speculative_config": {
             "method": "suffix",
             "disable_by_batch_size": 64,
@@ -43,6 +47,7 @@ VLLM_CONFIGS = {
     "llama_8b_spec": {
         "model": "RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic",
         "tensor_parallel_size": 2,
+        "ulysses_sequence_parallel_size": 2,
         "speculative_config": {
             "method": "arctic",
             "model": "Snowflake/Arctic-LSTM-Speculator-Llama-3.1-8B-Instruct",
@@ -53,6 +58,7 @@ VLLM_CONFIGS = {
     },
     "llama_8b_all": {
         "model": "Snowflake/Llama-3.1-SwiftKV-8B-Instruct-FP8",
+        "tensor_parallel_size": 2,
         "ulysses_sequence_parallel_size": 2,
         "enable_shift_parallel": True,
         "speculative_config": {

--- a/tests/benchmarks/benchmark_utils.py
+++ b/tests/benchmarks/benchmark_utils.py
@@ -17,8 +17,7 @@ class BenchmarkTask:
 VLLM_CONFIGS = {
     "llama_8b": {
         "model": "RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic",
-        "tensor_parallel_size": 2,
-        "ulysses_sequence_parallel_size": 2,
+        "tensor_parallel_size": 4,
         "enable_prefix_caching": False,
     },
     "llama_8b_shift": {
@@ -30,14 +29,12 @@ VLLM_CONFIGS = {
     },
     "llama_8b_swiftkv": {
         "model": "Snowflake/Llama-3.1-SwiftKV-8B-Instruct-FP8",
-        "tensor_parallel_size": 2,
-        "ulysses_sequence_parallel_size": 2,
+        "tensor_parallel_size": 4,
         "enable_prefix_caching": False,
     },
     "llama_8b_suffix": {
         "model": "RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic",
-        "tensor_parallel_size": 2,
-        "ulysses_sequence_parallel_size": 2,
+        "tensor_parallel_size": 4,
         "speculative_config": {
             "method": "suffix",
             "disable_by_batch_size": 64,
@@ -46,8 +43,7 @@ VLLM_CONFIGS = {
     },
     "llama_8b_spec": {
         "model": "RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic",
-        "tensor_parallel_size": 2,
-        "ulysses_sequence_parallel_size": 2,
+        "tensor_parallel_size": 4,
         "speculative_config": {
             "method": "arctic",
             "model": "Snowflake/Arctic-LSTM-Speculator-Llama-3.1-8B-Instruct",


### PR DESCRIPTION
This fix handles this [issue](https://github.com/snowflakedb/ArcticInference/issues/72).

The issue was preventing using arbitrary (SP, TP) combinations with shift model because the shift model was violating vLLM's assumption of the order of `sym_shape_indices` [here](https://github.com/vllm-project/vllm/blob/v0.9.0.1/vllm/compilation/base_piecewise_backend.py#L64). Please see the diff for details.

The branch is tested on Llama, Qwen, and Mistral models with arbitrary of (SP, TP) combinations.