### PR TITLE
Allow overrides of benchmark test configs

### DIFF
--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -1,12 +1,50 @@
 import json
 import pathlib
+import yaml
 
+import benchmark_utils
 from .benchmark_utils import get_benchmark_summary
+
 
 
 def pytest_addoption(parser):
     parser.addoption("--benchmark-result-dir", type=pathlib.Path)
+    parser.addoption("--benchmark-config", type=pathlib.Path)
 
+def pytest_configure(config):
+    path = config.getoption("--benchmark-config")
+    if not path:
+        return
+
+    with open(path, "r") as f:
+        overrides = yaml.safe_load(f)
+
+    for key, value in overrides.items():
+        config_dict_name = key.upper()
+        if config_dict_name in benchmark_utils.__dict__:
+            if config_dict_name.endswith('_TASKS'):
+                task_dict = {}
+                for task_name, task_data in value.items():
+                    task_dict[task_name] = benchmark_utils.BenchmarkTask(
+                        config=task_data['config'],
+                        metrics=task_data['metrics']
+                    )
+                benchmark_utils.__dict__[config_dict_name] = task_dict
+            else:
+                benchmark_utils.__dict__[config_dict_name] = value
+
+def pytest_generate_tests(metafunc):
+    """Dynamic parametrization that runs after pytest_configure."""
+    if "vllm_server" in metafunc.fixturenames:
+        metafunc.parametrize("vllm_server", list(benchmark_utils.VLLM_CONFIGS.keys()), indirect=True)
+    
+    if "task_name" in metafunc.fixturenames:
+        if "test_performance" in metafunc.function.__name__:
+            metafunc.parametrize("task_name", list(benchmark_utils.PERFORMANCE_TASKS.keys()))
+        elif "test_accuracy" in metafunc.function.__name__:
+            metafunc.parametrize("task_name", list(benchmark_utils.ACCURACY_TASKS.keys()))
+        elif "test_json_mode" in metafunc.function.__name__:
+            metafunc.parametrize("task_name", list(benchmark_utils.JSON_MODE_TASKS.keys()))
 
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
     """

--- a/tests/benchmarks/example_config_override.yaml
+++ b/tests/benchmarks/example_config_override.yaml
@@ -1,0 +1,32 @@
+vllm_configs:
+  my_custom_config:
+    model: "some-other-model"
+    tensor_parallel_size: 2
+
+performance_tasks:
+  my_batch_test:
+    config:
+      dataset_name: "random"
+      random_input_len: 1000
+      random_output_len: 100
+      num_prompts: 500
+    metrics:
+      throughput: "total_token_throughput"
+
+accuracy_tasks:
+  my_arc_test:
+    config:
+      tasks: ["arc_challenge_chat"]
+      apply_chat_template: true
+      num_fewshot: 3
+    metrics:
+      acc: "exact_match,remove_whitespace"
+
+json_mode_tasks:
+  my_json_test:
+    config:
+      task: "json-mode-all"
+      input: "json_mode/datasets/WikiQuestions.json"
+      n_samples: 10
+    metrics:
+      score: "json-mode-all"

--- a/tests/benchmarks/test_benchmarks.py
+++ b/tests/benchmarks/test_benchmarks.py
@@ -7,9 +7,9 @@ import time
 import pytest
 import requests
 import uvloop
-#from vllm.entrypoints.openai.api_server import (
-#    make_arg_parser, run_server, validate_parsed_serve_args)
-#from vllm.utils import FlexibleArgumentParser
+from vllm.entrypoints.openai.api_server import (
+    make_arg_parser, run_server, validate_parsed_serve_args)
+from vllm.utils import FlexibleArgumentParser
 
 from .benchmark_utils import (ACCURACY_TASKS, PERFORMANCE_TASKS, VLLM_CONFIGS,
                               JSON_MODE_TASKS, update_benchmark_summary)                  

--- a/tests/benchmarks/test_benchmarks.py
+++ b/tests/benchmarks/test_benchmarks.py
@@ -7,16 +7,16 @@ import time
 import pytest
 import requests
 import uvloop
-from vllm.entrypoints.openai.api_server import (
-    make_arg_parser, run_server, validate_parsed_serve_args)
-from vllm.utils import FlexibleArgumentParser
+#from vllm.entrypoints.openai.api_server import (
+#    make_arg_parser, run_server, validate_parsed_serve_args)
+#from vllm.utils import FlexibleArgumentParser
 
 from .benchmark_utils import (ACCURACY_TASKS, PERFORMANCE_TASKS, VLLM_CONFIGS,
                               JSON_MODE_TASKS, update_benchmark_summary)                  
 
 CUSTOM_PORT = 8080
 
-@pytest.fixture(scope="module", params=list(VLLM_CONFIGS.keys()))
+@pytest.fixture(scope="module")
 def vllm_server(request):
     """
     Fixture to start the OpenAI API server for testing.
@@ -73,7 +73,6 @@ def vllm_server(request):
     print("Server process terminated")
 
 
-@pytest.mark.parametrize("task_name", list(PERFORMANCE_TASKS.keys()))
 def test_performance(request, vllm_server, task_name):
     from vllm.benchmarks.serve import add_cli_args, main
 
@@ -113,7 +112,6 @@ def test_performance(request, vllm_server, task_name):
     update_benchmark_summary(config_name, task_name, metrics)
 
 
