### PR TITLE
Explicitly initialize CUDA buffers for next tokens

### DIFF
--- a/arctic_inference/vllm/spec_dec/arctic_speculator.py
+++ b/arctic_inference/vllm/spec_dec/arctic_speculator.py
@@ -817,6 +817,9 @@ class ArcticLSTMSpeculator(nn.Module, SpeculatorTPInit):
 
             if g is None:
                 device = torch.cuda.current_device()
+                for i in range(num_predict_tokens):
+                    self.static_cuda_buffers["next_tokens"][i][:padded_size] = torch.zeros(
+                        (padded_size, 1), dtype=torch.long, device=device)
                 with graph_capture(device=device) as capture_context:
                     g = torch.cuda.CUDAGraph()
                     with torch.cuda.graph(g, stream=capture_context.stream):


### PR DESCRIPTION
Fix the integer overflow issue
```
(EngineCore_0 pid=1550045) ERROR 10-04 05:00:55 [core.py:702] File "/code/users/yewang/env/miniconda3/envs/oai/lib/python3.12/site-packages/vllm/v1/executor/multiproc_executor.py", line 230, in get_response (EngineCore_0 pid=1550045) ERROR 10-04 05:00:55 [core.py:702] raise RuntimeError( (EngineCore_0 pid=1550045) ERROR 10-04 05:00:55 [core.py:702] RuntimeError: Worker failed with error 'Python integer 4606974051693379674 out of bounds for int32', please check the stack trace above for the root cause