### PR TITLE
Tune rollout config: TP-aware FCA/SD thresholds

### DIFF
--- a/arctic_inference/server/config.py
+++ b/arctic_inference/server/config.py
@@ -54,17 +54,31 @@ class ModelConfig(BaseModel):
         use_fca = kwargs.pop("use_fca", False)
         spec_model = kwargs.pop("spec_model", "")
 
+        # Tuning for FCA and SD (if enabled)
         if arctic_inference_effective_enabled(self.extra_env):
+            tp_size = self.tensor_parallel_size
             if use_fca:
                 kwargs.setdefault("compilation_config", {"cudagraph_mode": "PIECEWISE"})
-                kwargs.setdefault("forest_cascade_attn_configs", "{}")
+                if tp_size == 8:
+                    kwargs["forest_cascade_attn_configs"] = '{"min_batch_size": 160}'
+                if tp_size == 4:
+                    kwargs["forest_cascade_attn_configs"] = '{"min_batch_size": 48}'
+                if tp_size == 2:
+                    kwargs["forest_cascade_attn_configs"] = '{"min_batch_size": 24}'
+            else:
+                kwargs.pop("forest_cascade_attn_configs", None)
             if spec_model:
                 kwargs.setdefault(
                     "speculative_config",
                     {"method": "arctic", "model": spec_model, "num_speculative_tokens": 3},
                 )
-        else:
-            kwargs.pop("forest_cascade_attn_configs", None)
+                if use_fca:
+                    if tp_size == 8:
+                        kwargs["speculative_config"]["hard_disable_by_batch_size"] = 160
+                    if tp_size == 4:
+                        kwargs["speculative_config"]["hard_disable_by_batch_size"] = 96
+                    if tp_size == 2:
+                        kwargs["speculative_config"]["hard_disable_by_batch_size"] = 96
         return kwargs
 
     @classmethod


### PR DESCRIPTION
1) Sets forest_cascade_attn_configs.min_batch_size per tensor-parallel size (tp8=160, tp4=48, tp2=24) instead of an empty config
2) Removes FCA configs when use_fca is disabled
3) dds per-TP speculative hard_disable_by_batch_size thresholds (tp8=160, tp4=96, tp2=96) when FCA+SD are both on.

Results on an H200 node (txt2sql recipe)
<img width="968" height="301" alt="Screenshot 2026-06-14 at 5 58 51 PM" src="https://github.com/user-attachments/assets/8fcc7c03-0b06-46fc-b1ae-88ee2661e69f" />