### PR TITLE
Simplify min_score selection logic, correct type hint for `propose_suffix_draft_token_ids`

### DIFF
--- a/arctic_inference/vllm/model_runner.py
+++ b/arctic_inference/vllm/model_runner.py
@@ -686,7 +686,7 @@ class GPUModelRunnerPatch(ArcticPatch[GPUModelRunner]):
         self,
         sampled_token_ids: list[list[int]],
         spec_token_ids: Optional[list[list[int]]] = None,
-    ) -> list[list[int]]:
+    ) -> list[SuffixDecodingDraft]:
         config = self.speculative_config
         results = []
         for i, sampled_ids in enumerate(sampled_token_ids):


### PR DESCRIPTION
The original logic is confusing and requires multiple comparisons - this PR simplifies this logic while maintaining the same functionality.

Decided to go with the traditional `if` code block for easier future expansion.

Verified offline it still works E2E.