### PR TITLE
Union type hint fix

### DIFF
--- a/arctic_inference/common/suffix_cache/suffix_cache.py
+++ b/arctic_inference/common/suffix_cache/suffix_cache.py
@@ -118,7 +118,7 @@ class SuffixCache:
     def update_response(
         self,
         req_id: Hashable,
-        token_ids: Union[int | Sequence[int]],
+        token_ids: Union[int, Sequence[int]],
     ):
         """
         Update the cached response for a given request by adding token(s) to


### PR DESCRIPTION
Should be `Union[X,Y,Z]` or `X|Y|Z`, see [ref](https://docs.python.org/3/library/typing.html#typing.Union).