### PR TITLE
[Ulysses] Add validation for max_num_seqs divisibility by sp_size

### DIFF
--- a/arctic_inference/vllm/config.py
+++ b/arctic_inference/vllm/config.py
@@ -197,6 +197,23 @@ class VllmConfigPatch(ArcticPatch[VllmConfig]):
             self._orig_post_init(*args, **kwargs)
         finally:
             setattr(target_module, "EagleModelTypes", original_types)
+        self._validate_ulysses_config()
+
+    def _validate_ulysses_config(self):
+        """Validate Ulysses sequence parallelism configuration."""
+        sp_size = getattr(self.parallel_config, 'ulysses_sequence_parallel_size', 1)
+        if sp_size > 1:
+            max_num_seqs = self.scheduler_config.max_num_seqs
+            if max_num_seqs % sp_size != 0:
+                raise ValueError(
+                    f"When using Ulysses sequence parallelism "
+                    f"(ulysses_sequence_parallel_size={sp_size}), "
+                    f"--max-num-seqs ({max_num_seqs}) must be divisible by "
+                    f"ulysses_sequence_parallel_size ({sp_size}). "
+                    f"Please set --max-num-seqs to a multiple of {sp_size}, "
+                    f"e.g., --max-num-seqs={max_num_seqs - (max_num_seqs % sp_size)} "
+                    f"or --max-num-seqs={max_num_seqs + (sp_size - max_num_seqs % sp_size)}."
+                )
 
 
 class MLPSpeculatorConfigPatch(ArcticPatch[MLPSpeculatorConfig]):

--- a/tests/unit_tests/test_ulysses_config.py
+++ b/tests/unit_tests/test_ulysses_config.py
@@ -1,0 +1,106 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Ulysses sequence parallelism configuration validation."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+class TestUlyssesConfigValidation:
+    """Test cases for Ulysses config validation in VllmConfigPatch."""
+
+    def test_max_num_seqs_divisibility_error_message(self):
+        """Test that non-divisible max_num_seqs raises ValueError with helpful message."""
+        from arctic_inference.vllm.config import VllmConfigPatch
+
+        # Create a mock VllmConfig instance
+        mock_config = MagicMock()
+        mock_config.parallel_config.ulysses_sequence_parallel_size = 4
+        mock_config.scheduler_config.max_num_seqs = 37  # Not divisible by 4
+
+        # Call the validation method directly
+        with pytest.raises(ValueError) as excinfo:
+            VllmConfigPatch._validate_ulysses_config(mock_config)
+
+        error_msg = str(excinfo.value)
+        # Check that error message contains helpful information
+        assert "ulysses_sequence_parallel_size=4" in error_msg
+        assert "--max-num-seqs (37)" in error_msg
+        assert "must be divisible by" in error_msg
+        # Check that it suggests valid values
+        assert "--max-num-seqs=36" in error_msg or "--max-num-seqs=40" in error_msg
+
+    def test_max_num_seqs_divisible_passes(self):
+        """Test that divisible max_num_seqs passes validation."""
+        from arctic_inference.vllm.config import VllmConfigPatch
+
+        mock_config = MagicMock()
+        mock_config.parallel_config.ulysses_sequence_parallel_size = 4
+        mock_config.scheduler_config.max_num_seqs = 36  # Divisible by 4
+
+        # Should not raise
+        VllmConfigPatch._validate_ulysses_config(mock_config)
+
+    def test_sp_size_one_skips_validation(self):
+        """Test that validation is skipped when sp_size is 1."""
+        from arctic_inference.vllm.config import VllmConfigPatch
+
+        mock_config = MagicMock()
+        mock_config.parallel_config.ulysses_sequence_parallel_size = 1
+        mock_config.scheduler_config.max_num_seqs = 37  # Any value should work
+
+        # Should not raise
+        VllmConfigPatch._validate_ulysses_config(mock_config)
+
+    def test_various_non_divisible_values(self):
+        """Test various non-divisible max_num_seqs values."""
+        from arctic_inference.vllm.config import VllmConfigPatch
+
+        test_cases = [
+            (4, 37),   # 37 % 4 = 1
+            (4, 38),   # 38 % 4 = 2
+            (4, 39),   # 39 % 4 = 3
+            (8, 100),  # 100 % 8 = 4
+            (2, 33),   # 33 % 2 = 1
+        ]
+
+        for sp_size, max_num_seqs in test_cases:
+            mock_config = MagicMock()
+            mock_config.parallel_config.ulysses_sequence_parallel_size = sp_size
+            mock_config.scheduler_config.max_num_seqs = max_num_seqs
+
+            with pytest.raises(ValueError):
+                VllmConfigPatch._validate_ulysses_config(mock_config)
+
+    def test_various_divisible_values(self):
+        """Test various divisible max_num_seqs values."""
+        from arctic_inference.vllm.config import VllmConfigPatch
+
+        test_cases = [
+            (4, 36),   # 36 % 4 = 0
+            (4, 40),   # 40 % 4 = 0
+            (8, 96),   # 96 % 8 = 0
+            (2, 32),   # 32 % 2 = 0
+            (16, 64),  # 64 % 16 = 0
+        ]
+
+        for sp_size, max_num_seqs in test_cases:
+            mock_config = MagicMock()
+            mock_config.parallel_config.ulysses_sequence_parallel_size = sp_size
+            mock_config.scheduler_config.max_num_seqs = max_num_seqs
+
+            # Should not raise
+            VllmConfigPatch._validate_ulysses_config(mock_config)


### PR DESCRIPTION
## Summary

Fixes #175

When using Ulysses sequence parallelism, `max_num_seqs` must be divisible by `ulysses_sequence_parallel_size`. Previously, using a non-divisible value (e.g., `--max-num-seqs=37` with `--ulysses-sequence-parallel-size=4`) would cause crashes or produce incorrect results.

## Changes

- Add `_validate_ulysses_config()` method in `VllmConfigPatch` that validates divisibility
- Hook validation into `VllmConfig.__post_init__`
- Provide clear error message with suggestions for valid values
- Add comprehensive unit tests

## Error Message Example

When a user tries to start with `--max-num-seqs=37 --ulysses-sequence-parallel-size=4`:

```
ValueError: When using Ulysses sequence parallelism (ulysses_sequence_parallel_size=4), 
--max-num-seqs (37) must be divisible by ulysses_sequence_parallel_size (4). 
Please set --max-num-seqs to a multiple of 4, e.g., --max-num-seqs=36 or --max-num-seqs=40.
```

## Test plan

- [x] Added unit tests covering:
  - Non-divisible values raise `ValueError`
  - Divisible values pass validation
  - `sp_size=1` skips validation
  - Various edge cases
- [x] Syntax validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)