### PR TITLE
Communication Fusing

### DIFF
--- a/arctic_inference/vllm/ulysses.py
+++ b/arctic_inference/vllm/ulysses.py
@@ -51,7 +51,6 @@ def apply_shift_parallel_patches():
     UlyssesMultiprocExecutor.apply_patch()
     UlyssesAttention.apply_patch()
     UlyssesCudagraphDispatcher.apply_patch()
-    UlyssesEngineCore.apply_patch()
 
 
 class UlyssesModelConfig(ArcticPatch[ModelConfig]):


### PR DESCRIPTION
GQA implementation with small # kv heads (e.g., Qwen-30B-A3B, Qwen-235B-A22B) has a scalability issue, i.e., when # kv heads < TP, KV cache is replicated by recomputation. When #kv heads < SP, KV we replicate the KV cache by communication.

The initial implementation uses SP_AA.all-to-all(kv) followed by and SP_AG.all-gather(kv), separate from SP.all-to-all (q) was working inefficiently.

This commit fuses all-to-all and all-gather communications into a single all-to-all by replicating the KV in memory and exchange, making a better use of hardware.