-@pytest.mark.parametrize("task_name", list(ACCURACY_TASKS.keys()))
 def test_accuracy(request, vllm_server, task_name):
 
     config_name, vllm_args = vllm_server
@@ -181,7 +179,6 @@ def test_accuracy(request, vllm_server, task_name):
     update_benchmark_summary(config_name, task_name, metrics)
 
 
-@pytest.mark.parametrize("task_name", list(JSON_MODE_TASKS.keys()))
 def test_json_mode(request, vllm_server, task_name):
     """
     Test JSON mode using the evaluate_text_json_mode script.


### PR DESCRIPTION
Added `--benchmark-config` option when running pytest to override defaults:

```shell
❯ python -m pytest --collect-only -q                               
tests/benchmarks/test_benchmarks.py::test_performance[llama_8b-batch]
tests/benchmarks/test_benchmarks.py::test_performance[llama_8b-single]
tests/benchmarks/test_benchmarks.py::test_accuracy[llama_8b-arc_challenge]
tests/benchmarks/test_benchmarks.py::test_accuracy[llama_8b-gsm8k]
tests/benchmarks/test_benchmarks.py::test_accuracy[llama_8b-ifeval]
tests/benchmarks/test_benchmarks.py::test_accuracy[llama_8b-mmlu_pro]
tests/benchmarks/test_benchmarks.py::test_json_mode[llama_8b-json_mode_score]
tests/benchmarks/test_benchmarks.py::test_performance[llama_8b_shift-batch]
tests/benchmarks/test_benchmarks.py::test_performance[llama_8b_shift-single]
tests/benchmarks/test_benchmarks.py::test_accuracy[llama_8b_shift-arc_challenge]
tests/benchmarks/test_benchmarks.py::test_accuracy[llama_8b_shift-gsm8k]
tests/benchmarks/test_benchmarks.py::test_accuracy[llama_8b_shift-ifeval]
tests/benchmarks/test_benchmarks.py::test_accuracy[llama_8b_shift-mmlu_pro]
tests/benchmarks/test_benchmarks.py::test_json_mode[llama_8b_shift-json_mode_score]
tests/benchmarks/test_benchmarks.py::test_performance[llama_8b_swiftkv-batch]
tests/benchmarks/test_benchmarks.py::test_performance[llama_8b_swiftkv-single]
tests/benchmarks/test_benchmarks.py::test_accuracy[llama_8b_swiftkv-arc_challenge]
tests/benchmarks/test_benchmarks.py::test_accuracy[llama_8b_swiftkv-gsm8k]
tests/benchmarks/test_benchmarks.py::test_accuracy[llama_8b_swiftkv-ifeval]
tests/benchmarks/test_benchmarks.py::test_accuracy[llama_8b_swiftkv-mmlu_pro]
tests/benchmarks/test_benchmarks.py::test_json_mode[llama_8b_swiftkv-json_mode_score]
tests/benchmarks/test_benchmarks.py::test_performance[llama_8b_suffix-batch]
tests/benchmarks/test_benchmarks.py::test_performance[llama_8b_suffix-single]
tests/benchmarks/test_benchmarks.py::test_accuracy[llama_8b_suffix-arc_challenge]
tests/benchmarks/test_benchmarks.py::test_accuracy[llama_8b_suffix-gsm8k]
tests/benchmarks/test_benchmarks.py::test_accuracy[llama_8b_suffix-ifeval]
tests/benchmarks/test_benchmarks.py::test_accuracy[llama_8b_suffix-mmlu_pro]
tests/benchmarks/test_benchmarks.py::test_json_mode[llama_8b_suffix-json_mode_score]
tests/benchmarks/test_benchmarks.py::test_performance[llama_8b_spec-batch]
tests/benchmarks/test_benchmarks.py::test_performance[llama_8b_spec-single]
tests/benchmarks/test_benchmarks.py::test_accuracy[llama_8b_spec-arc_challenge]
tests/benchmarks/test_benchmarks.py::test_accuracy[llama_8b_spec-gsm8k]
tests/benchmarks/test_benchmarks.py::test_accuracy[llama_8b_spec-ifeval]
tests/benchmarks/test_benchmarks.py::test_accuracy[llama_8b_spec-mmlu_pro]
tests/benchmarks/test_benchmarks.py::test_json_mode[llama_8b_spec-json_mode_score]
tests/benchmarks/test_benchmarks.py::test_performance[llama_8b_all-batch]
tests/benchmarks/test_benchmarks.py::test_performance[llama_8b_all-single]
tests/benchmarks/test_benchmarks.py::test_accuracy[llama_8b_all-arc_challenge]
tests/benchmarks/test_benchmarks.py::test_accuracy[llama_8b_all-gsm8k]
tests/benchmarks/test_benchmarks.py::test_accuracy[llama_8b_all-ifeval]
tests/benchmarks/test_benchmarks.py::test_accuracy[llama_8b_all-mmlu_pro]
tests/benchmarks/test_benchmarks.py::test_json_mode[llama_8b_all-json_mode_score]

42 tests collected in 0.06s
```

```shell
❯ python -m pytest --collect-only -q --benchmark-config ./example_config_override.yaml 
tests/benchmarks/test_benchmarks.py::test_performance[my_custom_config-my_batch_test]
tests/benchmarks/test_benchmarks.py::test_accuracy[my_custom_config-my_arc_test]
tests/benchmarks/test_benchmarks.py::test_json_mode[my_custom_config-my_json_test]

3 tests collected in 0.07s
```