### PR TITLE
Enable MoE models (Qwen & Llama)

### DIFF
--- a/arctic_inference/vllm/model_runner.py
+++ b/arctic_inference/vllm/model_runner.py
@@ -188,7 +188,7 @@ class GPUModelRunnerPatch(ArcticPatch[GPUModelRunner]):
             N_offset = N_ulysses * sp_rank
 
             # narrow the input
-            kwargs[input_keyword] = input_tensor[N_offset:N_offset + N_ulysses]
+            kwargs[input_key] = input_tensor[N_offset:N_offset + N_ulysses]
             kwargs['positions'] = positions[N_offset:N_offset + N_ulysses]
 
             with set_shift_parallel_mode(False):

--- a/arctic_inference/vllm/model_runner.py
+++ b/arctic_inference/vllm/model_runner.py
@@ -175,19 +175,20 @@ class GPUModelRunnerPatch(ArcticPatch[GPUModelRunner]):
         sp_rank = parallel_state._SP.rank_in_group
         device_group = parallel_state._SP.device_group
         model_forward = self.model.forward
+        input_key = 'inputs_embeds' if  self.is_multimodal_model else 'input_ids'
 
         def ulysses_forward(*args, **kwargs):
             # update inputs
-            input_ids = kwargs['input_ids']
+            input_tensor = kwargs[input_key]
             positions = kwargs['positions']
             # Ulysses parameters
-            N = input_ids.shape[0]
+            N = input_tensor.shape[0]
 
             N_ulysses = N // sp_size
             N_offset = N_ulysses * sp_rank
 
             # narrow the input
-            kwargs['input_ids'] = input_ids[N_offset:N_offset + N_ulysses]
+            kwargs[input_keyword] = input_tensor[N_offset:N_offset + N_ulysses]
             kwargs['positions'] = positions[N_offset:N_offset + N_ulysses]
 
             with set_shift_parallel_mode(False):
@@ -195,7 +196,7 @@ class GPUModelRunnerPatch(ArcticPatch[GPUModelRunner]):
 
             if output.size(0) == N_ulysses:
                 # all-gather model_output
