### PR TITLE
Move SwiftKV ops to JIT-build

### DIFF
--- a/arctic_inference/envs.py
+++ b/arctic_inference/envs.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
 environment_variables: dict[str, Callable[[], Any]] = {
     "ARCTIC_INFERENCE_ENABLED":
     lambda: os.getenv("ARCTIC_INFERENCE_ENABLED", "0") == "1",
+    "ARCTIC_INFERENCE_PRECOMPILED_OPS":
+    lambda: os.getenv("ARCTIC_INFERENCE_PRECOMPILED_OPS", "0") == "1",
     "ARCTIC_INFERENCE_SKIP_PLATFORM_CHECK":
     lambda: os.getenv("ARCTIC_INFERENCE_SKIP_PLATFORM_CHECK", "0") == "1",
     "ARCTIC_INFERENCE_SKIP_SPEC_MODEL_CHECK":

--- a/arctic_inference/envs.py
+++ b/arctic_inference/envs.py
@@ -22,8 +22,6 @@ if TYPE_CHECKING:
 environment_variables: dict[str, Callable[[], Any]] = {
     "ARCTIC_INFERENCE_ENABLED":
     lambda: os.getenv("ARCTIC_INFERENCE_ENABLED", "0") == "1",
-    "ARCTIC_INFERENCE_PRECOMPILED_OPS":
-    lambda: os.getenv("ARCTIC_INFERENCE_PRECOMPILED_OPS", "0") == "1",
     "ARCTIC_INFERENCE_SKIP_PLATFORM_CHECK":
     lambda: os.getenv("ARCTIC_INFERENCE_SKIP_PLATFORM_CHECK", "0") == "1",
     "ARCTIC_INFERENCE_SKIP_SPEC_MODEL_CHECK":

--- a/arctic_inference/op_builder/swiftkv_ops_builder.py
+++ b/arctic_inference/op_builder/swiftkv_ops_builder.py
@@ -14,7 +14,7 @@ class SwiftKVOpsBuilder(CUDAOpBuilder):
         return "arctic_inference" if os.path.isdir(ai_path) else ".."
 
     def sources(self):
-        return [
+        sources = [
             'csrc/custom_ops/torch_bindings.cpp',
             'csrc/custom_ops/kernels.cu',
         ]
@@ -23,7 +23,7 @@ class SwiftKVOpsBuilder(CUDAOpBuilder):
         return sources
 
     def include_paths(self):
-        return ['csrc/custom_ops']
+        sources = ['csrc/custom_ops']
         prefix = self.get_prefix()
         sources = [os.path.join(prefix, src) for src in sources]
         return sources

--- a/arctic_inference/op_builder/swiftkv_ops_builder.py
+++ b/arctic_inference/op_builder/swiftkv_ops_builder.py
@@ -1,0 +1,24 @@
+import os
+from .builder import CUDAOpBuilder
+
+class SwiftKVOpsBuilder(CUDAOpBuilder):
+    def __init__(self):
+        # Set the name of the operator, this will be the name of the compiled module.
+        super().__init__(name="reshape_and_cache_flash_bulk")
+
+    def absolute_name(self):
+        # This is the name of the JIT-compiled module.
+        return f'arctic_inference.swiftkv_ops.{self.name}'
+
+    def sources(self):
+        # List all C++ and CUDA source files.
+        # Paths should be relative to the root of the project.
+        return [
+            '../csrc/custom_ops/torch_bindings.cpp',
+            '../csrc/custom_ops/kernels.cu',
+        ]
+
+    def include_paths(self):
+        # Add the 'csrc' directory to the include path so files like
+        # 'custom_ops.h' can be found.
+        return ['../csrc/custom_ops']

--- a/arctic_inference/op_builder/swiftkv_ops_builder.py
+++ b/arctic_inference/op_builder/swiftkv_ops_builder.py
@@ -8,11 +8,22 @@ class SwiftKVOpsBuilder(CUDAOpBuilder):
     def absolute_name(self):
         return f'arctic_inference.swiftkv_ops.{self.name}'
 
+    def get_prefix(self):
+        # borrowed from moe_op. refactor later
+        ai_path = self._src_path("arctic_inference")
+        return "arctic_inference" if os.path.isdir(ai_path) else ".."
+
     def sources(self):
         return [
-            '../csrc/custom_ops/torch_bindings.cpp',
-            '../csrc/custom_ops/kernels.cu',
+            'csrc/custom_ops/torch_bindings.cpp',
+            'csrc/custom_ops/kernels.cu',
         ]
+        prefix = self.get_prefix()
+        sources = [os.path.join(prefix, src) for src in sources]
+        return sources
 
     def include_paths(self):
-        return ['../csrc/custom_ops']
+        return ['csrc/custom_ops']
+        prefix = self.get_prefix()
+        sources = [os.path.join(prefix, src) for src in sources]
+        return sources

--- a/arctic_inference/op_builder/swiftkv_ops_builder.py
+++ b/arctic_inference/op_builder/swiftkv_ops_builder.py
@@ -3,22 +3,16 @@ from .builder import CUDAOpBuilder
 
 class SwiftKVOpsBuilder(CUDAOpBuilder):
     def __init__(self):
-        # Set the name of the operator, this will be the name of the compiled module.
         super().__init__(name="reshape_and_cache_flash_bulk")
 
     def absolute_name(self):
-        # This is the name of the JIT-compiled module.
         return f'arctic_inference.swiftkv_ops.{self.name}'
 
     def sources(self):
-        # List all C++ and CUDA source files.
-        # Paths should be relative to the root of the project.
         return [
             '../csrc/custom_ops/torch_bindings.cpp',
             '../csrc/custom_ops/kernels.cu',
         ]
 
     def include_paths(self):
-        # Add the 'csrc' directory to the include path so files like
-        # 'custom_ops.h' can be found.
         return ['../csrc/custom_ops']

--- a/arctic_inference/py_custom_ops.py
+++ b/arctic_inference/py_custom_ops.py
@@ -43,9 +43,6 @@ def try_load_jit_library() -> bool:
         swiftkv_ops_module = SwiftKVOpsBuilder().load()
 
         return True
-    else:
-        logger.info("Could not find SwiftKVOpsBuilder, skipping JIT compilation.")
-        return False
     except ImportError as e:
         logger.info(
             f"Unable to import SwiftKVOpsBuilder. ImportError: {e}. Falling back to original implementation."

--- a/arctic_inference/py_custom_ops.py
+++ b/arctic_inference/py_custom_ops.py
@@ -37,6 +37,25 @@ def try_load_torch_library() -> bool:
         return False
 
 
+def try_load_jit_library() -> bool:
+    try:
+        from arctic_inference.op_builder.swiftkv_ops_builder import SwiftKVOpsBuilder
+        swiftkv_ops_module = SwiftKVOpsBuilder().load()
+    else:
+        logger.info("Could not find SwiftKVOpsBuilder, skipping JIT compilation.")
+        return False
+    except ImportError as e:
+        logger.info(
+            f"Unable to import SwiftKVOpsBuilder. ImportError: {e}. Falling back to original implementation."
+        )
+        return False
+    except Exception as e:
+        logger.info(
+            f"Unable to load JIT library. Exception: {e}. Falling back to original implementation."
+        )
+        return False
+
+
 def reshape_and_cache_flash_bulk(
     keys: list[torch.Tensor],
     values: list[torch.Tensor],

--- a/arctic_inference/py_custom_ops.py
+++ b/arctic_inference/py_custom_ops.py
@@ -41,6 +41,8 @@ def try_load_jit_library() -> bool:
     try:
         from arctic_inference.op_builder.swiftkv_ops_builder import SwiftKVOpsBuilder
         swiftkv_ops_module = SwiftKVOpsBuilder().load()
+
+        return True
     else:
         logger.info("Could not find SwiftKVOpsBuilder, skipping JIT compilation.")
         return False

--- a/arctic_inference/py_custom_ops.py
+++ b/arctic_inference/py_custom_ops.py
@@ -22,8 +22,8 @@ def try_load_torch_library() -> bool:
         return False
 
     try:
-        logger.info(f"Attempting to load custom ops from {library_path}...")
         torch.ops.load_library(library_path)
+        logger.info(f"Successfully loaded custom ops from {library_path}.")
         return True
     except RuntimeError as e:
         logger.info(
@@ -42,6 +42,7 @@ def try_load_jit_library() -> bool:
         from arctic_inference.op_builder.swiftkv_ops_builder import SwiftKVOpsBuilder
         swiftkv_ops_module = SwiftKVOpsBuilder().load()
 
+        logger.info("Successfully loaded SwiftKVOpsBuilder JIT library.")
         return True
     except ImportError as e:
         logger.info(

--- a/arctic_inference/vllm/swiftkv/llama_swiftkv.py
+++ b/arctic_inference/vllm/swiftkv/llama_swiftkv.py
@@ -373,8 +373,10 @@ class LlamaSwiftKVModel(nn.Module):
         self.use_custom_ops = False
         if envs.ARCTIC_INFERENCE_PRECOMPILED_OPS:
             self.use_custom_ops = try_load_torch_library()
+            print(f"Using precompiled custom ops: {self.use_custom_ops}")
         elif try_load_jit_library():
             self.use_custom_ops = True
+            print("Using JIT-compiled custom ops.")
 
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)

--- a/arctic_inference/vllm/swiftkv/llama_swiftkv.py
+++ b/arctic_inference/vllm/swiftkv/llama_swiftkv.py
@@ -370,13 +370,9 @@ class LlamaSwiftKVModel(nn.Module):
 
         from arctic_inference.py_custom_ops import (try_load_torch_library,
                                                     try_load_jit_library)
-        self.use_custom_ops = False
-        if envs.ARCTIC_INFERENCE_PRECOMPILED_OPS:
-            self.use_custom_ops = try_load_torch_library()
-            print(f"Using precompiled custom ops: {self.use_custom_ops}")
-        elif try_load_jit_library():
-            self.use_custom_ops = True
-            print("Using JIT-compiled custom ops.")
+
+        self.use_custom_ops = try_load_torch_library() or try_load_jit_library()
+
 
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)

--- a/arctic_inference/vllm/swiftkv/llama_swiftkv.py
+++ b/arctic_inference/vllm/swiftkv/llama_swiftkv.py
@@ -53,6 +53,7 @@ except ImportError:
 
 import arctic_inference.vllm.model_runner as model_runner
 from arctic_inference.common.swiftkv.configs import LlamaSwiftKVConfig
+import arctic_inference.envs as envs
 
 logger = init_logger(__name__)
 
@@ -367,8 +368,13 @@ class LlamaSwiftKVModel(nn.Module):
         self._init_prefill_runner(vllm_config)
         self._init_decode_runner(vllm_config)
 
-        from arctic_inference.py_custom_ops import try_load_torch_library
-        self.use_custom_ops = True if try_load_torch_library() else False
+        from arctic_inference.py_custom_ops import (try_load_torch_library,
+                                                    try_load_jit_library)
+        self.use_custom_ops = False
+        if envs.ARCTIC_INFERENCE_PRECOMPILED_OPS:
+            self.use_custom_ops = try_load_torch_library()
+        elif try_load_jit_library():
+            self.use_custom_ops = True
 
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)

--- a/csrc/custom_ops/torch_bindings.cpp
+++ b/csrc/custom_ops/torch_bindings.cpp
@@ -1,5 +1,6 @@
 #include "custom_ops.h"
 
+#include <torch/extension.h>
 #include <torch/library.h>
 
 TORCH_LIBRARY(arctic_inference, ops) {
@@ -16,4 +17,7 @@ TORCH_LIBRARY(arctic_inference, ops) {
       "                             int head_size) -> ()");
   ops.impl("reshape_and_cache_flash_bulk", torch::kCUDA,
            &reshape_and_cache_flash_bulk);
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ packages = [
     "arctic_inference.common",
     "arctic_inference.common.swiftkv",
     "arctic_inference.dynasor",
+    "arctic_inference.op_builder",
     "arctic_inference.suffix_decoding",
     "arctic_inference.vllm",
     "arctic_inference.vllm.swiftkv",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,11 @@ packages = [
     "arctic_inference.vllm.swiftkv",
     "arctic_inference.vllm.spec_dec",
     "arctic_inference.embedding",
+    "arctic_inference.csrc",
 ]
+
+[tool.setuptools.package-dir]
+"arctic_inference.csrc" = "csrc"
 
 [tool.setuptools.package-data]
 "arctic_inference.embedding" = ["arctic_inference/embedding/proto/*.proto"]

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,8 @@ from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 from setuptools.command.build_py import build_py as _build_py
 
+import arctic_inference.envs as envs
+
 # Convert distutils Windows platform specifiers to CMake -A arguments
 PLAT_TO_CMAKE = {
     "win32": "Win32",
@@ -171,12 +173,18 @@ class CompileGrpc(_build_py):
         _build_py.run(self)
 
 
-setup(
-    ext_modules=[
-        CMakeExtension("arctic_inference.suffix_decoding._C",
-                       "csrc/suffix_decoding"),
+ext_modules=[
+    CMakeExtension("arctic_inference.suffix_decoding._C",
+                   "csrc/suffix_decoding"),
+]
+
+if envs.ARCTIC_INFERENCE_PRECOMPILED_OPS:
+    ext_modules.append(
         CMakeExtension("arctic_inference.custom_ops", "csrc/custom_ops"),
-    ],
+    )
+
+setup(
+    ext_modules=ext_modules,
     cmdclass={
         "build_ext": CMakeBuild,
         'build_py': CompileGrpc

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,6 @@ from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 from setuptools.command.build_py import build_py as _build_py
 
-import arctic_inference.envs as envs
-
 # Convert distutils Windows platform specifiers to CMake -A arguments
 PLAT_TO_CMAKE = {
     "win32": "Win32",
@@ -173,12 +171,14 @@ class CompileGrpc(_build_py):
         _build_py.run(self)
 
 
+
+
 ext_modules=[
     CMakeExtension("arctic_inference.suffix_decoding._C",
                    "csrc/suffix_decoding"),
 ]
 
-if envs.ARCTIC_INFERENCE_PRECOMPILED_OPS:
+if os.environ.get("ARCTIC_INFERENCE_PRECOMPILED_OPS", "").lower() in ("1", "true", "on"):
     ext_modules.append(
         CMakeExtension("arctic_inference.custom_ops", "csrc/custom_ops"),
     )


### PR DESCRIPTION
If we still want to use pre-compiled build
do the following:
```
ARCTIC_INFERENCE_PRECOMPILED_OPS=1 pip install .
```
logs from running offline_inference_swiftkv.py:
```
INFO 09-29 21:21:48 [gpu_model_runner.py:1775] Loading model from scratch...
INFO 09-29 21:21:48 [cuda.py:284] Using Flash Attention backend on V1 engine.
/code/users/yewang/venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py:2356: UserWarning: TORCH_CUDA_ARCH_LIST is not set, all archs for visible cards are included for compilation. 
If this is not desired, please set os.environ['TORCH_CUDA_ARCH_LIST'].
  warnings.warn(
successfully loaded swiftkv_ops_module: <module 'reshape_and_cache_flash_bulk' from '/home/yak/.cache/torch_extensions/py310_cu126/reshape_and_cache_flash_bulk/reshape_and_cache_flash_bulk.so'>
Using JIT-compiled custom ops.
INFO 09-29 21:23:13 [weight_utils.py:292] Using model weights format ['*.safetensors']
Loading safetensors checkpoint shards:   0% Completed | 0/5 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  20% Completed | 1/5 [00:00<00:00,  5.82it/s]
```