### PR TITLE
Accelerate benchmarks by saturating GPUs

### DIFF
--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -6,6 +6,7 @@ import pathlib
 import subprocess
 import sys
 import time
+import torch
 from typing import Any, Dict, List
 
 import pytest
@@ -18,7 +19,6 @@ from .benchmark_utils import (ACCURACY_TASKS, JSON_MODE_TASKS,
                               PERFORMANCE_TASKS, VLLM_CONFIGS,
                               get_benchmark_summary)
 
-# --- Configuration for the parallel runner ---
 MAX_GPUS = torch.cuda.device_count()
 BASE_PORT = 8080
 
@@ -83,7 +83,7 @@ class BatchServerManager:
             return
         self.teardown_current_batch()
         self.current_batch_idx = batch_idx
-        print(f"\n--- 🚀 Starting Batch {batch_idx}: {batch_configs} ---")
+        print(f"\nStarting Batch {batch_idx}: {batch_configs} ---")
         gpu_pool = list(range(MAX_GPUS))
         gpus_assigned = 0
         for i, config_name in enumerate(batch_configs):
@@ -113,8 +113,7 @@ class BatchServerManager:
         if not self.processes:
             return
         print(
-            f"\n--- 🛑 Terminating servers for Batch {self.current_batch_idx} ---"
-        )
+            f"\n---Terminating servers for Batch {self.current_batch_idx} ---")
         for name, p in self.processes.items():
             if p.poll() is None:  # Check if the process is still running
                 print(

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -14,7 +14,6 @@ import requests
 
 import vllm
 
-# NOTE: We no longer import internal vLLM server code, making this more stable.
 from .benchmark_utils import (ACCURACY_TASKS, JSON_MODE_TASKS,
                               PERFORMANCE_TASKS, VLLM_CONFIGS,
                               get_benchmark_summary)
@@ -97,7 +96,6 @@ class BatchServerManager:
             gpus_assigned += gpus_needed
             self.port_map[config_name] = port
 
-            # Build the command and environment for the subprocess
             command = self._build_server_command(config_name, port)
             env = os.environ.copy()
             env["CUDA_VISIBLE_DEVICES"] = ",".join(map(str, gpu_ids))
@@ -105,7 +103,7 @@ class BatchServerManager:
             print(
                 f"  -> Launching '{config_name}' on port {port} with GPUs {gpu_ids}..."
             )
-            # Launch the server as a new, independent subprocess
+
             p = subprocess.Popen(command, env=env)
             self.processes[config_name] = p
 
@@ -118,7 +116,7 @@ class BatchServerManager:
         print(
             f"\n---Terminating servers for Batch {self.current_batch_idx} ---")
         for name, p in self.processes.items():
-            if p.poll() is None:  # Check if the process is still running
+            if p.poll() is None:
                 print(
                     f"  -> Terminating '{name}' on port {self.port_map.get(name)}"
                 )
@@ -155,7 +153,6 @@ class BatchServerManager:
         url = f"http://localhost:{port}/health"
         start_time = time.time()
         while True:
-            # Check if the process terminated unexpectedly
             if process.poll() is not None:
                 raise RuntimeError(
                     f"Server on port {port} terminated unexpectedly. "
@@ -166,14 +163,12 @@ class BatchServerManager:
                     print(f"Server on port {port} is ready.")
                     return
             except requests.exceptions.RequestException:
-                pass  # Not ready yet
+                pass
 
             if time.time() - start_time > 3600:
                 raise TimeoutError(f"Server on port {port} failed to start.")
             time.sleep(5)
 
-
-# --- The rest of the file remains the same ---
 
 batch_manager = BatchServerManager()
 

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -1,7 +1,26 @@
+import argparse
 import json
+import multiprocessing
+import os
 import pathlib
+import subprocess
+import sys
+import time
+from typing import Any, Dict, List
 
-from .benchmark_utils import get_benchmark_summary
+import pytest
+import requests
+
+import vllm
+
+# NOTE: We no longer import internal vLLM server code, making this more stable.
+from .benchmark_utils import (ACCURACY_TASKS, JSON_MODE_TASKS,
+                              PERFORMANCE_TASKS, VLLM_CONFIGS,
+                              get_benchmark_summary)
+
+# --- Configuration for the parallel runner ---
+MAX_GPUS = torch.cuda.device_count()
+BASE_PORT = 8080
 
 
 def pytest_addoption(parser):
@@ -9,20 +28,13 @@ def pytest_addoption(parser):
 
 
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
-    """
-    Add benchmark summary to pytest's terminal summary, and save it to a file
-    if a benchmark result directory is specified.
-    """
     summary = get_benchmark_summary()
-
     if summary.empty:
         return
 
-    # Print the summary to the terminal
     terminalreporter.write_sep("=", "Final Benchmark Summary")
     terminalreporter.write_line(summary.to_string())
 
-    # Save the summary to a file if a benchmark result directory is specified
     benchmark_result_dir = config.option.benchmark_result_dir
     if benchmark_result_dir is not None:
         benchmark_result_dir.mkdir(parents=True, exist_ok=True)
@@ -34,3 +46,185 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
                 summary_dict[task][metric][config_name] = config_value
         with open(benchmark_result_dir / "summary.json", "w") as f:
             json.dump(summary_dict, f, indent=4)
+
+
+def _schedule_configs() -> List[List[str]]:
+    sorted_configs = sorted(
+        VLLM_CONFIGS.items(),
+        key=lambda item: item[1].get("tensor_parallel_size", 1),
+        reverse=True)
+    batches: List[List[str]] = []
+    current_batch: List[str] = []
+    gpus_used_in_batch = 0
+    for name, config in sorted_configs:
+        gpus_needed = config.get("tensor_parallel_size", 1)
+        if gpus_used_in_batch + gpus_needed <= MAX_GPUS:
+            current_batch.append(name)
+            gpus_used_in_batch += gpus_needed
+        else:
+            if current_batch:
+                batches.append(current_batch)
+            current_batch = [name]
+            gpus_used_in_batch = gpus_needed
+    if current_batch:
+        batches.append(current_batch)
+    return batches
+
+
+class BatchServerManager:
+
+    def __init__(self):
+        self.current_batch_idx = -1
+        self.processes: Dict[str, subprocess.Popen] = {}
+        self.port_map: Dict[str, int] = {}
+
+    def start_batch(self, batch_idx: int, batch_configs: List[str]):
+        if self.current_batch_idx == batch_idx:
+            return
+        self.teardown_current_batch()
+        self.current_batch_idx = batch_idx
+        print(f"\n--- 🚀 Starting Batch {batch_idx}: {batch_configs} ---")
+        gpu_pool = list(range(MAX_GPUS))
+        gpus_assigned = 0
+        for i, config_name in enumerate(batch_configs):
+            port = BASE_PORT + i
+            gpus_needed = VLLM_CONFIGS[config_name].get(
+                "tensor_parallel_size", 1)
+            gpu_ids = gpu_pool[gpus_assigned:gpus_assigned + gpus_needed]
+            gpus_assigned += gpus_needed
+            self.port_map[config_name] = port
+
+            # Build the command and environment for the subprocess
+            command = self._build_server_command(config_name, port)
+            env = os.environ.copy()
+            env["CUDA_VISIBLE_DEVICES"] = ",".join(map(str, gpu_ids))
+
+            print(
+                f"  -> Launching '{config_name}' on port {port} with GPUs {gpu_ids}..."
+            )
+            # Launch the server as a new, independent subprocess
+            p = subprocess.Popen(command, env=env)
+            self.processes[config_name] = p
+
+        for config_name, process in self.processes.items():
+            self._wait_for_server_ready(process, self.port_map[config_name])
+
+    def teardown_current_batch(self):
+        if not self.processes:
+            return
+        print(
+            f"\n--- 🛑 Terminating servers for Batch {self.current_batch_idx} ---"
+        )
+        for name, p in self.processes.items():
+            if p.poll() is None:  # Check if the process is still running
+                print(
+                    f"  -> Terminating '{name}' on port {self.port_map.get(name)}"
+                )
+                p.terminate()
+                try:
+                    p.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    p.kill()
+        self.processes.clear()
+        self.port_map.clear()
+
+    @staticmethod
+    def _build_server_command(config_name: str, port: int) -> List[str]:
+        """Builds the command-line argument list to launch the server."""
+        command = [sys.executable, "-m", "vllm.entrypoints.openai.api_server"]
+        config = VLLM_CONFIGS[config_name]
+
+        for key, value in config.items():
+            arg_name = f"--{key.replace('_', '-')}"
+            if isinstance(value, bool):
+                if value:
+                    command.append(arg_name)
+            elif isinstance(value, dict):
+                command.extend([arg_name, json.dumps(value)])
+            else:
+                command.extend([arg_name, str(value)])
+
+        command.extend(["--port", str(port)])
+        command.append("--disable-log-requests")
+        return command
+
+    @staticmethod
+    def _wait_for_server_ready(process: subprocess.Popen, port: int):
+        url = f"http://localhost:{port}/health"
+        start_time = time.time()
+        while True:
+            # Check if the process terminated unexpectedly
+            if process.poll() is not None:
+                raise RuntimeError(
+                    f"Server on port {port} terminated unexpectedly. "
+                    f"Return code: {process.returncode}")
+
+            try:
+                if requests.get(url, timeout=5).status_code == 200:
+                    print(f"Server on port {port} is ready.")
+                    return
+            except requests.exceptions.RequestException:
+                pass  # Not ready yet
+
+            if time.time() - start_time > 3600:
+                raise TimeoutError(f"Server on port {port} failed to start.")
+            time.sleep(5)
+
+
+# --- The rest of the file remains the same ---
+
+batch_manager = BatchServerManager()
+
+
+def pytest_sessionstart(session):
+    session.config.vllm_batches = _schedule_configs()
+
+
+def pytest_generate_tests(metafunc):
+    if "benchmark_spec" in metafunc.fixturenames:
+        batches = metafunc.config.vllm_batches
+        all_specs: List[Dict[str, Any]] = []
+        all_ids: List[str] = []
+        task_map = {
+            "test_performance": PERFORMANCE_TASKS,
+            "test_accuracy": ACCURACY_TASKS,
+            "test_json_mode": JSON_MODE_TASKS,
+        }
+        test_func_name = metafunc.function.__name__
+        if test_func_name in task_map:
+            tasks_to_run = task_map[test_func_name]
+            for batch_idx, configs in enumerate(batches):
+                for config_name in configs:
+                    for task_name, task_obj in tasks_to_run.items():
+                        all_specs.append({
+                            "batch_idx": batch_idx,
+                            "config_name": config_name,
+                            "task_name": task_name,
+                            "task_obj": task_obj,
+                        })
+                        all_ids.append(
+                            f"b{batch_idx}-{config_name}-{task_name}")
+        metafunc.parametrize("benchmark_spec",
+                             all_specs,
+                             ids=all_ids,
+                             indirect=True)
+
+
+def pytest_collection_modifyitems(session, config, items):
+    items.sort(
+        key=lambda item: item.callspec.params["benchmark_spec"]["batch_idx"])
+
+
+@pytest.fixture(scope="module")
+def benchmark_spec(request):
+    spec = request.param
+    batch_idx = spec["batch_idx"]
+    batches = request.config.vllm_batches
+    batch_manager.start_batch(batch_idx, batches[batch_idx])
+    config_name = spec["config_name"]
+    spec["port"] = batch_manager.port_map[config_name]
+    yield spec
+
+
+def pytest_sessionfinish(session, exitstatus):
+    batch_manager.teardown_current_batch()

--- a/tests/benchmarks/test_benchmarks.py
+++ b/tests/benchmarks/test_benchmarks.py
@@ -58,7 +58,8 @@ def test_accuracy(benchmark_spec, request):
     port = benchmark_spec["port"]
 
     vllm_config = VLLM_CONFIGS[config_name]
-    assert len(task.config["tasks"]) == 1, "Accuracy benchmarks must have one task."
+    assert len(
+        task.config["tasks"]) == 1, "Accuracy benchmarks must have one task."
 
     q = multiprocessing.Queue()
 
@@ -124,7 +125,7 @@ def test_json_mode(benchmark_spec, request):
         pytest.skip("Skipping JSON mode test for spec + suffix decoding.")
 
     from .json_mode.evaluate_text_json_mode import main as evaluate_json
-    
+
     with tempfile.TemporaryDirectory() as tmpdir:
         result_path = f"{tmpdir}/result.json"
         # The evaluate_json script saves its own file, so we pass it the full path
@@ -141,10 +142,16 @@ def test_json_mode(benchmark_spec, request):
         parser.add_argument("--model", type=str, default=vllm_config["model"])
         parser.add_argument("--output", type=str, default=result_path)
         parser.add_argument("--port", type=int, default=port)
-        parser.add_argument("--task", type=str, default=task.config.get("task"))
-        parser.add_argument("--input", type=str, default=task.config.get("input"))
-        parser.add_argument("--n-samples", type=int, default=task.config.get("n_samples"))
-        
+        parser.add_argument("--task",
+                            type=str,
+                            default=task.config.get("task"))
+        parser.add_argument("--input",
+                            type=str,
+                            default=task.config.get("input"))
+        parser.add_argument("--n-samples",
+                            type=int,
+                            default=task.config.get("n_samples"))
+
         args = parser.parse_args([])
         evaluate_json(args)
 
@@ -153,7 +160,9 @@ def test_json_mode(benchmark_spec, request):
 
     result_data = result.get("results", {})
     metrics = {
-        name: key(result_data) if callable(key) else result_data.get(key, {}).get("score")
+        name:
+        key(result_data)
+        if callable(key) else result_data.get(key, {}).get("score")
         for name, key in task.metrics.items()
     }
     update_benchmark_summary(config_name, task_name, metrics)

--- a/tests/benchmarks/test_benchmarks.py
+++ b/tests/benchmarks/test_benchmarks.py
@@ -8,7 +8,6 @@ from .benchmark_utils import VLLM_CONFIGS, update_benchmark_summary
 
 def test_performance(benchmark_spec, request):
     """Tests vLLM performance (throughput and latency)."""
-    # Unpack the spec for the current test case
     config_name = benchmark_spec["config_name"]
     task_name = benchmark_spec["task_name"]
     task = benchmark_spec["task_obj"]
@@ -16,7 +15,6 @@ def test_performance(benchmark_spec, request):
 
     vllm_config = VLLM_CONFIGS[config_name]
 
-    # Run the performance benchmark client
     from vllm.benchmarks.serve import add_cli_args, main
     parser = argparse.ArgumentParser()
     add_cli_args(parser)
@@ -128,14 +126,12 @@ def test_json_mode(benchmark_spec, request):
 
     with tempfile.TemporaryDirectory() as tmpdir:
         result_path = f"{tmpdir}/result.json"
-        # The evaluate_json script saves its own file, so we pass it the full path
         final_result_path = None
         benchmark_result_dir = request.config.option.benchmark_result_dir
         if benchmark_result_dir is not None:
             config_result_dir = benchmark_result_dir / config_name
             config_result_dir.mkdir(parents=True, exist_ok=True)
             final_result_path = config_result_dir / f"json_mode-{task_name}.json"
-            # Pass the final path to the script
             result_path = str(final_result_path)
 
         parser = argparse.ArgumentParser()

--- a/tests/benchmarks/test_benchmarks.py
+++ b/tests/benchmarks/test_benchmarks.py
@@ -2,90 +2,26 @@ import argparse
 import json
 import multiprocessing
 import tempfile
-import time
 
-import pytest
-import requests
-import uvloop
-from vllm.entrypoints.openai.api_server import (
-    make_arg_parser, run_server, validate_parsed_serve_args)
-from vllm.utils import FlexibleArgumentParser
-
-from .benchmark_utils import (ACCURACY_TASKS, PERFORMANCE_TASKS, VLLM_CONFIGS,
-                              JSON_MODE_TASKS, update_benchmark_summary)                  
-
-CUSTOM_PORT = 8080
-
-@pytest.fixture(scope="module", params=list(VLLM_CONFIGS.keys()))
-def vllm_server(request):
-    """
-    Fixture to start the OpenAI API server for testing.
-    """
-    parser = FlexibleArgumentParser()
-    parser = make_arg_parser(parser)
-
-    args = parser.parse_args([])
-    args.disable_log_requests = True
-    args.disable_uvicorn_access_log = True
-
-    setattr(args, 'port', CUSTOM_PORT)
-
-    for key, value in VLLM_CONFIGS[request.param].items():
-        setattr(args, key, value)
-
-    validate_parsed_serve_args(args)
-
-    def _run_process():
-        uvloop.run(run_server(args))
-
-    # Start server process
-    process = multiprocessing.Process(target=_run_process)
-    process.start()
-
-    print("Waiting for server to start...")
-    timeout = 3600
-    interval = 5
-    start = time.time()
-
-    health_check_url = f"http://localhost:{CUSTOM_PORT}/v1/models"
-
-    while True:
-        try:
-            r = requests.get(health_check_url)
-            if r.status_code == 200:
-                break
-        except requests.exceptions.ConnectionError:
-            pass
-        if not process.is_alive():
-            raise RuntimeError("Server process terminated unexpectedly")
-        if time.time() - start > timeout:
-            raise TimeoutError(f"Server didn't start after {timeout} seconds")
-        time.sleep(interval)
-    print("Server process started")
-
-    yield request.param, args
-
-    # Stop server process
-    print("Terminating server process")
-    if process.is_alive():
-        process.terminate()
-        process.join()
-    print("Server process terminated")
+from .benchmark_utils import VLLM_CONFIGS, update_benchmark_summary
 
 
-@pytest.mark.parametrize("task_name", list(PERFORMANCE_TASKS.keys()))
-def test_performance(request, vllm_server, task_name):
+def test_performance(benchmark_spec, request):
+    """Tests vLLM performance (throughput and latency)."""
+    # Unpack the spec for the current test case
+    config_name = benchmark_spec["config_name"]
+    task_name = benchmark_spec["task_name"]
+    task = benchmark_spec["task_obj"]
+    port = benchmark_spec["port"]
+
+    vllm_config = VLLM_CONFIGS[config_name]
+
+    # Run the performance benchmark client
     from vllm.benchmarks.serve import add_cli_args, main
-
-    config_name, vllm_args = vllm_server
-    task = PERFORMANCE_TASKS[task_name]
-
     parser = argparse.ArgumentParser()
     add_cli_args(parser)
-
-    args = parser.parse_args(["--model", vllm_args.model])
-
-    setattr(args, 'port', CUSTOM_PORT)
+    args = parser.parse_args(["--model", vllm_config["model"]])
+    setattr(args, "port", port)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         args.save_result = True
@@ -96,127 +32,128 @@ def test_performance(request, vllm_server, task_name):
             setattr(args, key, value)
 
         main(args)
-
         with open(f"{tmpdir}/result.json", "r") as f:
             result = json.load(f)
 
     benchmark_result_dir = request.config.option.benchmark_result_dir
     if benchmark_result_dir is not None:
-        result_path = (benchmark_result_dir / "performance" /
-                       f"{config_name}-{task_name}.json")
-        result_path.parent.mkdir(parents=True, exist_ok=True)
+        config_result_dir = benchmark_result_dir / config_name
+        config_result_dir.mkdir(parents=True, exist_ok=True)
+        result_path = config_result_dir / f"performance-{task_name}.json"
         with open(result_path, "w") as f:
             json.dump(result, f, indent=4)
 
-    metrics = {name: key(result) if callable(key) else result[key]
-               for name, key in task.metrics.items()}
+    metrics = {
+        name: key(result) if callable(key) else result[key]
+        for name, key in task.metrics.items()
+    }
     update_benchmark_summary(config_name, task_name, metrics)
 
 
-@pytest.mark.parametrize("task_name", list(ACCURACY_TASKS.keys()))
-def test_accuracy(request, vllm_server, task_name):
+def test_accuracy(benchmark_spec, request):
+    """Tests model accuracy on lm-evaluation-harness tasks."""
+    config_name = benchmark_spec["config_name"]
+    task_name = benchmark_spec["task_name"]
+    task = benchmark_spec["task_obj"]
+    port = benchmark_spec["port"]
 
-    config_name, vllm_args = vllm_server
-    task = ACCURACY_TASKS[task_name]
-
-    assert len(task.config["tasks"]) == 1, \
-        "Accuracy benchmarks should only have one task configured"
+    vllm_config = VLLM_CONFIGS[config_name]
+    assert len(task.config["tasks"]) == 1, "Accuracy benchmarks must have one task."
 
     q = multiprocessing.Queue()
 
-    def _run_process():
-        # Run lm_eval in a separate process because it imports torch and
-        # initializes CUDA, which breaks process forking in later tests.
+    def _run_eval_process():
         try:
             from lm_eval import evaluator
             from lm_eval.utils import handle_non_serializable, make_table
 
-            base_url = f"http://localhost:{CUSTOM_PORT}/v1/completions"
-
             result = evaluator.simple_evaluate(
                 model="local-completions",
                 model_args={
-                    "model": vllm_args.model,
-                    "base_url": base_url,
+                    "model": vllm_config["model"],
+                    "base_url": f"http://localhost:{port}/v1/completions",
                     "num_concurrent": 256,
                     "timeout": 3600,
                 },
                 **task.config,
             )
             print(make_table(result))
-
             tmpfile = f"{tmpdir}/result.json"
             with open(tmpfile, "w") as f:
                 json.dump(result, f, indent=4, default=handle_non_serializable)
-        except Exception as exc:
-            # If an exception occurs, put it in the queue to be raised later
-            q.put(exc)
-        else:
-            # Send back the temporary file path instead of the result object
-            # since multiprocessing queue can hang on large objects.
             q.put(tmpfile)
+        except Exception as exc:
+            q.put(exc)
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        process = multiprocessing.Process(target=_run_process)
-        process.start()
-        r = q.get()
-        process.join()
-        if isinstance(r, Exception):
-            raise r
-        tmpfile = r
-        with open(tmpfile, "r") as f:
+        p = multiprocessing.Process(target=_run_eval_process)
+        p.start()
+        result_or_exc = q.get()
+        p.join()
+        if isinstance(result_or_exc, Exception):
+            raise result_or_exc
+        with open(result_or_exc, "r") as f:
             result = json.load(f)
 
     benchmark_result_dir = request.config.option.benchmark_result_dir
     if benchmark_result_dir is not None:
-        result_path = (benchmark_result_dir / "accuracy" /
-                       f"{config_name}-{task_name}.json")
-        result_path.parent.mkdir(parents=True, exist_ok=True)
+        config_result_dir = benchmark_result_dir / config_name
+        config_result_dir.mkdir(parents=True, exist_ok=True)
+        result_path = config_result_dir / f"accuracy-{task_name}.json"
         with open(result_path, "w") as f:
             json.dump(result, f, indent=4)
 
-    result = result["results"][task.config["tasks"][0]]
-    metrics = {name: key(result) if callable(key) else result[key]
-               for name, key in task.metrics.items()}
+    result_data = result["results"][task.config["tasks"][0]]
+    metrics = {
+        name: key(result_data) if callable(key) else result_data[key]
+        for name, key in task.metrics.items()
+    }
     update_benchmark_summary(config_name, task_name, metrics)
 
 
-@pytest.mark.parametrize("task_name", list(JSON_MODE_TASKS.keys()))
-def test_json_mode(request, vllm_server, task_name):
-    """
-    Test JSON mode using the evaluate_text_json_mode script.
-    """
+def test_json_mode(benchmark_spec, request):
+    """Tests the server's structured (JSON) output capability."""
+    config_name = benchmark_spec["config_name"]
+    task_name = benchmark_spec["task_name"]
+    task = benchmark_spec["task_obj"]
+    port = benchmark_spec["port"]
+
+    vllm_config = VLLM_CONFIGS[config_name]
+
+    if vllm_config.get("speculative_config", {}).get("enable_suffix_decoding"):
+        pytest.skip("Skipping JSON mode test for spec + suffix decoding.")
+
     from .json_mode.evaluate_text_json_mode import main as evaluate_json
-
-    config_name, vllm_args = vllm_server
-    task = JSON_MODE_TASKS[task_name]
-
-    if (vllm_args.speculative_config and
-            vllm_args.speculative_config.get('enable_suffix_decoding', False)):
-        pytest.skip("Skipping JSON mode test for spec + suffix decoding enabled")
-
+    
     with tempfile.TemporaryDirectory() as tmpdir:
         result_path = f"{tmpdir}/result.json"
+        # The evaluate_json script saves its own file, so we pass it the full path
+        final_result_path = None
+        benchmark_result_dir = request.config.option.benchmark_result_dir
+        if benchmark_result_dir is not None:
+            config_result_dir = benchmark_result_dir / config_name
+            config_result_dir.mkdir(parents=True, exist_ok=True)
+            final_result_path = config_result_dir / f"json_mode-{task_name}.json"
+            # Pass the final path to the script
+            result_path = str(final_result_path)
 
-        args = FlexibleArgumentParser()
-        args.model = vllm_args.model
-        args.output = result_path
-        args.task = task.config["task"]
-        args.input = task.config["input"]
-        args.n_samples = task.config["n_samples"]
-
-        args.port = CUSTOM_PORT
-
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--model", type=str, default=vllm_config["model"])
+        parser.add_argument("--output", type=str, default=result_path)
+        parser.add_argument("--port", type=int, default=port)
+        parser.add_argument("--task", type=str, default=task.config.get("task"))
+        parser.add_argument("--input", type=str, default=task.config.get("input"))
+        parser.add_argument("--n-samples", type=int, default=task.config.get("n_samples"))
+        
+        args = parser.parse_args([])
         evaluate_json(args)
 
         with open(result_path, "r") as f:
             result = json.load(f)
 
     result_data = result.get("results", {})
-    
     metrics = {
-        name: key(result_data) if callable(key) else result_data.get(key, {}).get('score')
+        name: key(result_data) if callable(key) else result_data.get(key, {}).get("score")
         for name, key in task.metrics.items()
     }
-
     update_benchmark_summary(config_name, task_name, metrics)


### PR DESCRIPTION
Added a simple scheduler to use idle GPUs to run benchmark tests

For example, part of the log is like
```
Starting Batch 0: ['llama_8b_all', 'llama_8b_shift', 'llama_8b', 'llama_8b_swiftkv'] ---
  -> Launching 'llama_8b_all' on port 8080 with GPUs [0, 1, 2, 3]...
  -> Launching 'llama_8b_shift' on port 8081 with GPUs [4, 5]...
  -> Launching 'llama_8b' on port 8082 with GPUs [6]...
  -> Launching 'llama_8b_swiftkv' on port 8083 with GPUs [7]...
```