-                model_output = torch.empty((N, self.model.config.hidden_size),
+                model_output = torch.empty((N, self.hidden_size),
                                         dtype=output.dtype,
                                         device=output.device)
                 torch.distributed.all_gather_into_tensor(model_output,

--- a/arctic_inference/vllm/ulysses.py
+++ b/arctic_inference/vllm/ulysses.py
@@ -89,6 +89,12 @@ class UlyssesParallelStatePatch(ArcticPatch[parallel_state]):
     _SP_TP = None
     _SP_AA = None
     _SP_AG = None
+    # Rationale for SP_AA and SP_AG groups:
+    # When num_kv_heads > SP, the kv heads are distributed and replicated as in TP.
+    # To implement the logic, the distributed kv heads are exchanged with a local
+    # all-to-all within SP_AA group followed by an local all-gather within SP_AG
+    # group. The SP_AA and SP_AG groups partitions the SP group into two orthogonal
+    # sub-groups.
 
     @staticmethod
     def initialize_model_parallel(

--- a/arctic_inference/vllm/ulysses.py
+++ b/arctic_inference/vllm/ulysses.py
@@ -15,6 +15,7 @@
 
 import threading
 import weakref
+from contextlib import contextmanager
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional, Any
 
@@ -96,7 +97,6 @@ class UlyssesParallelStatePatch(ArcticPatch[parallel_state]):
     # group. The SP_AA and SP_AG groups partitions the SP group into two orthogonal
     # sub-groups and will not be initialized if max(1, num_kv_heads / TP) < SP.
 
-    @staticmethod
     def initialize_model_parallel(
         tensor_model_parallel_size: int = 1,
         pipeline_model_parallel_size: int = 1,
@@ -286,7 +286,6 @@ class UlyssesParallelStatePatch(ArcticPatch[parallel_state]):
                     f"  SP_AA {parallel_state._SP_AA.world_size} ranks {SP_AA_group_ranks}\n"
                     f"  SP_AG {parallel_state._SP_AG.world_size} ranks {SP_AG_group_ranks}\n")
 
-    from contextlib import contextmanager
     @contextmanager
     def graph_capture(device: torch.device):
         """

--- a/arctic_inference/vllm/ulysses.py
+++ b/arctic_inference/vllm/ulysses.py
@@ -397,7 +397,7 @@ class UlyssesAttentionPatch(ArcticPatch[Attention]):
     def __init__(self, num_heads, *args, **kwargs):
         from .model_runner import is_shift_parallel_mode
         self.sp_size = parallel_state._SP.world_size
-        self.device_group = parallel_state._SP.device_group
+        self.sp_device_group = parallel_state._SP.device_group
         if not is_shift_parallel_mode():
             num_heads //= self.sp_size
             num_kv_heads = kwargs["num_kv_heads"]

--- a/arctic_inference/vllm/ulysses.py
+++ b/arctic_inference/vllm/ulysses.py
@@ -276,15 +276,15 @@ class UlyssesParallelStatePatch(ArcticPatch[parallel_state]):
         get_world_group().barrier()
         if torch.distributed.get_rank() == 0:
             print(f"UlyssesParallelStatePatch initialized:\n"
-                    f"                               PP {_PP.rank_in_group} / {_PP.world_size} ranks {PP_group_ranks}\n"
-                    f"                               TP {_TP.rank_in_group} / {_TP.world_size} ranks {TP_group_ranks}\n"
-                    f"                               SP {_SP.rank_in_group} / {_SP.world_size} ranks {SP_group_ranks}\n"
-                    f"                               DP {_DP.rank_in_group} / {_DP.world_size} ranks {DP_group_ranks}\n"
-                    f"                               EP {_EP.rank_in_group} / {_EP.world_size} ranks {EP_group_ranks}\n"
-                    f"                               SP_TP {_SP_TP.rank_in_group} / {_SP_TP.world_size} ranks {SP_TP_group_ranks}")
+                    f"                               PP {_PP.world_size} ranks {PP_group_ranks}\n"
+                    f"                               TP {_TP.world_size} ranks {TP_group_ranks}\n"
+                    f"                               SP {_SP.world_size} ranks {SP_group_ranks}\n"
+                    f"                               DP {_DP.world_size} ranks {DP_group_ranks}\n"
+                    f"                               EP {_EP.world_size} ranks {EP_group_ranks}\n"
+                    f"                               SP_TP {_SP_TP.world_size} ranks {SP_TP_group_ranks}")
             if _SP_AA is not None and _SP_AG is not None:
-                print(f"                               SP_AA {_SP_AA.rank_in_group} / {_SP_AA.world_size} ranks {SP_AA_group_ranks}\n"
-                    f"                               SP_AG {_SP_AG.rank_in_group} / {_SP_AG.world_size} ranks {SP_AG_group_ranks}\n")
+                print(f"                               SP_AA {_SP_AA.world_size} ranks {SP_AA_group_ranks}\n"
+                    f"                               SP_AG {_SP_AG.world_size} ranks {SP_AG_group_ranks}\n")
 
     from contextlib import contextmanager
     @contextmanager
@@ -413,12 +413,7 @@ class UlyssesAttentionPatch(ArcticPatch[Attention]):
                 self.order = [j * self.sp_aa_size + i 
                               for i in range(self.sp_aa_size) 
                               for j in range(self.sp_ag_size)]
-                # self.order = [0, 4, 1, 5, 2, 6, 3, 7]
-                if torch.distributed.get_rank() == 0:
-                    print(f"UlyssesAttentionPatch: kv heads {num_kv_heads}, "
-                          f"sp_aa_size {self.sp_aa_size}, "
-                          f"sp_ag_size {self.sp_ag_size}, "
-                          f"order {self.order}")
+                # self.order = [0, 4, 1, 5, 2, 6, 3, 7] for Qwen3-30B-3B, SP=8
             else:
                 self.is_kv_replicated = False
                 num_kv_heads //= self.sp_size

--- a/arctic_inference/vllm/ulysses.py
+++ b/arctic_inference/vllm/ulysses.py
@@ -282,9 +282,9 @@ class UlyssesParallelStatePatch(ArcticPatch[parallel_state]):
                     f"                               DP {_DP.world_size} ranks {DP_group_ranks}\n"
                     f"                               EP {_EP.world_size} ranks {EP_group_ranks}\n"
                     f"                               SP_TP {_SP_TP.world_size} ranks {SP_TP_group_ranks}")
-            if _SP_AA is not None and _SP_AG is not None:
-                print(f"                               SP_AA {_SP_AA.world_size} ranks {SP_AA_group_ranks}\n"
-                    f"                               SP_AG {_SP_AG.world_size} ranks {SP_AG_group_ranks}\n")
+            if parallel_state._SP_AA is not None and parallel_state._SP_AG is not None:
+                print(f"                               SP_AA {parallel_state._SP_AA.world_size} ranks {SP_AA_group_ranks}\n"
+                    f"                               SP_AG {parallel_state._SP_AG.world_size} ranks {SP_AG_group_ranks}\n")
 
     from contextlib import contextmanager
     @contextmanager

--- a/arctic_inference/vllm/ulysses.py
+++ b/arctic_inference/vllm/ulysses.py
@@ -484,7 +484,7 @@ class UlyssesAttentionPatch(ArcticPatch[Attention]):
 
         # Ulysses all-to-all 2/2
         c = torch.empty_like(c_)
-        torch.distributed.all_to_all_single(c, c_, group=self.device_group)
+        torch.distributed.all_to_all_single(c, c_, group=self.sp_device_group)
         output = (c.view(self.sp_size, -1, self.num_heads * self.head_size)
                   .transpose(0, 1)
                   .reshape(-1, self.num_heads * self.sp_size * self.head_size))

--- a/arctic_inference/vllm/ulysses.py
+++ b/arctic_inference/vllm/ulysses.py
@@ -94,7 +94,7 @@ class UlyssesParallelStatePatch(ArcticPatch[parallel_state]):
     # To implement the logic, the distributed kv heads are exchanged with a local
     # all-to-all within SP_AA group followed by an local all-gather within SP_AG
     # group. The SP_AA and SP_AG groups partitions the SP group into two orthogonal
-    # sub-groups.
+    # sub-groups and will not be initialized if max(1, num_kv_heads / TP) < SP.
 
     @staticmethod
     def initialize_model_parallel(

--- a/arctic_inference/vllm/ulysses.py
+++ b/arctic_inference/vllm/ulysses.py
@@ -276,15 +276,15 @@ class UlyssesParallelStatePatch(ArcticPatch[parallel_state]):
         get_world_group().barrier()
         if torch.distributed.get_rank() == 0:
             print(f"UlyssesParallelStatePatch initialized:\n"
-                    f"                               PP {_PP.world_size} ranks {PP_group_ranks}\n"
-                    f"                               TP {_TP.world_size} ranks {TP_group_ranks}\n"
-                    f"                               SP {_SP.world_size} ranks {SP_group_ranks}\n"
-                    f"                               DP {_DP.world_size} ranks {DP_group_ranks}\n"
-                    f"                               EP {_EP.world_size} ranks {EP_group_ranks}\n"
-                    f"                               SP_TP {_SP_TP.world_size} ranks {SP_TP_group_ranks}")
+                    f"  PP {_PP.world_size} ranks {PP_group_ranks}\n"
+                    f"  TP {_TP.world_size} ranks {TP_group_ranks}\n"
+                    f"  SP {_SP.world_size} ranks {SP_group_ranks}\n"
+                    f"  DP {_DP.world_size} ranks {DP_group_ranks}\n"
+                    f"  EP {_EP.world_size} ranks {EP_group_ranks}\n"
+                    f"  SP_TP {_SP_TP.world_size} ranks {SP_TP_group_ranks}")
             if parallel_state._SP_AA is not None and parallel_state._SP_AG is not None:
-                print(f"                               SP_AA {parallel_state._SP_AA.world_size} ranks {SP_AA_group_ranks}\n"
-                    f"                               SP_AG {parallel_state._SP_AG.world_size} ranks {SP_AG_group_ranks}\n")
+                print(f"  SP_AA {parallel_state._SP_AA.world_size} ranks {SP_AA_group_ranks}\n"
+                    f"  SP_AG {parallel_state._SP_AG.world_size} ranks {SP_AG_group_ranks}\n")
 
     from contextlib import contextmanager
     @contextmanager
@@ -440,8 +440,8 @@ class UlyssesAttentionPatch(ArcticPatch[Attention]):
                             value.view(-1, self.sp_aa_size, self.num_kv_heads * self.head_size)),
                            dim=-1).transpose(0, 1).reshape(
                                -1, 2 * self.num_kv_heads * self.head_size)
-            kv__ = torch.empty_like(kv)
             # Ulysses all-to-all (key, value)
+            kv__ = torch.empty_like(kv)
             torch.distributed.all_to_all_single(kv__, kv, group=self.sp_aa_device_group)
             # Ulysses all-gather (key, value)
             kv_ = torch.empty(q_.shape[0],


### PR DESCRIPTION
Enables Qwen3-30B-A3B by handling Ulysses attention when kv_heads < SP.

New communicators is created for implementing partial all-to-all and all-gather of the replicated KV communication.

<img width="955" height="247" alt="Screenshot 2025-07-14 at 3 31 45 PM" src="https://github.com/user-attachments/assets/7e23199a-23dd-477d-aa3a-c69118f5cd60" />
