### PR TITLE
semi-persistence post release

### DIFF
--- a/arctic_inference/semi_persistence/README.md
+++ b/arctic_inference/semi_persistence/README.md
@@ -126,7 +126,10 @@ inst.generate(["Hello, world!"], {}).wait().print_status()
 
 `scripts/test_image.py` is the minimal save-then-restore walkthrough;
 `scripts/main_test.py` shows five instances being multiplexed across two GPUs by
-hand.
+hand. `scripts/test_weights.py` keeps the weights outside the image
+(`save_weights` / `load_weights`, so the dump runs against a detached, small
+process), and `scripts/test_tp2.py` does the same at tensor_parallel_size=2 with
+expert parallel, cold-starting on one GPU pair and restoring onto another.
 
 ## Repository layout
 

--- a/arctic_inference/semi_persistence/README.md
+++ b/arctic_inference/semi_persistence/README.md
@@ -117,10 +117,10 @@ from arctic_inference.semi_persistence import Instance
 
 inst = Instance({"model": "Qwen/Qwen3-8B-FP8", "enforce_eager": True})
 
-inst.init(gpu=0).attach().stage().sleep().checkpoint_cuda()
-inst.save_image("/data-fast/image-cache/qwen3-8b").wait()
+inst.init(gpu=0).attach().stage().sleep().cuda_checkpoint()
+inst.criu_dump("/data-fast/image-cache/qwen3-8b").wait()
 
-inst.restore_cuda(gpu=3).wake_up_weights().restore_weights().wake_up_kv_cache()
+inst.cuda_restore(gpu=3).wake_up_weights().restore_weights().wake_up_kv_cache()
 inst.generate(["Hello, world!"], {}).wait().print_status()
 ```
 
@@ -167,7 +167,7 @@ python -m pytest tests/ -q      # CPU-only, no GPU needed
   CUDA context and leaves no GPU residency behind; the on-disk form is a CRIU
   image of the entire child process tree.
 - A CRIU dump is destructive: the child is killed once the image is written, so
-  after `save_image` the model is `saved` with no live process.
+  after `criu_dump` the model is `saved` with no live process.
 - The orchestrator and its HTTP control plane are experimental research code
   with no authentication or per-user isolation. Do not expose the control port
   on an untrusted network.

--- a/arctic_inference/semi_persistence/README.md
+++ b/arctic_inference/semi_persistence/README.md
@@ -37,8 +37,8 @@ on AWS p5en.48xlarge (192 vCPU, 2 TiB host memory, 8x H200) with vLLM v0.18.0.*
 
 - Linux with NVIDIA GPUs, and a driver providing `cuda-checkpoint`.
 - vLLM and ArcticInference installed (see the [repository README](../../README.md)).
-- CRIU 4.2 with the CUDA plugin, plus the empty plugin directory
-  `/usr/lib/criu/empty` — without it, dumps abort at plugin init.
+- CRIU 4.2 with the CUDA plugin. The empty plugin directory it needs,
+  `/usr/lib/criu/empty`, is created by the dump if missing.
 - Passwordless `sudo`: checkpoint and restore shell out to `cuda-checkpoint`
   and `criu`, which need root.
 

--- a/arctic_inference/semi_persistence/_semip_worker.py
+++ b/arctic_inference/semi_persistence/_semip_worker.py
@@ -1,0 +1,46 @@
+"""Custom vLLM worker for TP semi-persistence.
+
+Standalone ``worker_cls`` (subclasses vanilla vLLM ``Worker``; no
+arctic_inference dependency).  Wired via ``vllm_config["worker_cls"] =
+"_semip_worker.SemipGPUWorker"`` for TP>1 instances.
+
+Two hooks:
+  * ``init_device`` remaps the vLLM ``local_rank`` to a physical GPU via
+    ``SEMIP_GPU_MAP`` (set by vllm_child before spawn), so a TP group can be
+    placed on an arbitrary set of physical GPUs while keeping all GPUs
+    visible (required for the cuda-checkpoint physical-GPU addressing).
+  * ``compile_or_warm_up_model`` forces the single cold-start CUDA-graph
+    capture onto the CustomAllreduce copy path (registered=False) with
+    keep_graph=True, so the preserved graph is reuse-friendly and
+    ``ca_graph_rebind`` can rewrite its baked addresses after CRIU restore.
+    The patches are scoped to the capture window (try/finally) so runtime is
+    unaffected.
+
+Both hooks return whatever the base class returns, so this stays agnostic to
+the ``compile_or_warm_up_model`` return type (a float on older vLLM, a
+``CompilationTimes`` on newer).
+"""
+import os
+
+from vllm.v1.worker.gpu_worker import Worker
+
+
+class SemipGPUWorker(Worker):
+    def init_device(self):
+        gpu_map = os.environ.get("SEMIP_GPU_MAP")
+        if gpu_map:
+            self.local_rank = int(gpu_map.split(",")[self.local_rank])
+        return super().init_device()
+
+    def compile_or_warm_up_model(self):
+        try:
+            import ca_graph_rebind
+        except Exception:
+            return super().compile_or_warm_up_model()
+        ca_graph_rebind.install_force_copy_patch()
+        ca_graph_rebind.install_keepgraph_patch()
+        try:
+            return super().compile_or_warm_up_model()
+        finally:
+            ca_graph_rebind.restore_force_copy_patch()
+            ca_graph_rebind.restore_keepgraph_patch()

--- a/arctic_inference/semi_persistence/abstract.py
+++ b/arctic_inference/semi_persistence/abstract.py
@@ -159,7 +159,7 @@ class InstanceBase(ABC):
 
     Usage:
         instance = Instance(vllm_config)
-        instance.init(gpu=0).attach().sleep().checkpoint_cuda().wait()
+        instance.init(gpu=0).attach().sleep().cuda_checkpoint().wait()
     """
 
     @abstractmethod
@@ -178,11 +178,11 @@ class InstanceBase(ABC):
         """Free GPU memory for weights and KV cache (vLLM sleep level=2)."""
 
     @abstractmethod
-    def checkpoint_cuda(self) -> InstanceBase:
+    def cuda_checkpoint(self) -> InstanceBase:
         """Save CUDA state to CPU. Instance becomes stateless (gpu=None)."""
 
     @abstractmethod
-    def save_image(self, filename: str) -> InstanceBase:
+    def criu_dump(self, filename: str | None = None) -> InstanceBase:
         """CRIU-dump the child process tree to disk (non-destructive).
 
         Uses --leave-running so the child stays alive after the dump.
@@ -190,7 +190,7 @@ class InstanceBase(ABC):
         """
 
     @abstractmethod
-    def load_image(self, filename: str | None = None) -> InstanceBase:
+    def criu_restore(self, filename: str | None = None) -> InstanceBase:
         """Restore a live process from a CRIU image on disk.
 
         Validates that the image's vllm_config matches this instance.
@@ -198,7 +198,7 @@ class InstanceBase(ABC):
         """
 
     @abstractmethod
-    def restore_cuda(self, gpu: int) -> InstanceBase:
+    def cuda_restore(self, gpu: int) -> InstanceBase:
         """Restore checkpointed CUDA state onto the specified GPU."""
 
     @abstractmethod
@@ -211,7 +211,7 @@ class InstanceBase(ABC):
 
         Like attach() but the buffer is pinned for its entire lifetime
         (until detach()). Skips the per-cycle repin()/unpin() pattern at
-        the cost of ~34 ms/GiB extra inside checkpoint_cuda/restore_cuda.
+        the cost of ~34 ms/GiB extra inside cuda_checkpoint/cuda_restore.
         Calling repin()/unpin() on a buffer created via attach_pinned()
         raises RuntimeError.
         """

--- a/arctic_inference/semi_persistence/abstract.py
+++ b/arctic_inference/semi_persistence/abstract.py
@@ -203,17 +203,18 @@ class InstanceBase(ABC):
 
     @abstractmethod
     def attach(self) -> InstanceBase:
-        """Allocate pinned CPU memory for staging weights."""
+        """Allocate CPU memory for staging weights, on each vLLM worker.
+
+        One buffer per worker, sized to that rank's parameters; pinning is
+        the separate repin() step.
+        """
 
     @abstractmethod
     def attach_pinned(self) -> InstanceBase:
-        """Allocate pinned host memory for staging (via torch pin_memory=True).
+        """Not supported; raises RuntimeError.  Use attach() -> repin().
 
-        Like attach() but the buffer is pinned for its entire lifetime
-        (until detach()). Skips the per-cycle repin()/unpin() pattern at
-        the cost of ~34 ms/GiB extra inside cuda_checkpoint/cuda_restore.
-        Calling repin()/unpin() on a buffer created via attach_pinned()
-        raises RuntimeError.
+        It allocated a permanently-pinned buffer (torch pin_memory=True)
+        before staging moved onto the workers.
         """
 
     @abstractmethod

--- a/arctic_inference/semi_persistence/ca_graph_rebind.py
+++ b/arctic_inference/semi_persistence/ca_graph_rebind.py
@@ -1,0 +1,3954 @@
+"""Dense-TP graph reuse: re-establish CustomAllreduce state after reinit so a
+surviving decode graph replays without full recapture.
+
+Measured facts (cuda_graph_recap/PROGRESS_savegraph.md, va_landscape + RECAP_PROFILE runs):
+  * The decode graph's CA all-reduce kernels read peer DATA pointers at runtime
+    from the CA `rank_data` device buffer. `rank_data`'s VA is STABLE across
+    destroy_nccl->reinit_nccl (torch caching-allocator reuse), so the baked
+    `RankData* _dp` kernel arg stays valid -- only its CONTENTS need refilling.
+  * The per-peer signal-pad pointers (`meta_ptrs`) ARE baked by value into the
+    kernel nodes and move on reinit -> handled separately (Part B).
+  * Re-establishing the ~5800 registered graph buffers costs ~0.1s (vs ~3-5s
+    forward-pass recapture).
+
+PART A (this module): refill the new CA's rank_data after reinit by replaying
+`register_graph_buffers` with the THIS-rank (handle, offset) recorded at cold
+start -- no forward-pass recapture per restore.
+
+Data-acquisition subtlety: `ops.get_graph_buffer_ipc_meta(fa)` returns the
+*unregistered delta* and is DRAINED by the cold-start register_graph_buffers, so
+reading it post-init yields 0. We therefore record it AS register_graph_buffers
+consumes it, by patching the op around one cold-start (re)capture
+(install_recorder -> capture_model -> read_recorder). That extra capture is a
+one-time cold-start cost; the per-restore path only does the cheap replay.
+
+Everything is wrapped so a failure logs and the caller falls back to recapture
+rather than crashing the worker.
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+log = logging.getLogger("semip.ca.rebind")
+
+_SNAP_ATTR = "_semip_graph_reuse_snapshot"
+_RANK_DATA_KEEP_ATTR = "_semip_rank_data_keep"
+_E4_INV_ATTR = "_semip_e4_pre_inventory"  # E4 pre-freeze baked-pointer inventory
+# Module-global recorder: captures the (handle, offset) that
+# register_graph_buffers consumes from get_graph_buffer_ipc_meta.
+_recorder: dict = {"active": False, "orig": None, "handle": None, "offset": None}
+
+
+def enabled() -> bool:
+    """Compatibility shim for older callers.
+
+    The active gate now lives in ``recapture_graphs("reuse")`` policy; this
+    module only performs work when its explicit preparation/rebind helpers run.
+    """
+    return True
+
+
+def _find_ca(worker):
+    """Return the worker's CustomAllreduce (ca_comm), or None."""
+    try:
+        from vllm.distributed import parallel_state as ps
+    except Exception as e:  # noqa: BLE001
+        log.warning("vllm import failed: %s", e)
+        return None
+    tp = getattr(ps, "_TP", None)
+    comm = getattr(tp, "device_communicator", None) if tp is not None else None
+    ca = getattr(comm, "ca_comm", None) if comm is not None else None
+    if ca is None or getattr(ca, "disabled", True):
+        return None
+    return ca
+
+
+def _rank_data_words(ca, n=24):
+    """First n uint64 words of rank_data, as hex, for verification dumps."""
+    try:
+        import torch
+        rd = getattr(ca, "rank_data", None)
+        if rd is None:
+            return None
+        words = rd.view(torch.int64)[:n].cpu().tolist()
+        return [hex(w & ((1 << 64) - 1)) for w in words]
+    except Exception as e:  # noqa: BLE001
+        return [f"err:{type(e).__name__}:{e}"]
+
+
+def install_recorder() -> bool:
+    """Patch ops.get_graph_buffer_ipc_meta to record the (handle, offset) that
+    the next register_graph_buffers consumes. Returns True if installed."""
+    try:
+        from vllm import _custom_ops as ops
+    except Exception as e:  # noqa: BLE001
+        log.warning("install_recorder: cannot import _custom_ops: %s", e)
+        return False
+    if _recorder["active"]:
+        return True
+    orig = ops.get_graph_buffer_ipc_meta
+
+    def _patched(fa):
+        handle, offset = orig(fa)
+        # Keep the richest (non-empty) capture seen while active.
+        if offset:
+            _recorder["handle"] = handle
+            _recorder["offset"] = offset
+        return handle, offset
+
+    _recorder["orig"] = orig
+    _recorder["handle"] = None
+    _recorder["offset"] = None
+    _recorder["active"] = True
+    ops.get_graph_buffer_ipc_meta = _patched
+    return True
+
+
+def read_recorder():
+    """Return (handle, offset) recorded since install_recorder."""
+    return _recorder.get("handle"), _recorder.get("offset")
+
+
+def restore_recorder() -> None:
+    """Undo install_recorder."""
+    if not _recorder["active"]:
+        return
+    try:
+        from vllm import _custom_ops as ops
+        if _recorder["orig"] is not None:
+            ops.get_graph_buffer_ipc_meta = _recorder["orig"]
+    except Exception:  # noqa: BLE001
+        pass
+    _recorder["active"] = False
+    _recorder["orig"] = None
+
+
+_kg = {"active": False, "orig": None}
+
+
+def install_keepgraph_patch() -> bool:
+    """Force torch.cuda.CUDAGraph to retain its topology graph (keep_graph=True)
+    so raw_cuda_graph() works for node enumeration/rewrite. Must be installed
+    BEFORE the graphs are (re)captured.
+
+    keep_graph appears in BOTH CUDAGraph.__new__(cls, keep_graph=False) and the
+    pybind CUDAGraph.__init__. Python constructs via __new__ THEN __init__ with the
+    SAME user args -- so for vLLM's `torch.cuda.CUDAGraph()` (no args) __init__ runs
+    keep_graph=default-False and is the FINAL word. VERIFIED EMPIRICALLY on this
+    torch 2.11 build (see PROGRESS_reuse_B200_v24.md R4): patching __new__ ALONE
+    leaves raw_cuda_graph() failing (__init__ resets keep_graph); patching __init__
+    makes raw_cuda_graph() succeed. So patch __init__ (this is what the original code
+    did; the __new__ detour was a wrong turn). Costs extra host memory for the kept
+    topology graphs (fine here)."""
+    try:
+        import torch
+    except Exception:  # noqa: BLE001
+        return False
+    if _kg["active"]:
+        return True
+    orig = torch.cuda.CUDAGraph.__init__
+
+    def _init(self, *a, **k):
+        k["keep_graph"] = True
+        return orig(self, *a, **k)
+
+    _kg["orig"] = orig
+    _kg["active"] = True
+    torch.cuda.CUDAGraph.__init__ = _init
+    return True
+
+
+def restore_keepgraph_patch() -> None:
+    if not _kg["active"]:
+        return
+    try:
+        import torch
+        if _kg["orig"] is not None:
+            torch.cuda.CUDAGraph.__init__ = _kg["orig"]
+    except Exception:  # noqa: BLE001
+        pass
+    _kg["active"] = False
+    _kg["orig"] = None
+
+
+_fc = {"active": False, "orig": None}
+
+
+def install_force_copy_patch() -> bool:
+    """Force CustomAllreduce to take the COPY path (`registered=False`) so the
+    captured graph bakes only the ONE static `buffer_ptrs[rank]` (in a memcpy
+    node) instead of thousands of per-buffer RankData. Install before the
+    (re)capture; restore after. The peer table for that one buffer lives in
+    rank_data slot 0, which the post-reinit `register_buffer` auto-refreshes."""
+    try:
+        import torch
+        from vllm.distributed.device_communicators.custom_all_reduce import (
+            CustomAllreduce as _CA)
+    except Exception:  # noqa: BLE001
+        return False
+    if _fc["active"]:
+        return True
+    orig_ar = _CA.all_reduce
+    orig_car = _CA.custom_all_reduce
+
+    def _forced_ar(self, inp, *, out=None, registered=False):
+        _fc["ar_calls"] = _fc.get("ar_calls", 0) + 1
+        return orig_ar(self, inp, out=out, registered=False)
+
+    def _forced_car(self, input):
+        # Mirror custom_all_reduce but FORCE the copy path during capture, so the
+        # captured graph bakes slot-0 (the symmetric staging buffer) instead of
+        # the registered per-buffer RankData peer slots (which go stale on reinit).
+        _fc["car_calls"] = _fc.get("car_calls", 0) + 1
+        if self.disabled or not self.should_custom_ar(input):
+            return None
+        if self._IS_CAPTURING:
+            if torch.cuda.is_current_stream_capturing():
+                return self.all_reduce(input, registered=False)  # FORCE copy path
+            return torch.empty_like(input)
+        return self.all_reduce(input, registered=False)
+
+    _fc["orig"] = orig_ar
+    _fc["orig_car"] = orig_car
+    _fc["active"] = True
+    _fc["ar_calls"] = 0
+    _fc["car_calls"] = 0
+    _CA.all_reduce = _forced_ar
+    _CA.custom_all_reduce = _forced_car
+    return True
+
+
+def restore_force_copy_patch() -> None:
+    if not _fc["active"]:
+        return
+    try:
+        from vllm.distributed.device_communicators.custom_all_reduce import (
+            CustomAllreduce as _CA)
+        if _fc["orig"] is not None:
+            _CA.all_reduce = _fc["orig"]
+        if _fc.get("orig_car") is not None:
+            _CA.custom_all_reduce = _fc["orig_car"]
+    except Exception:  # noqa: BLE001
+        pass
+    _fc["active"] = False
+    _fc["orig"] = None
+    _fc["orig_car"] = None
+
+
+_sr = {"active": False, "orig": None}
+
+
+def install_suppress_register_patch() -> bool:
+    """No-op CustomAllreduce.register_graph_buffers for a keep-graph (reuse) capture.
+
+    vLLM 0.24's CUDA-graph capture context ALWAYS calls register_graph_buffers() on exit
+    (custom_all_reduce.py), re-opening per-buffer IPC handles. On the reuse-snapshot's SECOND
+    capture_model() -- after the cold-start capture already registered once -- that double
+    registration faults at custom_all_reduce.cuh:434 'invalid argument' on B200 (and H200; confirmed
+    R1 in PROGRESS_reuse_B200_v24.md). With install_force_copy_patch active the kept graph bakes only
+    the COPY path (slot-0 staging buffer), so the registered per-buffer peer table is never used at
+    replay -- skipping the 2nd registration is safe and avoids the 434. Install alongside
+    install_force_copy_patch (around the 2nd capture_model); restore after. The cold-start (1st)
+    registration that install_recorder snapshots for rebind is untouched."""
+    try:
+        from vllm.distributed.device_communicators.custom_all_reduce import (
+            CustomAllreduce as _CA)
+    except Exception:  # noqa: BLE001
+        return False
+    if _sr["active"]:
+        return True
+    _sr["orig"] = _CA.register_graph_buffers
+
+    def _noop_register(self):
+        _sr["skipped"] = _sr.get("skipped", 0) + 1
+        return
+
+    _sr["active"] = True
+    _sr["skipped"] = 0
+    _CA.register_graph_buffers = _noop_register
+    return True
+
+
+def restore_suppress_register_patch() -> None:
+    if not _sr["active"]:
+        return
+    try:
+        from vllm.distributed.device_communicators.custom_all_reduce import (
+            CustomAllreduce as _CA)
+        if _sr["orig"] is not None:
+            _CA.register_graph_buffers = _sr["orig"]
+    except Exception:  # noqa: BLE001
+        pass
+    _sr["active"] = False
+    _sr["orig"] = None
+
+
+# rank_data-reuse patch (ported from v24 commit 66b3bf3): force the reinit
+# CustomAllreduce to reuse the preserved cold-start rank_data tensor (same VA)
+# instead of a fresh torch.empty, so rank_data_moved=False and the kept-graph _dp
+# pointers remain in range. This is the fix for the tp>=2 disk-wake worker death:
+# without it the rebuilt CA's rank_data can land at a new VA (allocator free-list
+# dependent), dangling the reused graphs' baked all-reduce pointers.
+_rd_reuse = {"active": False, "orig": None, "tensor": None, "used": False, "hit": False}
+
+
+def install_rank_data_reuse_patch(tensor) -> bool:
+    """Monkeypatch torch.empty so the NEXT 8MB-uint8-cuda allocation (the reinit
+    CustomAllreduce rank_data alloc, custom_all_reduce.py:184-186) returns the
+    preserved cold-start rank_data `tensor` instead. One-shot + tightly guarded
+    (exactly 8*1024*1024 uint8 on cuda); MUST be paired with restore_rank_data_reuse_patch
+    right after the CA is constructed. Returns False if no tensor to reuse.
+
+    Safe because semip runs with VLLM_ALLREDUCE_USE_SYMM_MEM=0 and FlashInfer AR off, so
+    within init_worker_distributed_environment the CA rank_data is the only 8MB-uint8-cuda
+    torch.empty; the one-shot `used` flag guarantees we intercept it at most once."""
+    import torch
+    if _rd_reuse["active"]:
+        return True
+    if tensor is None:
+        return False
+    orig = torch.empty
+
+    def _patched(*args, **kwargs):
+        if (not _rd_reuse["used"]
+                and len(args) == 1 and args[0] == 8 * 1024 * 1024
+                and kwargs.get("dtype") == torch.uint8
+                and str(kwargs.get("device", "")).startswith("cuda")):
+            _rd_reuse["used"] = True
+            _rd_reuse["hit"] = True
+            return _rd_reuse["tensor"]
+        return orig(*args, **kwargs)
+
+    _rd_reuse.update(orig=orig, tensor=tensor, used=False, hit=False, active=True)
+    torch.empty = _patched
+    return True
+
+
+def restore_rank_data_reuse_patch() -> bool:
+    """Undo install_rank_data_reuse_patch. Returns True iff the reuse tensor was
+    actually handed out (i.e. the rank_data alloc was intercepted)."""
+    if not _rd_reuse["active"]:
+        return False
+    try:
+        import torch
+        if _rd_reuse["orig"] is not None:
+            torch.empty = _rd_reuse["orig"]
+    except Exception:  # noqa: BLE001
+        pass
+    hit = _rd_reuse["hit"]
+    _rd_reuse.update(active=False, orig=None, tensor=None, used=False, hit=False)
+    return hit
+
+
+def store_snapshot(worker, handle, offset) -> dict:
+    """Store this rank's recorded registration + old meta_ptrs on the worker so
+    they survive the checkpoint and drive the post-reinit rebind."""
+    ca = _find_ca(worker)
+    snap = {
+        "handle": handle,
+        "offset": offset,
+        "n_offsets": len(offset) if offset else 0,
+        "meta_ptrs": list(getattr(ca, "meta_ptrs", []) or []) if ca else [],
+        "buffer_ptrs": list(getattr(ca, "buffer_ptrs", []) or []) if ca else [],
+        "rank_data": (int(ca.rank_data.data_ptr())
+                      if (ca is not None and getattr(ca, "rank_data", None) is not None)
+                      else 0),
+        "rank": getattr(ca, "rank", None) if ca else None,
+        "world_size": getattr(ca, "world_size", None) if ca else None,
+    }
+    setattr(worker, _SNAP_ATTR, snap)
+    # Hold a LIVE ref to the cold-start rank_data tensor so CA teardown at reinit does
+    # NOT return its 8MB caching-allocator block to the pool. On reinit the new CA
+    # reuses this exact tensor (install_rank_data_reuse_patch), so rank_data's VA is
+    # identical across reinit (rank_data_moved=False) and the kept-graph _dp pointers
+    # stay in range. Without this, models whose reinit free-list differs from cold-start
+    # (observed: 397B tp8 hybrid) get a NEW rank_data VA -> "no CA _dp slots" -> fallback.
+    try:
+        setattr(worker, _RANK_DATA_KEEP_ATTR,
+                ca.rank_data if (ca is not None
+                                 and getattr(ca, "rank_data", None) is not None)
+                else None)
+    except Exception:  # noqa: BLE001
+        pass
+    result = {
+        "ok": True,
+        "n_offsets": snap["n_offsets"],
+        "meta_ptrs": [hex(x) for x in snap["meta_ptrs"]],
+        "rank": snap["rank"],
+        "force_copy_ar_calls": _fc.get("ar_calls", 0),
+        "force_copy_car_calls": _fc.get("car_calls", 0),
+    }
+    # Phase-1 SP feasibility probe (Approach 2): dump the NCCL kernel nodes the kept
+    # graph bakes, and PERSIST to a file -- so the data survives regardless of log
+    # or return-dict propagation across the SP-worker (collective_rpc) boundary.
+    # Driven from store_snapshot because it demonstrably runs current code in the
+    # SP worker. Read-only (modifies no graph).
+    try:
+        import json as _json
+        import sys as _sys
+        sp_dump = dump_sp_nccl_nodes(worker)
+        sp_dump["_loaded_files"] = {
+            "ca_graph_rebind": getattr(_sys.modules.get("ca_graph_rebind"),
+                                       "__file__", None),
+            "vllm_child": getattr(_sys.modules.get("vllm_child"),
+                                  "__file__", None),
+        }
+        with open(f"/tmp/sp_graph_dump.{os.getpid()}.json", "w") as _f:
+            _json.dump(sp_dump, _f, indent=2, default=str)
+        result["sp_graph_dump"] = {k: sp_dump.get(k) for k in
+                                   ("n_graphs", "n_kernel_nodes", "n_nccl_nodes",
+                                    "nccl_kernels", "top_arg0", "_loaded_files")}
+    except Exception as _e:  # noqa: BLE001
+        result["sp_graph_dump_error"] = f"{type(_e).__name__}: {_e}"
+    # E4 PRE inventory (SEMIP_CA_E4_INVENTORY=1): snapshot every graph-baked size==8
+    # device pointer while the kept graph is known-good (this runs after cold capture,
+    # before any freeze -- codex resume8 confirmed store_snapshot as the correct
+    # last-known-good pre-hook, NOT pre-lock checkpoint_cuda). Stored on the worker for
+    # the post-reinit reclassify in rebind_after_reinit.
+    if _ca_e4_inventory_enabled():
+        result["e4_pre"] = e4_pre_inventory(worker)
+    return result
+
+
+def _replay_register_graph_buffers(ca, my_handle, my_offset) -> dict:
+    """Replay register_graph_buffers using the snapshotted local meta, without
+    re-running capture. Refills the (stable-VA) rank_data of the freshly
+    reinitialized CA. Mirrors CustomAllreduce.register_graph_buffers but uses
+    the snapshotted (handle, offset) for this rank.
+    """
+    import torch.distributed as dist
+    from vllm import _custom_ops as ops
+
+    group = ca.group
+    world_size = dist.get_world_size(group=group)
+    rank = dist.get_rank(group=group)
+    all_data = [[None, None] for _ in range(world_size)]
+    all_data[rank] = [my_handle, my_offset]
+    ranks = sorted(dist.get_process_group_ranks(group=group))
+    for i, r in enumerate(ranks):
+        dist.broadcast_object_list(all_data[i], src=r, group=group, device="cpu")
+    handles = [d[0] for d in all_data]
+    offsets = [d[1] for d in all_data]
+    ops.register_graph_buffers(ca._ptr, handles, offsets)
+    return {"n_offsets_self": len(my_offset) if my_offset else 0,
+            "n_ranks": world_size}
+
+
+# ---------------------------------------------------------------------------
+# PART B: rewrite the baked meta_ptrs in the captured graph execs.
+# The per-peer signal-pad pointers (meta_ptrs) are baked by value into the CA
+# all-reduce kernel nodes (RankSignals sg, Signal* self_sg) and move on reinit.
+# We walk each captured graph, identify CA kernels BY NAME (cuFuncGetName ->
+# "cross_device_reduce*") so we never deref a non-CA node's params, then
+# value-match old->new meta_ptrs in sg/self_sg and commit with
+# cuGraphExecKernelNodeSetParams. No vLLM CustomAllreduce source is touched.
+# ---------------------------------------------------------------------------
+import ctypes  # noqa: E402
+
+_CU = None
+_CU_NODE_TYPE_KERNEL = 0
+_CU_NODE_TYPE_MEMCPY = 1
+# E8 (resume12 Q2/Q3): the full CUgraphNodeType enum so we can histogram which
+# node classes a preserved FULL graph carries -- E4 only inventoried KERNEL(0) +
+# MEMCPY(1) params; codex flagged MEMSET(2), MEM_ALLOC(10)/MEM_FREE(11) (graph-
+# owned mempool), and GRAPH(4) child graphs (E4 never recursed) as the untested
+# node classes that could still bake a VA that moved across reinit.
+_CU_NODE_TYPE_MEMSET = 2
+_CU_NODE_TYPE_HOST = 3
+_CU_NODE_TYPE_GRAPH = 4          # child graph
+_CU_NODE_TYPE_EMPTY = 5
+_CU_NODE_TYPE_WAIT_EVENT = 6
+_CU_NODE_TYPE_EVENT_RECORD = 7
+_CU_NODE_TYPE_EXT_SEMAS_SIGNAL = 8
+_CU_NODE_TYPE_EXT_SEMAS_WAIT = 9
+_CU_NODE_TYPE_MEM_ALLOC = 10
+_CU_NODE_TYPE_MEM_FREE = 11
+_CU_NODE_TYPE_BATCH_MEM_OP = 12
+_CU_NODE_TYPE_CONDITIONAL = 13
+_CU_NODE_TYPE_NAMES = {
+    0: "kernel", 1: "memcpy", 2: "memset", 3: "host", 4: "child_graph",
+    5: "empty", 6: "wait_event", 7: "event_record", 8: "ext_sem_signal",
+    9: "ext_sem_wait", 10: "mem_alloc", 11: "mem_free", 12: "batch_mem_op",
+    13: "conditional",
+}
+
+
+class _KernelNodeParams(ctypes.Structure):
+    # CUDA_KERNEL_NODE_PARAMS_v2 (CUDA 12.x)
+    _fields_ = [
+        ("func", ctypes.c_void_p),
+        ("gridDimX", ctypes.c_uint), ("gridDimY", ctypes.c_uint),
+        ("gridDimZ", ctypes.c_uint),
+        ("blockDimX", ctypes.c_uint), ("blockDimY", ctypes.c_uint),
+        ("blockDimZ", ctypes.c_uint),
+        ("sharedMemBytes", ctypes.c_uint),
+        ("kernelParams", ctypes.POINTER(ctypes.c_void_p)),
+        ("extra", ctypes.POINTER(ctypes.c_void_p)),
+        ("kern", ctypes.c_void_p),
+        ("ctx", ctypes.c_void_p),
+    ]
+
+
+class _Memcpy3D(ctypes.Structure):
+    # CUDA_MEMCPY3D_v2 (driver). We only read/write srcDevice/dstDevice; the rest
+    # is here for correct struct SIZE so Get/SetParams round-trip cleanly.
+    _fields_ = [
+        ("srcXInBytes", ctypes.c_size_t), ("srcY", ctypes.c_size_t),
+        ("srcZ", ctypes.c_size_t), ("srcLOD", ctypes.c_size_t),
+        ("srcMemoryType", ctypes.c_uint),
+        ("srcHost", ctypes.c_void_p),
+        ("srcDevice", ctypes.c_uint64),
+        ("srcArray", ctypes.c_void_p),
+        ("reserved0", ctypes.c_void_p),
+        ("srcPitch", ctypes.c_size_t), ("srcHeight", ctypes.c_size_t),
+        ("dstXInBytes", ctypes.c_size_t), ("dstY", ctypes.c_size_t),
+        ("dstZ", ctypes.c_size_t), ("dstLOD", ctypes.c_size_t),
+        ("dstMemoryType", ctypes.c_uint),
+        ("dstHost", ctypes.c_void_p),
+        ("dstDevice", ctypes.c_uint64),
+        ("dstArray", ctypes.c_void_p),
+        ("reserved1", ctypes.c_void_p),
+        ("dstPitch", ctypes.c_size_t), ("dstHeight", ctypes.c_size_t),
+        ("WidthInBytes", ctypes.c_size_t), ("Height", ctypes.c_size_t),
+        ("Depth", ctypes.c_size_t),
+    ]
+
+
+class _MemsetNodeParams(ctypes.Structure):
+    # CUDA_MEMSET_NODE_PARAMS (driver). E8 reads only `dst` (the baked target VA);
+    # the rest is present for correct struct size so GetParams round-trips.
+    _fields_ = [
+        ("dst", ctypes.c_uint64),
+        ("pitch", ctypes.c_size_t),
+        ("value", ctypes.c_uint),
+        ("elementSize", ctypes.c_uint),
+        ("width", ctypes.c_size_t),
+        ("height", ctypes.c_size_t),
+    ]
+
+
+def _cu():
+    global _CU
+    if _CU is not None:
+        return _CU
+    cu = ctypes.CDLL("libcuda.so.1")
+    cu.cuGraphGetNodes.argtypes = [ctypes.c_void_p,
+                                   ctypes.POINTER(ctypes.c_void_p),
+                                   ctypes.POINTER(ctypes.c_size_t)]
+    cu.cuGraphNodeGetType.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_int)]
+    cu.cuGraphKernelNodeGetParams_v2.argtypes = [ctypes.c_void_p,
+                                                 ctypes.POINTER(_KernelNodeParams)]
+    cu.cuFuncGetName.argtypes = [ctypes.POINTER(ctypes.c_char_p), ctypes.c_void_p]
+    cu.cuGraphExecKernelNodeSetParams_v2.argtypes = [ctypes.c_void_p, ctypes.c_void_p,
+                                                     ctypes.POINTER(_KernelNodeParams)]
+    cu.cuGraphMemcpyNodeGetParams.argtypes = [ctypes.c_void_p,
+                                              ctypes.POINTER(_Memcpy3D)]
+    cu.cuGraphExecMemcpyNodeSetParams.argtypes = [ctypes.c_void_p, ctypes.c_void_p,
+                                                  ctypes.POINTER(_Memcpy3D),
+                                                  ctypes.c_void_p]
+    cu.cuCtxGetCurrent.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
+    # Topology (non-exec) setters: patch the kept cudaGraph_t so graphs that are
+    # (re-)instantiated AFTER rebind are born with the new addresses.
+    cu.cuGraphKernelNodeSetParams_v2.argtypes = [ctypes.c_void_p,
+                                                 ctypes.POINTER(_KernelNodeParams)]
+    cu.cuGraphMemcpyNodeSetParams.argtypes = [ctypes.c_void_p,
+                                              ctypes.POINTER(_Memcpy3D)]
+    # Signal-pad probe (SEMIP_CA_PAD_PROBE / SEMIP_CA_ZERO_SIGNAL): read the local
+    # CA Signal header D->H and (optionally) zero it. CUdeviceptr is 64-bit.
+    cu.cuMemcpyDtoH_v2.argtypes = [ctypes.c_void_p, ctypes.c_uint64,
+                                   ctypes.c_size_t]
+    cu.cuMemsetD8_v2.argtypes = [ctypes.c_uint64, ctypes.c_ubyte, ctypes.c_size_t]
+    # E3 (SEMIP_CA_E3_DUMP): classify graph-baked activation/result pointers.
+    # cuPointerGetAttribute(CU_POINTER_ATTRIBUTE_MEMORY_TYPE=2) is an independent
+    # validity/type check alongside cuMemGetAddressRange_v2 (bound in _cu_ipc).
+    cu.cuPointerGetAttribute.argtypes = [ctypes.c_void_p, ctypes.c_int,
+                                         ctypes.c_uint64]
+    # E4 (SEMIP_CA_E4_INVENTORY): per-function parameter reflection. cuFuncGetParamCount
+    # is absent on driver 13000, so iterate cuFuncGetParamInfo(func, i, &off, &sz) until it
+    # returns CUDA_ERROR_INVALID_VALUE -> yields both the param count and each (offset,size).
+    cu.cuFuncGetParamInfo.argtypes = [ctypes.c_void_p, ctypes.c_size_t,
+                                      ctypes.POINTER(ctypes.c_size_t),
+                                      ctypes.POINTER(ctypes.c_size_t)]
+    # E5 (SEMIP_CA_E5_REINSTANTIATE): build a FRESH cudaGraphExec_t from the kept,
+    # already-rebound cudaGraph_t (cuGraphInstantiateWithFlags), optionally upload
+    # it, and launch it in place of the preserved exec (cuGraphLaunch). Tests whether
+    # the stale INSTANTIATED exec (device-side launch/scheduling state that survives
+    # checkpoint_cuda but is invalidated by reinit) is the IMA source. Additive
+    # argtypes only; symbols exist on driver 13000.
+    cu.cuGraphInstantiateWithFlags.argtypes = [ctypes.POINTER(ctypes.c_void_p),
+                                               ctypes.c_void_p, ctypes.c_uint64]
+    cu.cuGraphUpload.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+    cu.cuGraphLaunch.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+    # E8 (SEMIP_E8_NODE_INV): read the baked target of the non-kernel/non-memcpy
+    # node classes E4 skipped. MEMSET.dst and MEM_FREE.dptr are single device VAs
+    # we classify against the live map; child graphs are recursed. MEM_ALLOC's
+    # struct is nested/complex -> we only COUNT those (presence alone is decisive:
+    # a graph-owned mempool node re-reserves VA at instantiate time). Best-effort:
+    # some symbols may be absent on this driver -> guarded at call sites.
+    for _sym in ("cuGraphMemsetNodeGetParams", "cuGraphMemsetNodeGetParams_v2"):
+        try:
+            getattr(cu, _sym).argtypes = [ctypes.c_void_p,
+                                          ctypes.POINTER(_MemsetNodeParams)]
+        except AttributeError:
+            pass
+    try:
+        cu.cuGraphMemFreeNodeGetParams.argtypes = [ctypes.c_void_p,
+                                                   ctypes.POINTER(ctypes.c_uint64)]
+    except AttributeError:
+        pass
+    try:
+        cu.cuGraphChildGraphNodeGetGraph.argtypes = [ctypes.c_void_p,
+                                                     ctypes.POINTER(ctypes.c_void_p)]
+    except AttributeError:
+        pass
+    _CU = cu
+    return cu
+
+
+def _ck(name, code):
+    if code != 0:
+        raise RuntimeError(f"{name} failed: CUresult={code}")
+
+
+def _graph_nodes(cu, graph):
+    num = ctypes.c_size_t(0)
+    _ck("cuGraphGetNodes(count)", cu.cuGraphGetNodes(graph, None, ctypes.byref(num)))
+    n = num.value
+    if n == 0:
+        return []
+    arr = (ctypes.c_void_p * n)()
+    _ck("cuGraphGetNodes", cu.cuGraphGetNodes(graph, arr, ctypes.byref(num)))
+    return [arr[i] for i in range(n)]
+
+
+def _func_name(cu, func):
+    namep = ctypes.c_char_p()
+    code = cu.cuFuncGetName(ctypes.byref(namep), func)
+    if code != 0 or not namep.value:
+        return ""
+    try:
+        return namep.value.decode("utf-8", "replace")
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _graph_manager_holders(worker):
+    """The objects that own a {desc: torch.cuda.CUDAGraph} `graphs` dict, i.e. the
+    FULL-cudagraph managers. The dense runner's is the one that matters; a spec-decode
+    speculator carries its own and its FULL graphs bake the same CA pointers, so
+    include it too. Returns (managers, why) -- `why` explains an empty result so a log
+    can tell "V1 runner, nothing to find" apart from "V2 runner, plumbing broken".
+
+    ONLY THE V2 RUNNER HAS ONE. vLLM 0.24 picks the runner per model
+    (`gpu_worker.py:355` on `vllm_config.use_v2_model_runner`, an ARCHITECTURE
+    ALLOWLIST -- `config/vllm.py:550` DEFAULT_V2_MODEL_RUNNER_ARCHITECTURES =
+    {Qwen3ForCausalLM, DeepseekV2ForCausalLM, Qwen2MoeForCausalLM,
+    GraniteMoeForCausalLM, LlamaForCausalLM, MistralForCausalLM}). V2
+    (`v1/worker/gpu/model_runner.py:466`) always builds a ModelCudaGraphManager; V1
+    (`v1/worker/gpu_model_runner.py`) has no decode manager at all -- its only
+    `*cudagraph_manager` is `encoder_cudagraph_manager` for multimodal encoders, and
+    its FULL graphs go through CUDAGraphWrapper, so source 1 already covers them.
+
+    So `n_managers == 0` is EXPECTED on a V1 model (any Qwen3Moe / Qwen2 / Qwen3_5 /
+    GLM / DeepseekV4 / gpt-oss ...) and is a BUG only on a V2 model. Record
+    `runner_class` in diag rather than inferring it: an empty result is otherwise
+    indistinguishable between the two, which is what made the first read of the
+    Qwen3-235B-A22B-tp4 (Qwen3MoeForCausalLM -> V1) validation run wrong."""
+    out = []
+    mr = getattr(worker, "model_runner", None)
+    if worker is None:
+        return out, "worker is None (caller did not pass it)"
+    if mr is None:
+        return out, f"{type(worker).__name__} has no .model_runner"
+    # 0.24 names the spec-decode holder `speculator` (model_runner.py:188/193);
+    # `drafter` is kept for older/newer spellings, hence both.
+    for attr, holder in (("model_runner", mr),
+                         ("speculator", getattr(mr, "speculator", None)),
+                         ("drafter", getattr(mr, "drafter", None))):
+        if holder is None:
+            continue
+        mgr = getattr(holder, "cudagraph_manager", None)
+        if mgr is not None and not any(m is mgr for m in out):
+            out.append(mgr)
+    if out:
+        return out, None
+    return out, (f"{type(mr).__name__} has no cudagraph_manager -- expected on the "
+                 f"V1 runner, where FULL graphs live in CUDAGraphWrapper (source 1)")
+
+
+def _find_captured_graphs(worker=None):
+    """Collect (cudaGraph_t, cudaGraphExec_t_or_0) for every captured
+    torch.cuda.CUDAGraph vLLM 0.24 holds.
+
+    A gc.get_objects() scan returns 0 on 0.24: vLLM gc.freeze()s the worker heap
+    after capture (gpu_worker.py freeze_gc_heap; comment literally lists "CUDA
+    graphs"), moving the graphs into CPython's permanent generation which
+    gc.get_objects() does NOT return. So enumerate the two places vLLM itself keeps
+    them, both freeze-immune:
+
+      1. the WRAPPER REGISTRIES -- CUDAGraphWrapper._all_instances (+
+         BreakableCUDAGraphWrapper) -> .concrete_cudagraph_entries[*].cudagraph
+         (cuda_graph.py). Take ALL wrappers, not just runtime_mode=FULL ones: the TP
+         custom-all-reduce kernels live in the piecewise regions too.
+      2. the GRAPH MANAGER -- worker.model_runner.cudagraph_manager.graphs, a plain
+         {BatchExecutionDescriptor: torch.cuda.CUDAGraph}.
+
+    Source 2 is here because omitting it WAS the reuse-graph bug (resume18, codex
+    gpt-5.5 consensus 2026-08-01), on the model runners where it applies. Which runner
+    you get is decided per-architecture by vllm/config/vllm.py:522 use_v2_model_runner
+    against DEFAULT_V2_MODEL_RUNNER_ARCHITECTURES (vllm.py:68), and that gate is also
+    the answer to why reuse "sometimes" worked:
+
+      * arch NOT in that set -> V1 runner (gpu_model_runner.py). With FULL_AND_PIECEWISE
+        and breakable cudagraphs off, :5317 wraps the model in
+        CUDAGraphWrapper(runtime_mode=FULL), so source 1 already covers the FULL graphs.
+        e.g. Qwen3-235B-A22B (Qwen3MoeForCausalLM, 94 layers): n_wrappers=96,
+        n_entries=4896=96x51, i.e. 95 piecewise pieces + 1 FULL wrapper. This model never
+        faulted on ckpt-wake -- its FULL graphs were always patched.
+      * arch IN that set -> V2 runner (gpu/model_runner.py:466). The FULL graphs are bare
+        torch.cuda.CUDAGraph objects in mgr.graphs[desc] (gpu/cudagraph_utils.py:316/327)
+        replayed via self.graphs[desc].replay() (:373); no CUDAGraphWrapper is ever
+        constructed, so they are in NO registry and source 1 misses every one of them.
+        e.g. Qwen3-32B (Qwen3ForCausalLM, 64 layers): n_wrappers=65, n_entries=3315=65x51,
+        i.e. 65 piecewise pieces and NO FULL wrapper. Across a CA address move those FULL
+        graphs kept freed VAs -> async illegal-memory-access on the first FULL decode
+        replay. That is the observed fault
+        (agent_run_log/ep/wakepath_qwen3-32b-tp4-dense_20260731-203342.log).
+
+    The capture progress-bar label is an independent tell for which runner ran: only V1's
+    gpu_model_runner.py:6718 emits the two-part "Capturing CUDA graphs ({}, {})", so
+    "(decode, FULL)" means V1 and a bare "(FULL)" means V2.
+
+    The gap also made E4's "pre_valid_post_invalid=0" true but vacuous on V2 models: E4
+    used this same enumerator, so it inventoried only the set that had just been patched.
+
+    `worker` is optional so the few diagnostic callers that have no worker still
+    work, but passing None silently reverts to the piecewise-only bug -- hence
+    diag["src"] records which sources actually contributed.
+
+    Topology needs keep_graph=True (install_keepgraph_patch, on __new__); exec may
+    be 0 for a shape captured-but-not-yet-instantiated -- we patch topology for all
+    and exec for the instantiated ones (later instantiate() inherits the patched
+    topology). Deduped by graph handle as well as by object identity: a handle
+    reachable from both sources must be patched once, since applying an old->new
+    value map twice can misfire if a new address is also an old key.
+    Preserves the (pairs, diag) contract of the old gc-scan version; diag carries
+    the manager handle set under the private key "_manager_handles" so callers can
+    split their counters by source (pop it before logging -- it is not a metric)."""
+    pairs = []
+    diag = {"n_wrappers": 0, "n_entries": 0, "n_cudagraph_objs": 0,
+            "n_topo_ok": 0, "n_exec_ok": 0, "n_topo_fail": 0,
+            "n_uninstantiated": 0, "n_managers": 0, "n_manager_graphs": 0,
+            "n_dup_handles": 0, "src": None, "err": None,
+            "runner_class": None, "mgr_why": None}
+    try:
+        import torch
+        cls = torch.cuda.CUDAGraph
+        wrappers = []
+        try:
+            from vllm.compilation.cuda_graph import CUDAGraphWrapper
+            wrappers += list(CUDAGraphWrapper._all_instances)
+        except Exception as ex:  # noqa: BLE001
+            diag["err"] = f"import CUDAGraphWrapper: {type(ex).__name__}: {ex}"
+        try:
+            from vllm.compilation.breakable_cudagraph import (
+                BreakableCUDAGraphWrapper)
+            wrappers += list(BreakableCUDAGraphWrapper._all_instances)
+        except Exception:  # noqa: BLE001
+            pass
+        diag["n_wrappers"] = len(wrappers)
+        diag["src"] = "vllm_wrappers"
+        seen = set()
+        cgs = []
+        for w in wrappers:
+            # graphs live in .concrete_cudagraph_entries (CUDAGraphWrapper) or
+            # .entries (BreakableCUDAGraphWrapper); duck-type CUDAGraph out of
+            # each entry's attrs (robust to attr renames / segment lists).
+            for attr in ("concrete_cudagraph_entries", "entries"):
+                m = getattr(w, attr, None)
+                if not isinstance(m, dict):
+                    continue
+                for entry in m.values():
+                    diag["n_entries"] += 1
+                    vals = (list(vars(entry).values())
+                            if hasattr(entry, "__dict__") else [])
+                    for v in vals:
+                        if isinstance(v, cls):
+                            if id(v) not in seen:
+                                seen.add(id(v)); cgs.append(v)
+                        elif isinstance(v, (list, tuple)):
+                            for it in v:
+                                if isinstance(it, cls) and id(it) not in seen:
+                                    seen.add(id(it)); cgs.append(it)
+        # Source 2: the FULL graphs, which live in no registry (see docstring).
+        # V2 runner only -- on V1 there is no manager and source 1 already has them.
+        mgr_ids = set()
+        _mr = getattr(worker, "model_runner", None)
+        diag["runner_class"] = type(_mr).__name__ if _mr is not None else None
+        managers, diag["mgr_why"] = _graph_manager_holders(worker)
+        for mgr in managers:
+            graphs = getattr(mgr, "graphs", None)
+            if not isinstance(graphs, dict):
+                diag["mgr_why"] = (f"{type(mgr).__name__}.graphs is "
+                                   f"{type(graphs).__name__}, not a dict")
+                continue
+            diag["n_managers"] += 1
+            for g in graphs.values():
+                if not isinstance(g, cls) or id(g) in seen:
+                    continue
+                seen.add(id(g)); cgs.append(g); mgr_ids.add(id(g))
+                diag["n_manager_graphs"] += 1
+        if diag["n_managers"]:
+            diag["src"] = "vllm_wrappers+manager" if wrappers else "manager"
+        # Fallback (registries unexpectedly empty): unfreeze the heap, gc scan,
+        # then re-freeze -- so we still find graphs if the wrapper path changes.
+        if not cgs:
+            import gc
+            gc.unfreeze()
+            try:
+                for o in gc.get_objects():
+                    try:
+                        ok = isinstance(o, cls)
+                    except Exception:  # noqa: BLE001
+                        ok = False
+                    if ok and id(o) not in seen:
+                        seen.add(id(o)); cgs.append(o)
+            finally:
+                gc.freeze()
+            diag["src"] = "gc_unfreeze_fallback"
+        emitted = set()
+        mgr_handles = []
+        for o in cgs:
+            diag["n_cudagraph_objs"] += 1
+            try:
+                g = int(o.raw_cuda_graph())
+            except Exception as ex:  # noqa: BLE001 - no topology (keep_graph False)
+                diag["n_topo_fail"] += 1
+                if diag["err"] is None:
+                    diag["err"] = f"topo: {type(ex).__name__}: {ex}"
+                continue
+            if g in emitted:
+                # Same graph reached from both sources -- patch it once (see docstring).
+                diag["n_dup_handles"] += 1
+                continue
+            emitted.add(g)
+            e = 0
+            try:
+                e = int(o.raw_cuda_graph_exec())
+            except Exception:  # noqa: BLE001 - captured but not yet instantiated
+                diag["n_uninstantiated"] += 1
+            diag["n_topo_ok"] += 1
+            if e:
+                diag["n_exec_ok"] += 1
+                # E7 (resume11 Q3): remember which graph objects already had a live
+                # exec pre-rebind, so a FULL replay hook can tag preserved vs fresh.
+                if _reuse_diag_enabled():
+                    _PRESERVED_EXEC_IDS.add(id(o))
+            if id(o) in mgr_ids:
+                mgr_handles.append(g)
+            pairs.append((g, e))
+        diag["_manager_handles"] = frozenset(mgr_handles)
+    except Exception as e:  # noqa: BLE001
+        diag["err"] = f"{type(e).__name__}: {e}"
+        log.warning("Part B: _find_captured_graphs failed: %s", e)
+    log.info("Part B _find_captured_graphs: %s",
+             {k: v for k, v in diag.items() if not k.startswith("_")})
+    return pairs, diag
+
+
+def dump_sp_nccl_nodes(worker, max_samples=48, n_words=8):
+    """Phase-1 feasibility probe for SP keep-graph (Approach 2): walk the captured
+    graphs, find NCCL kernel nodes (the Ulysses all-to-all + any pynccl all-reduce
+    that fell back from CA during shift capture) and dump what each bakes into its
+    FIRST kernel arg -- so we can judge whether the comm/device state is a small,
+    rewritable set (-> build the ncclCommAbort+rebind of Approach 2) or too opaque
+    (-> fall back to Approach 3, SP uses recapture).
+
+    READ-ONLY: modifies no graph. We deref only kernelParams[0] (always present
+    for a kernel) for a few words; we never walk kp[1..] (unknown NCCL arg count ->
+    out-of-bounds). Logs detail to the worker log; returns a compact summary."""
+    summary = {"n_graphs": 0, "n_kernel_nodes": 0, "n_nccl_nodes": 0,
+               "nccl_kernels": {}, "n_samples": 0, "top_arg0": [], "err": None}
+    try:
+        cu = _cu()
+        pairs, _diag = _find_captured_graphs(worker)
+        summary["n_graphs"] = len(pairs)
+        arg0_hist = {}
+        samples = []
+        for gi, (g, _e) in enumerate(pairs):
+            if not g:
+                continue
+            for ni, node in enumerate(_graph_nodes(cu, g)):
+                t = ctypes.c_int(-1)
+                if cu.cuGraphNodeGetType(node, ctypes.byref(t)) != 0:
+                    continue
+                if t.value != _CU_NODE_TYPE_KERNEL:
+                    continue
+                summary["n_kernel_nodes"] += 1
+                params = _KernelNodeParams()
+                if cu.cuGraphKernelNodeGetParams_v2(node, ctypes.byref(params)) != 0:
+                    continue
+                name = _func_name(cu, params.func)
+                low = name.lower()
+                if ("nccl" not in low and "all_to_all" not in low
+                        and "alltoall" not in low and "sendrecv" not in low):
+                    continue
+                summary["n_nccl_nodes"] += 1
+                summary["nccl_kernels"][name] = \
+                    summary["nccl_kernels"].get(name, 0) + 1
+                kp = params.kernelParams
+                words = []
+                if kp:
+                    arg0 = kp[0]               # first kernel-arg storage (host)
+                    if arg0:
+                        try:
+                            buf = (ctypes.c_uint64 * n_words).from_address(arg0)
+                            words = [int(buf[i]) for i in range(n_words)]
+                        except Exception:      # noqa: BLE001
+                            words = []
+                if words:
+                    arg0_hist[words[0]] = arg0_hist.get(words[0], 0) + 1
+                if len(samples) < max_samples:
+                    samples.append({"g": gi, "n": ni, "name": name,
+                                    "grid": (params.gridDimX, params.gridDimY,
+                                             params.gridDimZ),
+                                    "arg0_words": [hex(w) for w in words]})
+        summary["n_samples"] = len(samples)
+        top = sorted(arg0_hist.items(), key=lambda kv: -kv[1])[:16]
+        summary["top_arg0"] = [{"addr": hex(a), "count": c} for a, c in top]
+        log.info("SP_GRAPH_DUMP: n_graphs=%d n_kernel_nodes=%d n_nccl_nodes=%d "
+                 "kernels=%s", summary["n_graphs"], summary["n_kernel_nodes"],
+                 summary["n_nccl_nodes"], summary["nccl_kernels"])
+        log.info("SP_GRAPH_DUMP: top_arg0(addr:count)=%s", summary["top_arg0"])
+        for s in samples:
+            log.info("SP_GRAPH_DUMP node g%d n%d %s grid=%s arg0=%s",
+                     s["g"], s["n"], s["name"], s["grid"], s["arg0_words"])
+    except Exception as ex:  # noqa: BLE001
+        summary["err"] = f"{type(ex).__name__}: {ex}"
+        log.warning("dump_sp_nccl_nodes failed: %s", ex)
+    return summary
+
+
+def _patch_node(cu, exec_handle, node, meta_map, vfy=None):
+    """If `node` is a CA all-reduce kernel, value-match old->new meta_ptrs in its
+    sg (kernelParams[1], 8 ptrs) and self_sg (kernelParams[2], 1 ptr) and commit.
+    Returns the number of pointer slots rewritten (0 if not a CA node / no match).
+
+    `vfy`: optional counter dict for the transactional topology readback at the end
+    of this function (keys k_topo_ok / k_topo_bad / topo_readback_err). None skips it.
+    """
+    t = ctypes.c_int(-1)
+    if cu.cuGraphNodeGetType(node, ctypes.byref(t)) != 0:
+        return 0
+    if t.value != _CU_NODE_TYPE_KERNEL:
+        return 0
+    params = _KernelNodeParams()
+    if cu.cuGraphKernelNodeGetParams_v2(node, ctypes.byref(params)) != 0:
+        return 0
+    name = _func_name(cu, params.func)
+    if "cross_device_reduce" not in name:
+        return 0
+    kp = params.kernelParams
+    if not kp:
+        return 0
+    # CA kernel signature: (RankData* _dp, RankSignals sg, Signal* self_sg,
+    #                       T* result, int rank, int size) -> 6 args.
+    dp_addr = kp[0]
+    sg_addr = kp[1]
+    self_addr = kp[2]
+    if not sg_addr or not self_addr:
+        return 0
+    rewrites = 0
+    # _dp (kernelParams[0]) is a pointer INTO rank_data (the per-buffer RankData
+    # slot). Rewrite if rank_data moved across reinit.
+    new_dp = None
+    if dp_addr:
+        dp_cur = int((ctypes.c_uint64 * 1).from_address(dp_addr)[0])
+        mapped = meta_map.get(dp_cur, dp_cur)
+        if mapped != dp_cur:
+            new_dp = mapped
+            rewrites += 1
+    sg = (ctypes.c_uint64 * 8).from_address(sg_addr)
+    self_sg = (ctypes.c_uint64 * 1).from_address(self_addr)
+    new_sg_vals = []
+    # Snapshot the pre-patch values: `sg` is a view onto the driver's arg storage,
+    # so after SetParams below it is no longer a reliable source for "what did this
+    # slot hold before?" -- which the readback needs to know which slots to verify.
+    sg_before = []
+    for i in range(8):
+        v = int(sg[i])
+        sg_before.append(v)
+        nv = meta_map.get(v, v)
+        new_sg_vals.append(nv)
+        if nv != v:
+            rewrites += 1
+    sv = int(self_sg[0])
+    new_self = meta_map.get(sv, sv)
+    if new_self != sv:
+        rewrites += 1
+    if rewrites == 0:
+        return 0
+    # Commit with fresh backing buffers (don't mutate driver-owned arg storage).
+    new_sg_buf = (ctypes.c_uint64 * 8)(*new_sg_vals)
+    new_self_buf = (ctypes.c_uint64 * 1)(new_self)
+    dp_slot = kp[0]
+    new_dp_buf = None
+    if new_dp is not None:
+        new_dp_buf = (ctypes.c_uint64 * 1)(new_dp)
+        dp_slot = ctypes.cast(new_dp_buf, ctypes.c_void_p)
+    new_kp = (ctypes.c_void_p * 6)(
+        dp_slot, ctypes.cast(new_sg_buf, ctypes.c_void_p),
+        ctypes.cast(new_self_buf, ctypes.c_void_p), kp[3], kp[4], kp[5])
+    params.kernelParams = ctypes.cast(new_kp, ctypes.POINTER(ctypes.c_void_p))
+    # Topology set (always): so graphs (re-)instantiated AFTER rebind are correct.
+    _ck("cuGraphKernelNodeSetParams_v2",
+        cu.cuGraphKernelNodeSetParams_v2(node, ctypes.byref(params)))
+    # Exec set (only if this graph is already instantiated): fix the live exec.
+    if exec_handle:
+        _ck("cuGraphExecKernelNodeSetParams_v2",
+            cu.cuGraphExecKernelNodeSetParams_v2(exec_handle, node,
+                                                 ctypes.byref(params)))
+    # Transactional TOPOLOGY readback (codex consensus, E14): prove per node that
+    # the commit took, by reading the slot back and comparing it to the value we
+    # meant to write. This replaces "does any slot still hold an OLD address?" as
+    # the primary confirm-not-lucky counter, because that question is unanswerable
+    # on a 2nd-or-later wake: CA reallocates into the VAs the previous wake freed,
+    # so addr_map becomes a permutation whose value set overlaps its key set, and a
+    # CORRECTLY rewritten slot then holds a value that is also some other rank's old
+    # address. (E14 measured exactly that: 4 of 8 rebind events reported tens of
+    # thousands of "stale" hits with the rewrite provably complete -- see
+    # agent_run_log/e14_v2arch_v24/audit_falsepos_proof.py.)
+    #
+    # Only the slots actually rewritten are counted, so
+    #     k_topo_ok + k_topo_bad == kernel_slots_rewritten
+    # is an exact invariant of a healthy wake; unchanged slots need no proof.
+    #
+    # TOPOLOGY ONLY: there is no cuGraphExecKernelNodeGetParams, so the
+    # cuGraphExecKernelNodeSetParams_v2 above stays verified by return code +
+    # replay behaviour alone. Hence the field name -- do not read k_topo_ok as
+    # evidence about the live exec.
+    if vfy is not None:
+        back = _KernelNodeParams()
+        if cu.cuGraphKernelNodeGetParams_v2(node, ctypes.byref(back)) != 0 \
+                or not back.kernelParams:
+            vfy["topo_readback_err"] += 1
+        else:
+            bkp = back.kernelParams
+            got_sg = (ctypes.c_uint64 * 8).from_address(bkp[1])
+            for i in range(8):
+                if new_sg_vals[i] == sg_before[i]:
+                    continue
+                vfy["k_topo_ok" if int(got_sg[i]) == new_sg_vals[i]
+                    else "k_topo_bad"] += 1
+            if new_self != sv:
+                got_self = int((ctypes.c_uint64 * 1).from_address(bkp[2])[0])
+                vfy["k_topo_ok" if got_self == new_self else "k_topo_bad"] += 1
+            if new_dp is not None and bkp[0]:
+                got_dp = int((ctypes.c_uint64 * 1).from_address(bkp[0])[0])
+                vfy["k_topo_ok" if got_dp == new_dp else "k_topo_bad"] += 1
+    # keep new_sg_buf/new_self_buf/new_dp_buf/new_kp alive until the calls return
+    return rewrites
+
+
+def _patch_memcpy_node(cu, exec_handle, node, ctx, addr_map, vfy=None):
+    """If `node` is a MEMCPY whose src/dst device ptr is a stale (old) CA buffer
+    (e.g. the copy-path `buffer_ptrs[rank]`), rewrite it to the new addr and
+    commit. Returns the number of device-ptr fields rewritten.
+
+    `vfy`: optional counter dict for the transactional topology readback (keys
+    m_topo_ok / m_topo_bad / topo_readback_err). See _patch_node for why readback
+    replaced old-address membership as the primary counter."""
+    t = ctypes.c_int(-1)
+    if cu.cuGraphNodeGetType(node, ctypes.byref(t)) != 0:
+        return 0
+    if t.value != _CU_NODE_TYPE_MEMCPY:
+        return 0
+    p = _Memcpy3D()
+    if cu.cuGraphMemcpyNodeGetParams(node, ctypes.byref(p)) != 0:
+        return 0
+    rewrites = 0
+    changed = {}
+    for field in ("srcDevice", "dstDevice"):
+        v = int(getattr(p, field))
+        nv = addr_map.get(v)
+        if nv is not None and nv != v:
+            setattr(p, field, nv)
+            changed[field] = nv
+            rewrites += 1
+    if rewrites:
+        # Topology set (always) + exec set (only if instantiated).
+        _ck("cuGraphMemcpyNodeSetParams",
+            cu.cuGraphMemcpyNodeSetParams(node, ctypes.byref(p)))
+        if exec_handle:
+            _ck("cuGraphExecMemcpyNodeSetParams",
+                cu.cuGraphExecMemcpyNodeSetParams(
+                    exec_handle, node, ctypes.byref(p), ctx))
+        # Topology-only readback; m_topo_ok + m_topo_bad == memcpy_ptrs_rewritten.
+        if vfy is not None:
+            back = _Memcpy3D()
+            if cu.cuGraphMemcpyNodeGetParams(node, ctypes.byref(back)) != 0:
+                vfy["topo_readback_err"] += 1
+            else:
+                for field, want in changed.items():
+                    vfy["m_topo_ok" if int(getattr(back, field)) == want
+                        else "m_topo_bad"] += 1
+    return rewrites
+
+
+def _audit_stale_ca_addrs(cu, pairs, addr_map, ca=None) -> dict:
+    """Read-only post-rewrite audit of the CA pointer slots baked into `pairs`.
+
+    `bad` must be 0 after rewrite_addrs_in_graphs. It sums only the counters that
+    are UNAMBIGUOUS evidence of a graph that will fault on its next replay.
+
+    Why this is not simply "does any slot still hold a key of addr_map" -- which is
+    what this function used to ask (and what E14 tripped over): that predicate is a
+    staleness test ONLY when addr_map's key set and value set are disjoint. They are
+    on the first wake (old = pre-CRIU VAs, new = freshly allocated), but on a 2nd or
+    later wake CA reallocates into the VAs the previous wake just freed, so addr_map
+    becomes a permutation with heavy key/value overlap and a CORRECTLY rewritten slot
+    holds a value that is also some other rank's old address. E14 reported
+    hits=39780 on 3 ranks and 26520 on a 4th with the rewrite provably complete; every
+    one of those integers is reproduced exactly by the overlap model in
+    agent_run_log/e14_v2arch_v24/audit_falsepos_proof.py. Worse than the noise: on
+    such a wake the old predicate could not have distinguished a real residual, so it
+    would have masked one.
+
+    So the audit now asks two answerable questions instead:
+
+      * POSITIONAL (primary, needs `ca`): a CA kernel is identified by func name --
+        address-independent -- and then every slot is compared to the value it OUGHT
+        to hold now: sg[i] == ca.meta_ptrs[i] for i < tp, and self_sg ==
+        ca.meta_ptrs[ca.rank]. vLLM builds both lists rank-positionally
+        (create_shared_buffer fills by enumerate(all_gather_object(...)) and inserts
+        its own pointer at i == rank; CustomAllreduce itself indexes
+        buffer_ptrs[self.rank]), so position is meaningful. This is strictly stronger
+        than membership: it also catches a rank PERMUTATION, which any set-membership
+        test passes happily. Reported split as kernel_sg_pos_bad / kernel_self_pos_bad
+        so a positional-only failure is legible.
+      * DEFINITELY STALE (fallback, no `ca` needed): a slot holding a value in
+        `keys - values` -- an old address that is not the correct new value of
+        anything -- is provably a freed VA. Slots in `keys & values` are recorded as
+        `ambiguous` and NOT counted as bad; that bucket is exactly the old false
+        positive, kept visible rather than silently dropped.
+
+    The sg tail (i >= tp) is informational only: nothing here has ever proven
+    RankSignals is zero-filled past ngpus, so a nonzero tail is counted
+    (`sg_tail_nonzero`) but is `bad` only if it is provably stale (`sg_tail_stale`).
+    Making the tail a correctness gate would repeat the mistake this rewrite fixes.
+
+    `legacy_hits` recomputes the OLD predicate purely so runs can be compared against
+    pre-fix logs. It is EXPECTED to be nonzero on any 2nd-or-later wake and means
+    nothing on its own -- do not gate on it.
+
+    Also counts the node classes the patchers deliberately skip, to answer "does a
+    FULL graph bake a CA address somewhere we do not write?" empirically. E14
+    answered NO (memset/memfree/memalloc/child all 0 across 8 rebind events on the V2
+    manager path), so the patchers stay at KERNEL+MEMCPY; these counters remain as
+    the regression tripwire for that decision. Child graphs are recursed one level.
+    Never raises."""
+    out = {"bad": 0, "kernel_sg_pos_bad": 0, "kernel_self_pos_bad": 0,
+           "kernel_definite": 0, "memcpy_definite": 0, "memset_definite": 0,
+           "memfree_definite": 0, "sg_tail_stale": 0,
+           "kernel_ambiguous": 0, "memcpy_ambiguous": 0, "sg_tail_nonzero": 0,
+           "n_ca_kernel": 0, "n_memset": 0, "n_memfree": 0, "n_memalloc": 0,
+           "n_child": 0, "legacy_hits": 0, "pos_checked": False, "why": None,
+           "err": None}
+
+    values = set(addr_map.values())
+    definite = set(addr_map) - values          # provably freed VAs
+    ambig = set(addr_map) & values             # indistinguishable by value alone
+    out["n_definite"] = len(definite)
+    out["n_ambiguous_addrs"] = len(ambig)
+
+    # Expected current values (positional). Guarded: a missing/odd ca must degrade
+    # to the definite-stale check, never raise and never fabricate a failure.
+    meta: list = []
+    rank = None
+    try:
+        if ca is not None:
+            meta = [int(x) for x in (getattr(ca, "meta_ptrs", None) or [])]
+            r = getattr(ca, "rank", None)
+            rank = int(r) if isinstance(r, int) else None
+    except Exception as ex:  # noqa: BLE001
+        out["why"] = f"ca read failed: {type(ex).__name__}: {ex}"
+    tp = len(meta)
+    pos = tp > 0 and rank is not None and 0 <= rank < tp
+    out["pos_checked"] = pos
+    if not pos and out["why"] is None:
+        out["why"] = ("no ca" if ca is None else
+                      f"tp={tp} rank={rank} -> positional audit skipped")
+
+    def _cls(v):
+        """Classify one slot value; returns 'definite' | 'ambiguous' | None."""
+        if v in definite:
+            return "definite"
+        if v in ambig:
+            return "ambiguous"
+        return None
+
+    def _walk(g, depth):
+        try:
+            nodes = _graph_nodes(cu, g)
+        except Exception:  # noqa: BLE001
+            return
+        for node in nodes:
+            t = ctypes.c_int(-1)
+            if cu.cuGraphNodeGetType(node, ctypes.byref(t)) != 0:
+                continue
+            tv = t.value
+            if tv == _CU_NODE_TYPE_KERNEL:
+                params = _KernelNodeParams()
+                if cu.cuGraphKernelNodeGetParams_v2(
+                        node, ctypes.byref(params)) != 0:
+                    continue
+                if not params.func:
+                    continue
+                if "cross_device_reduce" not in _func_name(cu, params.func):
+                    continue
+                kp = params.kernelParams
+                if not kp or not kp[1] or not kp[2]:
+                    continue
+                out["n_ca_kernel"] += 1
+                sg = (ctypes.c_uint64 * 8).from_address(kp[1])
+                for i in range(8):
+                    v = int(sg[i])
+                    out["legacy_hits"] += 1 if v in addr_map else 0
+                    c = _cls(v)
+                    if c == "definite":
+                        out["kernel_definite"] += 1
+                    elif c == "ambiguous":
+                        out["kernel_ambiguous"] += 1
+                    if pos and i < tp:
+                        if v != meta[i]:
+                            out["kernel_sg_pos_bad"] += 1
+                    elif v:
+                        out["sg_tail_nonzero"] += 1
+                        if c == "definite":
+                            out["sg_tail_stale"] += 1
+                sv = int((ctypes.c_uint64 * 1).from_address(kp[2])[0])
+                out["legacy_hits"] += 1 if sv in addr_map else 0
+                c = _cls(sv)
+                if c == "definite":
+                    out["kernel_definite"] += 1
+                elif c == "ambiguous":
+                    out["kernel_ambiguous"] += 1
+                if pos and sv != meta[rank]:
+                    out["kernel_self_pos_bad"] += 1
+                if kp[0]:
+                    dp = int((ctypes.c_uint64 * 1).from_address(kp[0])[0])
+                    out["legacy_hits"] += 1 if dp in addr_map else 0
+                    # _dp points INTO rank_data, not at a meta_ptr, so there is no
+                    # positional expectation for it -- only "not a freed VA".
+                    if _cls(dp) == "definite":
+                        out["kernel_definite"] += 1
+            elif tv == _CU_NODE_TYPE_MEMCPY:
+                p = _Memcpy3D()
+                if cu.cuGraphMemcpyNodeGetParams(node, ctypes.byref(p)) != 0:
+                    continue
+                for f in ("srcDevice", "dstDevice"):
+                    v = int(getattr(p, f))
+                    out["legacy_hits"] += 1 if v in addr_map else 0
+                    c = _cls(v)
+                    if c == "definite":
+                        out["memcpy_definite"] += 1
+                    elif c == "ambiguous":
+                        out["memcpy_ambiguous"] += 1
+            elif tv == _CU_NODE_TYPE_MEMSET:
+                out["n_memset"] += 1
+                p = _MemsetNodeParams()
+                if _e8_memset_params(cu, node, p):
+                    d = int(p.dst)
+                    out["legacy_hits"] += 1 if d in addr_map else 0
+                    if d in definite:
+                        out["memset_definite"] += 1
+            elif tv == _CU_NODE_TYPE_MEM_FREE:
+                out["n_memfree"] += 1
+                dptr = ctypes.c_uint64(0)
+                if _e8_memfree_dptr(cu, node, dptr):
+                    d = int(dptr.value)
+                    out["legacy_hits"] += 1 if d in addr_map else 0
+                    if d in definite:
+                        out["memfree_definite"] += 1
+            elif tv == _CU_NODE_TYPE_MEM_ALLOC:
+                # Count only: CUDA_MEM_ALLOC_NODE_PARAMS is deeply nested and a
+                # mis-sized struct would let the driver write past our buffer.
+                out["n_memalloc"] += 1
+            elif tv == _CU_NODE_TYPE_GRAPH:
+                out["n_child"] += 1
+                if depth == 0:
+                    sub = ctypes.c_void_p()
+                    if _e8_child_graph(cu, node, sub) and sub.value:
+                        _walk(sub.value, depth + 1)
+
+    try:
+        for g, _e in pairs:
+            if g:
+                _walk(g, 0)
+        # A positionally-bad slot is usually also a definitely-stale slot, so these
+        # buckets can overlap; `bad` is a must-be-zero flag, not a slot count.
+        out["bad"] = (out["kernel_sg_pos_bad"] + out["kernel_self_pos_bad"]
+                      + out["kernel_definite"] + out["memcpy_definite"]
+                      + out["memset_definite"] + out["memfree_definite"]
+                      + out["sg_tail_stale"])
+    except Exception as ex:  # noqa: BLE001 - an audit must never break the wake
+        out["err"] = f"{type(ex).__name__}: {ex}"
+    return out
+
+
+# ---------------------------------------------------------------------------
+# CA graph-exec force-recommit (disk-wake stale-exec fix). Root-caused + A/B
+# proven in DEBUG_reuse_graph.md: on a reuse DISK-wake, CRIU reproduces every CA
+# VA -> addr_map=={} -> rewrite_addrs_in_graphs would early-return WITHOUT calling
+# cuGraphExecKernelNodeSetParams for the CA nodes. The pre-CRIU-instantiated
+# cuGraphExec then replays stale against the post-restore context and
+# intermittently HANGS (1-stage signal barrier) or the worker silently dies
+# (2-stage). ckpt-wake never hit this: its addr_map is non-empty -> SetParams
+# fires -> the exec is re-committed "for free". A/B (forced reuse, both failers):
+# 5/12 failures OFF -> 0/12 ON (p ~= 0.0009).
+#
+# These helpers DELIBERATELY DUPLICATE the struct handling of
+# _patch_node/_patch_memcpy_node (instead of adding a `force` flag) so the vetted
+# rewrite path used on the WORKING ckpt-wake (addr_map!={}) stays byte-for-byte
+# identical -- all risk is isolated to the disk-wake no-op branch.
+# ---------------------------------------------------------------------------
+def _recommit_ca_kernel_node(cu, exec_handle, node) -> int:
+    """Force the driver to re-accept a CA all-reduce kernel node's params with
+    IDENTICAL current values (topology + exec). Mirrors _patch_node's struct
+    handling but rewrites nothing. Returns 1 iff this was a CA kernel node and it
+    was recommitted, else 0."""
+    t = ctypes.c_int(-1)
+    if cu.cuGraphNodeGetType(node, ctypes.byref(t)) != 0:
+        return 0
+    if t.value != _CU_NODE_TYPE_KERNEL:
+        return 0
+    params = _KernelNodeParams()
+    if cu.cuGraphKernelNodeGetParams_v2(node, ctypes.byref(params)) != 0:
+        return 0
+    name = _func_name(cu, params.func)
+    if "cross_device_reduce" not in name:
+        return 0
+    kp = params.kernelParams
+    if not kp:
+        return 0
+    sg_addr = kp[1]
+    self_addr = kp[2]
+    if not sg_addr or not self_addr:
+        return 0
+    # Re-pack sg (8 ptrs) + self_sg (1 ptr) into fresh backing buffers holding the
+    # SAME current values; _dp (kp[0]) / result,rank,size (kp[3..5]) pass through
+    # by their existing arg-storage pointers (unchanged, exactly as _patch_node
+    # does when new_dp is None).
+    sg = (ctypes.c_uint64 * 8).from_address(sg_addr)
+    self_sg = (ctypes.c_uint64 * 1).from_address(self_addr)
+    new_sg_buf = (ctypes.c_uint64 * 8)(*[int(sg[i]) for i in range(8)])
+    new_self_buf = (ctypes.c_uint64 * 1)(int(self_sg[0]))
+    new_kp = (ctypes.c_void_p * 6)(
+        kp[0], ctypes.cast(new_sg_buf, ctypes.c_void_p),
+        ctypes.cast(new_self_buf, ctypes.c_void_p), kp[3], kp[4], kp[5])
+    params.kernelParams = ctypes.cast(new_kp, ctypes.POINTER(ctypes.c_void_p))
+    _ck("cuGraphKernelNodeSetParams_v2(recommit)",
+        cu.cuGraphKernelNodeSetParams_v2(node, ctypes.byref(params)))
+    if exec_handle:
+        _ck("cuGraphExecKernelNodeSetParams_v2(recommit)",
+            cu.cuGraphExecKernelNodeSetParams_v2(exec_handle, node,
+                                                 ctypes.byref(params)))
+    # keep new_sg_buf/new_self_buf/new_kp alive until the calls return
+    return 1
+
+
+def _recommit_ca_memcpy_node(cu, exec_handle, node, ctx, ca_buf_set) -> int:
+    """Recommit a memcpy node whose src/dst device ptr is a CURRENT CA buffer_ptr
+    (the copy-path scratch buffer) with identical params. ca_buf_set: set of int
+    VAs from ca.buffer_ptrs. Returns 1 iff recommitted, else 0."""
+    if not ca_buf_set:
+        return 0
+    t = ctypes.c_int(-1)
+    if cu.cuGraphNodeGetType(node, ctypes.byref(t)) != 0:
+        return 0
+    if t.value != _CU_NODE_TYPE_MEMCPY:
+        return 0
+    p = _Memcpy3D()
+    if cu.cuGraphMemcpyNodeGetParams(node, ctypes.byref(p)) != 0:
+        return 0
+    if int(p.srcDevice) not in ca_buf_set and int(p.dstDevice) not in ca_buf_set:
+        return 0
+    _ck("cuGraphMemcpyNodeSetParams(recommit)",
+        cu.cuGraphMemcpyNodeSetParams(node, ctypes.byref(p)))
+    if exec_handle:
+        _ck("cuGraphExecMemcpyNodeSetParams(recommit)",
+            cu.cuGraphExecMemcpyNodeSetParams(exec_handle, node, ctypes.byref(p), ctx))
+    return 1
+
+
+def _force_recommit_ca_nodes(worker, out) -> dict:
+    """Force-recommit body: walk every captured graph exec and re-commit the CA
+    kernel nodes (+ CA-buffer memcpy nodes) with their CURRENT values. Fills
+    recommit counters into `out`. Root cause / A-B evidence: see the comment block
+    above. Only call site: the addr_map=={} branch of rewrite_addrs_in_graphs."""
+    out["forced_recommit"] = True
+    try:
+        cu = _cu()
+        ctx = ctypes.c_void_p()
+        cu.cuCtxGetCurrent(ctypes.byref(ctx))
+        ca = _find_ca(worker)
+        ca_buf_set = set(int(b) for b in (getattr(ca, "buffer_ptrs", []) or [])) if ca else set()
+        pairs, gdiag = _find_captured_graphs(worker)
+        gdiag.pop("_manager_handles", None)
+        out["graph_discovery"] = gdiag
+        out["n_graphs"] = len(pairs)
+        kn = mn = 0
+        for g, e in pairs:
+            for node in _graph_nodes(cu, g):
+                kn += _recommit_ca_kernel_node(cu, e, node)
+                mn += _recommit_ca_memcpy_node(cu, e, node, ctx, ca_buf_set)
+        out["kernel_nodes_recommitted"] = kn
+        out["memcpy_nodes_recommitted"] = mn
+        out["ok"] = True
+        log.info("FORCE_RECOMMIT: %d graphs; recommitted kernel=%d memcpy=%d "
+                 "(identical values, addr_map empty)", len(pairs), kn, mn)
+    except Exception as ex:  # noqa: BLE001
+        out["ok"] = False
+        out["error"] = f"{type(ex).__name__}: {ex}"
+        log.warning("force_recommit failed: %s", out["error"])
+    return out
+
+
+def rewrite_addrs_in_graphs(worker, addr_map) -> dict:
+    """Rewrite every baked old->new address across all captured graph execs:
+    meta_ptrs in CA kernel nodes (sg/self_sg) and CA buffer_ptrs in memcpy nodes
+    (the copy path's scratch buffer). addr_map: {old_int: new_int}."""
+    out: dict = {"step": "rewrite_addrs"}
+    addr_map = {int(o): int(n) for o, n in addr_map.items() if int(o) != int(n)}
+    out["n_map"] = len(addr_map)
+    out["addr_map_sample"] = {hex(k): hex(v) for k, v in list(addr_map.items())[:6]}
+    if not addr_map:
+        # Disk-wake: CRIU reproduced every CA VA -> addr_map=={}. Re-committing
+        # the CA graph-exec node params (identical values) forces the driver to
+        # re-accept the pre-CRIU exec against the post-restore context; without it
+        # the stale exec intermittently hangs/dies on the first real forward
+        # (DEBUG_reuse_graph.md root cause, A/B 5/12 -> 0/12). The recommit is
+        # unconditional on this branch -- it is the only correct behaviour here,
+        # and a no-op early-return is NOT a safe alternative. Only this no-op
+        # branch is affected; it is reached only via rebind_after_reinit (ckpt/disk
+        # wake), never on sleep-wake. Cost: one cuGraphExecKernelNodeSetParams per
+        # CA node at wake (us-scale).
+        return _force_recommit_ca_nodes(worker, out)
+    try:
+        cu = _cu()
+        ctx = ctypes.c_void_p()
+        cu.cuCtxGetCurrent(ctypes.byref(ctx))
+        pairs, gdiag = _find_captured_graphs(worker)
+        mgr_handles = gdiag.pop("_manager_handles", frozenset())
+        out["graph_discovery"] = gdiag
+        out["n_graphs"] = len(pairs)
+        kn = kr = mn = mr = 0
+        mkn = mmn = 0   # manager-source split: proves the FULL graphs got patched
+        # Transactional readback counters, filled in-place by the patchers. Invariants
+        # on a healthy wake: k_topo_ok == kernel_slots_rewritten and
+        # m_topo_ok == memcpy_ptrs_rewritten, with the *_bad/err counters 0.
+        vfy = {"k_topo_ok": 0, "k_topo_bad": 0, "m_topo_ok": 0, "m_topo_bad": 0,
+               "topo_readback_err": 0}
+        for g, e in pairs:
+            is_mgr = g in mgr_handles
+            for node in _graph_nodes(cu, g):
+                r = _patch_node(cu, e, node, addr_map, vfy)
+                if r:
+                    kn += 1
+                    kr += r
+                    if is_mgr:
+                        mkn += 1
+                r2 = _patch_memcpy_node(cu, e, node, ctx, addr_map, vfy)
+                if r2:
+                    mn += 1
+                    mr += r2
+                    if is_mgr:
+                        mmn += 1
+        out["kernel_nodes_patched"] = kn
+        out["kernel_slots_rewritten"] = kr
+        out["memcpy_nodes_patched"] = mn
+        out["memcpy_ptrs_rewritten"] = mr
+        # Split by source so a regression to the piecewise-only enumerator is visible
+        # as a number rather than as an IMA three minutes later (resume18): on a
+        # ckpt-wake with FULL graphs present, manager_kernel_nodes_patched == 0 means
+        # the FULL graphs were not reached and the next decode replay will fault.
+        out["manager_kernel_nodes_patched"] = mkn
+        out["manager_memcpy_nodes_patched"] = mmn
+        # Primary confirm-not-lucky counters. topo_readback proves the commits took
+        # (per node, immune to addr_map key/value overlap); stale_ca_audit answers
+        # the semantic question against the CA object's CURRENT rank-ordered ptrs.
+        vfy["k_topo_expected"] = kr
+        vfy["m_topo_expected"] = mr
+        vfy["ok"] = (vfy["k_topo_bad"] == 0 and vfy["m_topo_bad"] == 0
+                     and vfy["topo_readback_err"] == 0
+                     and vfy["k_topo_ok"] == kr and vfy["m_topo_ok"] == mr)
+        out["topo_readback"] = vfy
+        try:
+            ca_for_audit = _find_ca(worker)
+        except Exception as ex:  # noqa: BLE001 - the audit is optional, the wake is not
+            ca_for_audit = None
+            log.warning("audit: _find_ca failed: %s", ex)
+        out["stale_ca_audit"] = _audit_stale_ca_addrs(cu, pairs, addr_map,
+                                                     ca_for_audit)
+        out["ok"] = True
+        log.info("rewrite_addrs_in_graphs: %d graphs (%d from manager); kernel %d "
+                 "nodes/%d slots (manager %d); memcpy %d nodes/%d ptrs (manager %d); "
+                 "topo_readback ok=%s(%d/%d ok, %d bad, %d err); audit bad=%s "
+                 "(pos_checked=%s ambiguous=%d legacy_hits=%d)",
+                 len(pairs), len(mgr_handles), kn, kr, mkn, mn, mr, mmn,
+                 vfy["ok"], vfy["k_topo_ok"] + vfy["m_topo_ok"], kr + mr,
+                 vfy["k_topo_bad"] + vfy["m_topo_bad"], vfy["topo_readback_err"],
+                 out["stale_ca_audit"].get("bad"),
+                 out["stale_ca_audit"].get("pos_checked"),
+                 (out["stale_ca_audit"].get("kernel_ambiguous", 0)
+                  + out["stale_ca_audit"].get("memcpy_ambiguous", 0)),
+                 out["stale_ca_audit"].get("legacy_hits"))
+    except Exception as ex:  # noqa: BLE001
+        out["ok"] = False
+        out["error"] = f"{type(ex).__name__}: {ex}"
+        log.warning("rewrite_addrs_in_graphs failed: %s", out["error"])
+    return out
+
+
+# ---------------------------------------------------------------------------
+# PATH 1: in-place rank_data peer-pointer refresh (keeps CA's registered fast
+# path). The captured CA kernels bake `_dp = rank_data_base + slot*sizeof(RankData)`
+# and read peer buffer pointers from RankData.ptrs[peer] at replay. rank_data's
+# VA is stable across destroy/reinit, but its CONTENTS go stale: destroy_nccl
+# unmaps the old peer IPC mappings and the new CA only re-registers slot 0. So
+# we refresh every registered slot in place: read its own local ptr (ptrs[rank],
+# stable VA, still valid), re-derive a FRESH IPC handle for it, exchange across
+# ranks, open the peer's fresh handle, and write the live peer ptr into
+# ptrs[peer]. In place (slot-aligned, no append) + fresh handles -> fixes the two
+# bugs that sank the original Part A (slot-misalignment + stale handles).
+# ---------------------------------------------------------------------------
+
+_CU_IPC_HANDLE_SIZE = 64
+_CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS = 1
+_RANKDATA_PTRS = 8           # struct RankData { void* ptrs[8]; } -> 8 i64 / slot
+
+
+class _CUipcMemHandle(ctypes.Structure):
+    _fields_ = [("reserved", ctypes.c_ubyte * _CU_IPC_HANDLE_SIZE)]
+
+
+def _cu_ipc(cu):
+    """Lazily add IPC + address-range bindings to the cached libcuda handle."""
+    if getattr(cu, "_semip_ipc_ready", False):
+        return cu
+    cu.cuMemGetAddressRange_v2.argtypes = [ctypes.POINTER(ctypes.c_uint64),
+                                           ctypes.POINTER(ctypes.c_size_t),
+                                           ctypes.c_uint64]
+    cu.cuIpcGetMemHandle.argtypes = [ctypes.POINTER(_CUipcMemHandle), ctypes.c_uint64]
+    cu.cuIpcOpenMemHandle_v2.argtypes = [ctypes.POINTER(ctypes.c_uint64),
+                                         _CUipcMemHandle, ctypes.c_uint]
+    cu._semip_ipc_ready = True
+    return cu
+
+
+def _collect_dp_slots(cu, base_rd, nbytes, worker=None):
+    """Walk captured graphs; return sorted distinct RankData slot indices that
+    the CA kernels' baked `_dp` (kernelParams[0]) reference, within rank_data.
+
+    Pass `worker` so the FULL graphs are included: a slot referenced only by a FULL
+    graph would otherwise never be refreshed by Path 1 (same root cause as the
+    unpatched-FULL-graph bug, resume18)."""
+    slots = set()
+    stride = _RANKDATA_PTRS * 8
+    lo, hi = base_rd, base_rd + nbytes
+    pairs, _diag = _find_captured_graphs(worker)
+    for g, _e in pairs:
+        for node in _graph_nodes(cu, g):
+            t = ctypes.c_int(-1)
+            if (cu.cuGraphNodeGetType(node, ctypes.byref(t)) != 0
+                    or t.value != _CU_NODE_TYPE_KERNEL):
+                continue
+            params = _KernelNodeParams()
+            if cu.cuGraphKernelNodeGetParams_v2(node, ctypes.byref(params)) != 0:
+                continue
+            if "cross_device_reduce" not in _func_name(cu, params.func):
+                continue
+            kp = params.kernelParams
+            if not kp or not kp[0]:
+                continue
+            dp = int((ctypes.c_uint64 * 1).from_address(kp[0])[0])
+            if lo <= dp < hi and (dp - base_rd) % stride == 0:
+                slots.add((dp - base_rd) // stride)
+    return sorted(slots)
+
+
+def refresh_rank_data_peers(worker) -> dict:
+    """Path 1: re-establish the stale peer pointers in the registered RankData
+    slots after reinit (rank_data VA stable; only its peer IPC contents are
+    stale). For each slot the kept graph references: read ptrs[rank] (own local
+    buffer, stable), derive a FRESH IPC handle, exchange cross-rank, open the
+    peer handle, write the live peer ptr into ptrs[peer] -- in place."""
+    out: dict = {"step": "refresh_rank_data_peers"}
+    try:
+        import torch
+        import torch.distributed as dist
+    except Exception as e:  # noqa: BLE001
+        return {"ok": False, "error": f"import: {e}"}
+    ca = _find_ca(worker)
+    if ca is None or getattr(ca, "rank_data", None) is None:
+        out["skipped"] = "no ca/rank_data"
+        return out
+    rd = ca.rank_data
+    rank = int(ca.rank)
+    world_size = int(ca.world_size)
+    group = ca.group
+    base_rd = int(rd.data_ptr())
+    nbytes = rd.numel() * rd.element_size()
+    mask = (1 << 64) - 1
+    try:
+        cu = _cu_ipc(_cu())
+        torch.cuda.synchronize()
+        slots = _collect_dp_slots(cu, base_rd, nbytes, worker)
+        out["n_slots"] = len(slots)
+        if not slots:
+            out["skipped"] = "no CA _dp slots in rank_data range"
+            return out
+        n_words = (max(slots) + 1) * _RANKDATA_PTRS
+        view = rd.view(torch.int64)
+        words = view[:n_words].cpu().tolist()
+        # 1. FRESH (handle, offset) for OUR own buffer at each slot (dedupe / alloc)
+        my, hcache, n_own_fail = {}, {}, 0
+        out["base_rd"] = hex(base_rd)
+        out["words_head"] = [hex(int(w) & mask) for w in words[0:16]]
+        out["slots_head"] = list(slots[0:6])
+        sample = []
+        for idx, s in enumerate(slots):
+            own = int(words[s * _RANKDATA_PTRS + rank]) & mask
+            if own == 0:
+                if idx < 6:
+                    sample.append(f"slot{s}: own=0x0")
+                continue
+            b, sz = ctypes.c_uint64(0), ctypes.c_size_t(0)
+            rc1 = cu.cuMemGetAddressRange_v2(ctypes.byref(b), ctypes.byref(sz),
+                                             ctypes.c_uint64(own))
+            if rc1 != 0:
+                n_own_fail += 1
+                if idx < 6:
+                    sample.append(f"slot{s}: own={hex(own)} addrrange_rc={rc1}")
+                continue
+            own_base = int(b.value)
+            hb = hcache.get(own_base)
+            if hb is None:
+                h = _CUipcMemHandle()
+                rc2 = cu.cuIpcGetMemHandle(ctypes.byref(h), ctypes.c_uint64(own_base))
+                if rc2 != 0:
+                    n_own_fail += 1
+                    if idx < 6:
+                        sample.append(f"slot{s}: own={hex(own)} base={hex(own_base)} "
+                                      f"ipc_rc={rc2}")
+                    continue
+                hb = bytes(h.reserved)
+                hcache[own_base] = hb
+            if idx < 6:
+                sample.append(f"slot{s}: own={hex(own)} base={hex(own_base)} OK")
+            my[s] = (hb, own - own_base)
+        out["sample"] = sample
+        out["n_my"] = len(my)
+        out["n_own_fail"] = n_own_fail
+        # 2. exchange each rank's {slot: (handle, offset)} (mirror CA's broadcast)
+        ranks = sorted(dist.get_process_group_ranks(group=group))
+        gathered = [[None] for _ in range(world_size)]
+        gathered[rank] = [my]
+        for i, r in enumerate(ranks):
+            dist.broadcast_object_list(gathered[i], src=r, group=group, device="cpu")
+        # 3. open peers + write ptrs[peer] in place
+        opened, n_written, n_open_fail = {}, 0, 0
+        for s in slots:
+            for j in range(world_size):
+                if j == rank:
+                    continue
+                peer_map = gathered[j][0] or {}
+                ent = peer_map.get(s)
+                if not ent:
+                    continue
+                hb, offset = ent
+                pbase = opened.get(hb)
+                if pbase is None:
+                    h = _CUipcMemHandle()
+                    ctypes.memmove(h.reserved, hb, _CU_IPC_HANDLE_SIZE)
+                    pd = ctypes.c_uint64(0)
+                    if cu.cuIpcOpenMemHandle_v2(
+                            ctypes.byref(pd), h,
+                            _CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS) != 0:
+                        n_open_fail += 1
+                        continue
+                    pbase = int(pd.value)
+                    opened[hb] = pbase
+                words[s * _RANKDATA_PTRS + j] = pbase + offset
+                n_written += 1
+        # 4. write the refreshed slots back to device
+        view[:n_words].copy_(torch.tensor(words, dtype=torch.int64))
+        torch.cuda.synchronize()
+        out.update(n_written=n_written, n_opened=len(opened), n_open_fail=n_open_fail)
+        out["ok"] = (n_written > 0 and n_own_fail == 0 and n_open_fail == 0)
+        log.info("refresh_rank_data_peers: slots=%d my=%d own_fail=%d written=%d "
+                 "opened=%d open_fail=%d", len(slots), len(my), n_own_fail,
+                 n_written, len(opened), n_open_fail)
+    except Exception as e:  # noqa: BLE001
+        out["ok"] = False
+        out["error"] = f"{type(e).__name__}: {e}"
+        log.warning("refresh_rank_data_peers failed: %s", out["error"])
+    return out
+
+
+def refresh_copy_path_slots(worker) -> dict:
+    """Copy-path keep-graph fix (no IPC, no peer derivation). With force-copy, the
+    captured CA kernels reduce the ONE symmetric staging buffer (buffer_ptrs[rank]),
+    but the C++ still registers it per-call during capture, baking `_dp` into slots
+    6043..N. The new CA's register_buffer only refreshes slot-0 (the staging), so the
+    captured slots are stale. Since they ALL reference the same staging buffer, just
+    replicate slot-0's (refreshed) RankData into every used slot."""
+    out: dict = {"step": "refresh_copy_path_slots"}
+    try:
+        import torch
+    except Exception as e:  # noqa: BLE001
+        return {"ok": False, "error": f"import: {e}"}
+    ca = _find_ca(worker)
+    if ca is None or getattr(ca, "rank_data", None) is None:
+        out["skipped"] = "no ca/rank_data"
+        return out
+    rd = ca.rank_data
+    base_rd = int(rd.data_ptr())
+    nbytes = rd.numel() * rd.element_size()
+    mask = (1 << 64) - 1
+    try:
+        cu = _cu()
+        torch.cuda.synchronize()
+        slots = _collect_dp_slots(cu, base_rd, nbytes, worker)
+        out["n_slots"] = len(slots)
+        if not slots:
+            out["skipped"] = "no CA _dp slots"
+            return out
+        view = rd.view(torch.int64)
+        slot0 = view[0:_RANKDATA_PTRS].clone()      # the refreshed staging RankData
+        # E3 tail-zero (codex resume7, gated SEMIP_CA_REFRESH_FIRST_WORLD=1): slot0's
+        # uninitialized tail ptrs[world..7] is per-rank garbage that the loop below
+        # would replicate into every used slot (0->garbage vs cold-start ZERO). When
+        # gated, zero the clone's tail so each slot matches the cold-start RankData.
+        # Robust across repeated rebinds (explicit zero, not 'leave as-is').
+        if _ca_refresh_first_world_enabled():
+            w = int(getattr(ca, "world_size", 0) or 0)
+            if w <= 0:
+                w = len(getattr(ca, "buffer_ptrs", []) or []) or _RANKDATA_PTRS
+            w = max(0, min(w, _RANKDATA_PTRS))
+            if 0 < w < _RANKDATA_PTRS:
+                slot0[w:_RANKDATA_PTRS] = 0      # zero tail -> match cold-start RankData
+            out["refresh_first_world"] = w
+        out["slot0"] = [hex(int(x) & mask) for x in slot0.tolist()]
+        # sample a used slot BEFORE (to confirm it was stale / differs from slot0)
+        s_first = slots[0]
+        out["used_before"] = [hex(int(x) & mask)
+                              for x in view[s_first * _RANKDATA_PTRS:
+                                            s_first * _RANKDATA_PTRS + _RANKDATA_PTRS].tolist()]
+        for s in slots:
+            view[s * _RANKDATA_PTRS:(s + 1) * _RANKDATA_PTRS] = slot0
+        torch.cuda.synchronize()
+        out["n_refreshed"] = len(slots)
+        out["ok"] = True
+        log.info("refresh_copy_path_slots: replicated slot0=%s into %d slots "
+                 "(used_before=%s)", out["slot0"], len(slots), out["used_before"])
+    except Exception as e:  # noqa: BLE001
+        out["ok"] = False
+        out["error"] = f"{type(e).__name__}: {e}"
+        log.warning("refresh_copy_path_slots failed: %s", out["error"])
+    return out
+
+
+def _ca_pad_probe_enabled() -> bool:
+    """Diagnostic dump of the CA one-shot Signal-pad state after reinit (default
+    OFF). Enable with SEMIP_CA_PAD_PROBE=1. See probe_ca_signal_pads and the
+    reuse-graph flakiness investigation."""
+    return os.environ.get("SEMIP_CA_PAD_PROBE", "") == "1"
+
+
+def _ca_zero_signal_enabled() -> bool:
+    """Zero THIS rank's CA Signal header (meta_ptrs[rank], meta_size() bytes) after
+    reinit, before the warmup replay (default OFF; enable SEMIP_CA_ZERO_SIGNAL=1).
+
+    Candidate fix for the reuse one-shot-barrier deadlock/death: the CA one-shot
+    barrier flag is a per-block MONOTONIC device counter (`_flag`) that is read,
+    incremented, and waited on with EQUALITY (`while ld_volatile(slot) != flag`),
+    and it is NEVER reset. A fresh post-reinit Signal that is zero-initialized is
+    the correct start state (0 -> 1 uniformly across ranks). A fresh Signal holding
+    garbage that DIFFERS ACROSS RANKS makes each rank derive a different `flag` ->
+    the equality waits never converge (one-shot spin-deadlock) or a half-written
+    slot is read (illegal access / silent worker death). Zeroing is a harmless
+    no-op if the allocator already zeroed the buffer. Each rank zeros ONLY its own
+    local Signal, then a group barrier guarantees all ranks finish before ANY
+    captured graph replays."""
+    return os.environ.get("SEMIP_CA_ZERO_SIGNAL", "") == "1"
+
+
+def _ca_e3_dump_enabled() -> bool:
+    """E3 fault-localization dump (default OFF; enable SEMIP_CA_E3_DUMP=1).
+
+    Read-only classification, run inside probe_ca_signal_pads AFTER rewrite +
+    refresh and BEFORE the warmup replay, of the graph-baked pointers the pad
+    probe does NOT inspect: kp[3] (CA all-reduce result / output activation), the
+    copy-path memcpy's non-CA-buffer endpoint (input activation), and the RankData
+    tail ptrs[world..7]. The pad probe validated every Signal / sg / self_sg /
+    rank_data slot as correct on a run that still IMA'd, so the invalid pointer is
+    one of these. Classifies each unique pointer with cuMemGetAddressRange_v2 +
+    cuPointerGetAttribute to name whether the IMA is a moved/unmapped activation
+    VA, a peer-buffer mismatch, or the tail garbage. NEVER mutates; never raises.
+    Consensus: codex resume6 (agent_run_log/codex_reuse_resume6*)."""
+    return os.environ.get("SEMIP_CA_E3_DUMP", "") == "1"
+
+
+def _ca_refresh_first_world_enabled() -> bool:
+    """E3 tail-zero confirmation (default OFF; enable SEMIP_CA_REFRESH_FIRST_WORLD=1).
+
+    E3 proved every CA-internal pointer valid (result / memcpy activation endpoints
+    / peers all in-range, attr_rc=0). The SOLE rebind-introduced anomaly is that
+    refresh_copy_path_slots replicates slot0's uninitialized tail ptrs[world..7]
+    (per-rank garbage) into all used _dp slots, flipping the tail from the cold-start
+    ZERO to garbage. When this gate is set, the refresh copies only the real peer
+    words ptrs[0..world-1] and EXPLICITLY zeros the tail [world..8] to match the
+    cold-start RankData (explicit zero, not 'leave as-is', so repeated rebinds cannot
+    inherit a prior rebind's garbage tail). If this clears the ckpt-wake IMA the tail
+    was causal; if it persists, CA metadata is excluded and we move to E4 (pre/post
+    non-CA baked-pointer inventory). Consensus: codex resume7
+    (agent_run_log/codex_reuse_resume7*)."""
+    return os.environ.get("SEMIP_CA_REFRESH_FIRST_WORLD", "") == "1"
+
+
+def _ca_e4_inventory_enabled() -> bool:
+    """E4 pre/post baked-pointer inventory (default OFF; enable SEMIP_CA_E4_INVENTORY=1).
+
+    E3 + tail-zero conclusively excluded ALL CA-internal pointers (result / memcpy
+    endpoints / peers / tail) as the immediate IMA source, yet the ckpt-wake IMA
+    persists. E4 tests the surviving hypothesis: a NON-CA graph kernel bakes a static
+    activation/output VA that reinit (checkpoint_cuda + reinit_nccl) reallocates, and
+    NOTHING rebinds it (the rebind touches only CA meta/buffer/rank_data). Sleep-wake
+    replays the same baked VAs and never IMAs -> the delta is exactly what reinit does
+    to non-CA baked pointers. This snapshots EVERY graph-baked size==8 device pointer
+    pre-freeze (cold capture, known-good) via cuFuncGetParamInfo reflection, then
+    post-reinit re-reads each at the same (graph,node,arg) and buckets it: a non-CA arg
+    that was valid pre and is now unmapped (pre_valid_post_invalid) or now maps to a
+    different allocation (value_same_range_changed) is the stale baked VA we are hunting.
+    Read-only; never mutates a graph. Consensus: codex resume8
+    (agent_run_log/codex_reuse_resume8*)."""
+    return os.environ.get("SEMIP_CA_E4_INVENTORY", "") == "1"
+
+
+def _ca_e5_reinstantiate_enabled() -> bool:
+    """E5a re-instantiate-vs-preserved exec discriminator (default OFF; enable
+    SEMIP_CA_E5_REINSTANTIATE=1).
+
+    E4 proved EVERY baked pointer arg valid post-reinit (0 stale/dangling), topology
+    stable (node_mismatch=0), CA structures valid (E3) -- yet the ckpt-wake reuse
+    replay still IMAs. E1 proved a FRESH full recapture on the same path replays
+    clean. So the fresh-vs-preserved delta is NOT a pointer value / topology / CA: it
+    is something the PRESERVED, previously-INSTANTIATED cudaGraphExec_t carries that a
+    fresh capture+instantiate regenerates and that a host-side param inventory cannot
+    see -- H_exec: stale instantiated-exec device-side launch/scheduling/dependency
+    state (incl. stream/event waits captured against pre-checkpoint objects reinit
+    replaced) that survives checkpoint_cuda(cuCheckpointProcessLock) but is invalidated
+    by the reinit_nccl frees/reallocs.
+
+    When set, rebind_after_reinit (after the normal CA rewrite/refresh -- so the kept
+    cudaGraph_t's CA nodes are ALREADY topology-patched, since ckpt-wake addr_map is
+    non-empty) calls cuGraphInstantiateWithFlags on each kept cudaGraph_t to build a
+    FRESH exec, then installs a torch.cuda.CUDAGraph.replay monkeypatch that launches
+    the FRESH exec (cuGraphLaunch on the current stream) in place of the preserved one.
+    If the IMA vanishes -> H_exec confirmed and re-instantiate (NOT re-capture -> no P2
+    pool balloon) is the fix; if it persists -> H_exec dead -> E5b full-node scalar
+    differential. Consensus: codex resume9/9b (agent_run_log/codex_reuse_resume9*)."""
+    return os.environ.get("SEMIP_CA_E5_REINSTANTIATE", "") == "1"
+
+
+def _e8_node_inventory_enabled() -> bool:
+    """E8 node-class inventory (default OFF; enable SEMIP_E8_NODE_INV=1).
+
+    E7 pinned the fault to a FRESH lazy re-instantiate + FULL-graph replay of a
+    preserved-but-rebound cudaGraph_t (H_topology): 66 FULL replays, all
+    preserved_exec=False, 0 piecewise, synchronous IMA on run_fullgraph ->
+    self.graphs[desc].replay() under CUDA_LAUNCH_BLOCKING=1. E4 already proved every
+    KERNEL-node arg + MEMCPY endpoint valid post-reinit. So the stale VA lives in a
+    node class E4 never inventoried. When set, rebind_after_reinit walks every
+    captured FULL/PIECEWISE graph and histograms node types (cuGraphNodeGetType),
+    then classifies the baked target of the classes E4 skipped -- MEMSET.dst,
+    MEM_FREE.dptr (single device VAs -> _e4_classify vs the live map), COUNTS
+    MEM_ALLOC nodes (graph-owned cudaMallocAsync mempool; presence alone is decisive
+    -- instantiate re-reserves VA), and recurses one level into CHILD_GRAPH nodes.
+    Paired with the run_fullgraph desc-marker (install_reuse_diag_counters) this names
+    both the faulting descriptor and the node class carrying the stale pointer.
+    Consensus: codex resume12 (agent_run_log/codex_reuse_resume12*)."""
+    return os.environ.get("SEMIP_E8_NODE_INV", "") == "1"
+
+
+def _e9_h4_enabled() -> bool:
+    """E9 H4 discriminator (default OFF; enable SEMIP_E9_H4=1).
+
+    E8 was a DECISIVE NEGATIVE: across all 3315 full-graph objects the only node
+    types present are kernel/memcpy/memset, and every baked pointer of every class
+    validates as mapped + in-range post-reinit. So there is NO enumerable node
+    carrying an unmapped stale VA -- option (b) targeted-node-repair has no target.
+    Two mechanisms survive E8, both invisible to a graph-node inventory (codex
+    resume13 ranks H4 > H1):
+      (H4) level-2 GPU-resident indirection -- a baked pointer is valid, but its
+           CONTENTS (block_table / slot_mapping / seq_lens -> paged-KV index) land
+           OOB on the REAL decode inputs (fits warmup-OK / first-real-decode-fault).
+      (H1) decode-only CA all-reduce peer-buffer read via IPC.
+    When set, the run_fullgraph diag hook, immediately BEFORE the replay of the
+    smallest decode desc (nt=1,nr=1,utc=1) -- the E7/E8 faulting descriptor --
+    reads the eager-written index tensors off the live GPUModelRunner
+    (input_buffers.seq_lens, block_tables.input_block_tables / .slot_mappings /
+    .num_blocks) and bounds-checks them against the KV-cache capacity
+    (kv_cache_config.num_blocks x block_size). Read-only, crash-safe marker written
+    BEFORE the (possibly faulting) replay, wrapped in try/except -- never perturbs
+    the replay path. Also logs the low-level gid on every full replay (nearly free)
+    to settle whether the faulting graph succeeded in warmup (input-dependent, H4)
+    or faulted on first instantiate. Consensus: codex resume13 Q3
+    (agent_run_log/codex_reuse_resume13*)."""
+    return os.environ.get("SEMIP_E9_H4", "") == "1"
+
+
+def _e11_valdiff_enabled() -> bool:
+    """E11 preserved-vs-fresh baked-value diff (default OFF; enable SEMIP_E11_VALDIFF=1).
+
+    codex resume15 Q3 consensus. E4/E8's baked-pointer inventory read ONLY size==8
+    kernel args (the `sz != 8` filter at _e4_read_kernel_ptrs), so every by-value
+    struct arg -- prime suspect the 128-byte CUtensorMap/TMA descriptor, which bakes a
+    global-memory base address at capture time -- was SKIPPED. That voids the
+    "exhaustion" claim: the mapped+in-range verdict only ever covered 8-byte pointers.
+    E11 bypasses the mapping/aliasing blind spot entirely by diffing the preserved-
+    rebound decode graph's baked kernel-arg VALUES (ALL sizes, raw bytes) against a
+    KNOWN-GOOD in-process FRESH recapture of the same descriptor. Any arg where
+    preserved != fresh is a baked resource the rebind did not rewrite; that names the
+    channel (which arg of which kernel) and the targeted repair. Runs IN-PROCESS (VAs
+    are process-local) inside the collective reuse path so the fresh capture_model() is
+    collective across ranks. Read-only diff; the fresh recapture replaces the preserved
+    graphs as a side effect (a decode after E11 uses the fresh graphs -> no IMA). Run at
+    reduced gpu_memory_utilization (E1v5: fresh recapture-FULL is zero-IMA + fits at
+    gmu=0.35; at 0.9 it OOMs -- P2). Consensus: codex resume15
+    (agent_run_log/codex_reuse_resume15*)."""
+    return os.environ.get("SEMIP_E11_VALDIFF", "") == "1"
+
+
+def probe_ca_signal_pads(worker, do_zero: bool = False) -> dict:
+    """Env-gated CA one-shot Signal-pad diagnostic (+ optional local zero).
+
+    Runs inside rebind_after_reinit AFTER rewrite + refresh_copy_path_slots and
+    BEFORE the warmup replay (worker collective_rpc; no CA collective in flight,
+    so a local memset is safe). Measures whether the fresh post-reinit LOCAL Signal
+    (meta_ptrs[rank], first meta_size() bytes) is zero-initialized, validates that
+    the graph-baked sg/self_sg pointers still match the current CA, checks that the
+    refreshed rank_data _dp slots equal slot-0, and (if do_zero) cudaMemsets this
+    rank's Signal to 0 then group-barriers so every rank starts the reused one-shot
+    barrier from _flag=0. Entirely best-effort; never raises into the caller."""
+    out: dict = {"step": "probe_ca_signal_pads", "do_zero": bool(do_zero)}
+    try:
+        import torch
+        from vllm import _custom_ops as ops
+        from vllm.distributed import parallel_state as ps
+    except Exception as e:  # noqa: BLE001
+        return {"step": "probe_ca_signal_pads", "ok": False,
+                "error": f"import: {e}"}
+    try:
+        ca = _find_ca(worker)
+        if ca is None:
+            out["skipped"] = "no ca"
+            return out
+        rank = int(getattr(ca, "rank", -1))
+        meta_ptrs = [int(x) for x in (getattr(ca, "meta_ptrs", []) or [])]
+        world = len(meta_ptrs)
+        out["rank"] = rank
+        out["world"] = world
+        if rank < 0 or rank >= world:
+            out["skipped"] = f"bad rank {rank} / {world} meta_ptrs"
+            return out
+        local = meta_ptrs[rank]
+        out["local_meta_ptr"] = hex(local)
+        try:
+            meta_size = int(ops.meta_size())
+        except Exception as e:  # noqa: BLE001
+            out["meta_size_err"] = f"{type(e).__name__}: {e}"
+            meta_size = 0
+        out["meta_size"] = meta_size
+        cu = _cu()
+
+        # --- dump: nonzero-u32 count over the Signal header (layout-agnostic and
+        # decisive). Heads at the standard Signal layout (kMaxBlocks=36,
+        # kMaxRanks=16): start@word0, end@word576, _flag@word1152 -- best-effort
+        # color only; a version with different maxima shifts these but not the
+        # total nonzero count. ---
+        def _dump(ptr, n):
+            if n <= 0:
+                return None
+            nb = (n // 4) * 4
+            host = (ctypes.c_uint32 * (nb // 4))()
+            code = cu.cuMemcpyDtoH_v2(ctypes.cast(host, ctypes.c_void_p),
+                                      ctypes.c_uint64(ptr), ctypes.c_size_t(nb))
+            if code != 0:
+                return {"err": f"cuMemcpyDtoH_v2 CUresult={code}"}
+            words = [int(host[i]) for i in range(nb // 4)]
+            nz = [(i, w) for i, w in enumerate(words) if w != 0]
+
+            def _head(word_off, k):
+                if word_off >= len(words):
+                    return None
+                return [hex(words[j])
+                        for j in range(word_off, min(word_off + k, len(words)))]
+
+            return {"n_u32": len(words), "nonzero_u32": len(nz),
+                    "first_nonzero": [(i, hex(w)) for i, w in nz[:16]],
+                    "start0_head": _head(0, max(world, 1)),
+                    "end0_head": _head(576, max(world, 1)),
+                    "flag_head": _head(1152, 8)}
+
+        out["pre"] = _dump(local, meta_size)
+
+        # --- graph-baked signal-pointer validation: for each cross_device_reduce
+        # node assert self_sg == meta_ptrs[rank] and every nonzero sg[i] is a
+        # current meta_ptr. Closes the "over-attribute failures to dirty flags"
+        # hole before we act on the pad dump. ---
+        meta_set = set(meta_ptrs)
+        n_nodes = n_self_ok = n_self_bad = n_sg_bad = 0
+        bad_samples: list = []
+        try:
+            pairs, _gd = _find_captured_graphs(worker)
+            for g, _e in pairs:
+                for node in _graph_nodes(cu, g):
+                    t = ctypes.c_int(-1)
+                    if cu.cuGraphNodeGetType(node, ctypes.byref(t)) != 0:
+                        continue
+                    if t.value != _CU_NODE_TYPE_KERNEL:
+                        continue
+                    params = _KernelNodeParams()
+                    if cu.cuGraphKernelNodeGetParams_v2(
+                            node, ctypes.byref(params)) != 0:
+                        continue
+                    if "cross_device_reduce" not in _func_name(cu, params.func):
+                        continue
+                    kp = params.kernelParams
+                    if not kp or not kp[1] or not kp[2]:
+                        continue
+                    n_nodes += 1
+                    sg = (ctypes.c_uint64 * 8).from_address(kp[1])
+                    self_sg = (ctypes.c_uint64 * 1).from_address(kp[2])
+                    sv = int(self_sg[0])
+                    if sv == local:
+                        n_self_ok += 1
+                    else:
+                        n_self_bad += 1
+                        if len(bad_samples) < 4:
+                            bad_samples.append({"self_sg": hex(sv),
+                                                "expected": hex(local)})
+                    for i in range(8):
+                        v = int(sg[i])
+                        if v and v not in meta_set:
+                            n_sg_bad += 1
+                            break
+            out["n_ca_nodes"] = n_nodes
+            out["n_self_ok"] = n_self_ok
+            out["n_self_mismatch"] = n_self_bad
+            out["n_sg_mismatch"] = n_sg_bad
+            out["graph_signal_ptr_ok"] = (n_self_bad == 0 and n_sg_bad == 0)
+            if bad_samples:
+                out["self_bad_samples"] = bad_samples
+        except Exception as e:  # noqa: BLE001
+            out["ptr_validate_err"] = f"{type(e).__name__}: {e}"
+
+        # --- rank_data slot-equality: used _dp slots must equal slot-0 after
+        # refresh_copy_path_slots (proves the copy actually took). ---
+        try:
+            rd = getattr(ca, "rank_data", None)
+            if rd is not None:
+                base_rd = int(rd.data_ptr())
+                nbytes = rd.numel() * rd.element_size()
+                slots = _collect_dp_slots(cu, base_rd, nbytes, worker)
+                view = rd.view(torch.int64)
+                slot0 = view[0:_RANKDATA_PTRS]
+                eq = True
+                for s in slots:
+                    seg = view[s * _RANKDATA_PTRS:(s + 1) * _RANKDATA_PTRS]
+                    if not bool(torch.equal(seg, slot0)):
+                        eq = False
+                        break
+                out["rankdata_slots_equal_slot0"] = eq
+                out["rankdata_n_slots"] = len(slots)
+        except Exception as e:  # noqa: BLE001
+            out["slot_eq_err"] = f"{type(e).__name__}: {e}"
+
+        # --- E3 (SEMIP_CA_E3_DUMP): read-only classification of the graph-baked
+        # pointers the pad probe does NOT inspect -- kp[3] (result / output
+        # activation), the copy-path memcpy's non-CA-buffer endpoint (input
+        # activation), and the RankData tail ptrs[world..7]. Names whether the IMA
+        # is a moved/unmapped activation VA (cuMemGetAddressRange_v2 fails), a peer
+        # mismatch, or the tail garbage. Dedupes pointer queries; treats an invalid
+        # query as DATA (never raises). Consensus: codex resume6. ---
+        if _ca_e3_dump_enabled():
+            e3: dict = {"sampled_kernels": [], "sampled_memcpys": []}
+            try:
+                cu2 = _cu_ipc(cu)
+                mask = (1 << 64) - 1
+                buf_ptrs = [int(x) & mask
+                            for x in (getattr(ca, "buffer_ptrs", []) or [])]
+                buf_set = set(buf_ptrs)
+                rd = getattr(ca, "rank_data", None)
+                rd_base = int(rd.data_ptr()) if rd is not None else 0
+                rd_view = rd.view(torch.int64) if rd is not None else None
+                sw = _RANKDATA_PTRS          # 8 int64 words / RankData slot
+                sb = sw * 8                  # 64 bytes / slot
+                # CA range table: allocation base -> label (base-membership).
+                ca_bases: dict = {}
+                for i, m in enumerate(meta_ptrs):
+                    ca_bases[int(m) & mask] = f"ca_meta[{i}]"
+                for i, b in enumerate(buf_ptrs):
+                    ca_bases[b] = f"ca_buffer[{i}]"
+                if rd_base:
+                    ca_bases[rd_base & mask] = "ca_rank_data"
+                pcache: dict = {}
+
+                def _classify(p):
+                    p = int(p) & mask
+                    if p in pcache:
+                        return pcache[p]
+                    base = ctypes.c_uint64(0)
+                    size = ctypes.c_size_t(0)
+                    rc = cu2.cuMemGetAddressRange_v2(
+                        ctypes.byref(base), ctypes.byref(size),
+                        ctypes.c_uint64(p))
+                    mt = ctypes.c_int(-1)
+                    rc2 = cu2.cuPointerGetAttribute(
+                        ctypes.byref(mt), 2, ctypes.c_uint64(p))  # 2=MEMORY_TYPE
+                    valid = (rc == 0)
+                    b = int(base.value) & mask
+                    d = {"ptr": hex(p), "valid": valid, "range_rc": rc,
+                         "base": (hex(b) if valid else None),
+                         "size": (int(size.value) if valid else None),
+                         "memtype": (mt.value if rc2 == 0 else None),
+                         "attr_rc": rc2,
+                         "region": ("INVALID" if not valid
+                                    else ca_bases.get(b, "other_device"))}
+                    pcache[p] = d
+                    return d
+
+                nk = nm = 0
+                n_result_invalid = n_result_other = 0
+                n_tail_nonzero = n_peer_mismatch = 0
+                n_memcpy_other_invalid = 0
+                CAP = 24
+                pairs2, _gd2 = _find_captured_graphs(worker)
+                for g, _e2 in pairs2:
+                    for node in _graph_nodes(cu2, g):
+                        t = ctypes.c_int(-1)
+                        if cu2.cuGraphNodeGetType(node, ctypes.byref(t)) != 0:
+                            continue
+                        if t.value == _CU_NODE_TYPE_KERNEL:
+                            params = _KernelNodeParams()
+                            if cu2.cuGraphKernelNodeGetParams_v2(
+                                    node, ctypes.byref(params)) != 0:
+                                continue
+                            if ("cross_device_reduce"
+                                    not in _func_name(cu2, params.func)):
+                                continue
+                            kp = params.kernelParams
+                            if not kp or not kp[0] or not kp[3]:
+                                continue
+                            nk += 1
+                            dp = int((ctypes.c_uint64 * 1).from_address(kp[0])[0])
+                            res = int((ctypes.c_uint64 * 1).from_address(kp[3])[0])
+                            rk = (int((ctypes.c_int * 1).from_address(kp[4])[0])
+                                  if kp[4] else None)
+                            sz = (int((ctypes.c_int * 1).from_address(kp[5])[0])
+                                  if kp[5] else None)
+                            slot = (((dp - rd_base) // sb)
+                                    if (rd_base and dp >= rd_base
+                                        and (dp - rd_base) % sb == 0) else -1)
+                            tail_hex = None
+                            peers_ok = None
+                            if (rd_view is not None and 0 <= slot
+                                    and (slot + 1) * sw <= rd_view.numel()):
+                                seg = [int(x) & mask for x in
+                                       rd_view[slot * sw:
+                                               (slot + 1) * sw].tolist()]
+                                tail = seg[world:sw]
+                                tail_hex = [hex(v) for v in tail]
+                                if any(v != 0 for v in tail):
+                                    n_tail_nonzero += 1
+                                peers_ok = all(v in buf_set for v in seg[0:world])
+                                if not peers_ok:
+                                    n_peer_mismatch += 1
+                            rcls = _classify(res)
+                            if rcls["region"] == "INVALID":
+                                n_result_invalid += 1
+                            elif rcls["region"] == "other_device":
+                                n_result_other += 1
+                            if len(e3["sampled_kernels"]) < CAP:
+                                e3["sampled_kernels"].append(
+                                    {"dp": hex(dp), "slot": slot,
+                                     "kp4_rank": rk, "kp5_size": sz,
+                                     "tail": tail_hex, "peers_ok": peers_ok,
+                                     "result": rcls})
+                        elif t.value == _CU_NODE_TYPE_MEMCPY:
+                            p = _Memcpy3D()
+                            if cu2.cuGraphMemcpyNodeGetParams(
+                                    node, ctypes.byref(p)) != 0:
+                                continue
+                            src = int(p.srcDevice) & mask
+                            dst = int(p.dstDevice) & mask
+                            if src not in buf_set and dst not in buf_set:
+                                continue
+                            nm += 1
+                            in_src = src in buf_set
+                            ocls = _classify(dst if in_src else src)
+                            if ocls["region"] == "INVALID":
+                                n_memcpy_other_invalid += 1
+                            if len(e3["sampled_memcpys"]) < CAP:
+                                e3["sampled_memcpys"].append(
+                                    {"src": hex(src), "dst": hex(dst),
+                                     "buf_endpoint": ("src" if in_src else "dst"),
+                                     "other": ocls})
+                n_attr_invalid = sum(1 for d in pcache.values()
+                                     if d["attr_rc"] != 0)
+                n_outside = sum(1 for d in pcache.values()
+                                if d["region"] == "other_device")
+                e3["counters"] = {
+                    "n_ca_kernels": nk, "n_ca_memcpys": nm,
+                    "n_result_invalid": n_result_invalid,
+                    "n_result_other_device": n_result_other,
+                    "n_memcpy_other_invalid": n_memcpy_other_invalid,
+                    "n_tail_nonzero": n_tail_nonzero,
+                    "n_rankdata_peer_mismatch": n_peer_mismatch,
+                    "n_attr_invalid": n_attr_invalid,
+                    "n_outside_ca_ranges": n_outside,
+                    "n_unique_ptrs": len(pcache)}
+                out["e3"] = e3
+                log.info(
+                    "CA_E3 rank=%s kernels=%s memcpys=%s result_invalid=%s "
+                    "result_other=%s memcpy_other_invalid=%s tail_nonzero=%s "
+                    "peer_mismatch=%s attr_invalid=%s outside_ca=%s uniq=%s | "
+                    "sample_result=%s sample_memcpy_other=%s",
+                    rank, nk, nm, n_result_invalid, n_result_other,
+                    n_memcpy_other_invalid, n_tail_nonzero, n_peer_mismatch,
+                    n_attr_invalid, n_outside, len(pcache),
+                    (e3["sampled_kernels"][0]["result"]
+                     if e3["sampled_kernels"] else None),
+                    (e3["sampled_memcpys"][0]["other"]
+                     if e3["sampled_memcpys"] else None))
+            except Exception as _e3e:  # noqa: BLE001
+                out["e3_err"] = f"{type(_e3e).__name__}: {_e3e}"
+                log.warning("CA_E3 dump failed: %s", out["e3_err"])
+
+        # --- candidate fix: zero THIS rank's local Signal, sync, group-barrier ---
+        if do_zero and meta_size > 0:
+            code = cu.cuMemsetD8_v2(ctypes.c_uint64(local), ctypes.c_ubyte(0),
+                                    ctypes.c_size_t(meta_size))
+            out["zero_memset_code"] = code
+            torch.cuda.synchronize()
+            barr = "none"
+            try:
+                tpg = getattr(ps, "_TP", None)
+                cpu_grp = getattr(tpg, "cpu_group", None) if tpg else None
+                if cpu_grp is not None:
+                    torch.distributed.barrier(group=cpu_grp)
+                    barr = "cpu_group"
+                elif tpg is not None and hasattr(tpg, "barrier"):
+                    tpg.barrier()
+                    barr = "tp.barrier"
+            except Exception as e:  # noqa: BLE001
+                barr = f"err:{type(e).__name__}:{e}"
+            out["zero_barrier"] = barr
+            out["post"] = _dump(local, meta_size)
+
+        log.info("CA_PAD_PROBE rank=%s meta_size=%s pre_nonzero_u32=%s "
+                 "graph_ptr_ok=%s self_mismatch=%s sg_mismatch=%s "
+                 "slots_eq_slot0=%s do_zero=%s post_nonzero_u32=%s barrier=%s",
+                 rank, meta_size, (out.get("pre") or {}).get("nonzero_u32"),
+                 out.get("graph_signal_ptr_ok"), out.get("n_self_mismatch"),
+                 out.get("n_sg_mismatch"), out.get("rankdata_slots_equal_slot0"),
+                 do_zero, (out.get("post") or {}).get("nonzero_u32"),
+                 out.get("zero_barrier"))
+        out["ok"] = True
+    except Exception as e:  # noqa: BLE001
+        out["ok"] = False
+        out["error"] = f"{type(e).__name__}: {e}"
+        log.warning("probe_ca_signal_pads failed: %s", out["error"])
+    return out
+
+
+# ---------------------------------------------------------------------------
+# E4: pre/post baked-pointer inventory (codex resume8 consensus). See
+# _ca_e4_inventory_enabled for the hypothesis. Additive, env-gated, read-only.
+# ---------------------------------------------------------------------------
+# CU_LAUNCH_PARAM sentinels for the `extra` packed-arg convention (cuLaunchKernel).
+_CU_LAUNCH_PARAM_END = 0
+_CU_LAUNCH_PARAM_BUFFER_POINTER = 1
+_CU_LAUNCH_PARAM_BUFFER_SIZE = 2
+
+_E4_PARAM_LAYOUT_CACHE: dict = {}  # int(CUfunction) -> [(offset, size), ...]
+
+
+def _func_param_layout(cu, func):
+    """[(offset, size), ...] for CUfunction `func` via cuFuncGetParamInfo, iterating
+    paramIndex until CUDA_ERROR_INVALID_VALUE (the terminator IS the count on driver
+    13000, which lacks cuFuncGetParamCount). Cached per func handle (layout is
+    per-function -> O(unique funcs), not O(nodes)). [] if func NULL / first query fails."""
+    key = int(func) if func else 0
+    if key == 0:
+        return []
+    cached = _E4_PARAM_LAYOUT_CACHE.get(key)
+    if cached is not None:
+        return cached
+    layout = []
+    off = ctypes.c_size_t(0)
+    sz = ctypes.c_size_t(0)
+    i = 0
+    while i < 512:  # hard cap; real kernels have far fewer params
+        rc = cu.cuFuncGetParamInfo(ctypes.c_void_p(key), ctypes.c_size_t(i),
+                                   ctypes.byref(off), ctypes.byref(sz))
+        if rc != 0:
+            break
+        layout.append((int(off.value), int(sz.value)))
+        i += 1
+    _E4_PARAM_LAYOUT_CACHE[key] = layout
+    return layout
+
+
+def _e4_read_kernel_ptrs(cu, params, layout):
+    """(list_of_(arg_idx, value), n_extra_unreadable) for each size==8 param of a
+    kernel node. Handles BOTH arg conventions:
+      - kernelParams != NULL: kernelParams[i] is the ADDRESS of arg-i storage -> deref.
+      - kernelParams == NULL, extra != NULL: args packed in one buffer at layout
+        offsets (CU_LAUNCH_PARAM_BUFFER_POINTER/SIZE). Parse extra; on failure or
+        offset+size > buffer_size, skip and flag n_extra_unreadable (codex point 4)."""
+    out = []
+    kp = params.kernelParams
+    if kp:
+        for i, (_off, sz) in enumerate(layout):
+            if sz != 8:
+                continue
+            addr = kp[i]
+            if not addr:
+                continue
+            try:
+                val = int((ctypes.c_uint64 * 1).from_address(int(addr))[0])
+            except Exception:  # noqa: BLE001
+                continue
+            out.append((i, val))
+        return out, 0
+    extra = params.extra
+    if not extra:
+        return out, 0
+    buf_base = 0
+    buf_size = None
+    try:
+        j = 0
+        while j < 64:
+            key = extra[j]
+            if not key or int(key) == _CU_LAUNCH_PARAM_END:
+                break
+            k = int(key)
+            nxt = extra[j + 1]
+            if k == _CU_LAUNCH_PARAM_BUFFER_POINTER:
+                buf_base = int(nxt) if nxt else 0  # entry IS the packed-arg buffer ptr
+            elif k == _CU_LAUNCH_PARAM_BUFFER_SIZE:
+                buf_size = (int((ctypes.c_size_t * 1).from_address(int(nxt))[0])
+                            if nxt else None)  # entry is &size_t
+            j += 2
+    except Exception:  # noqa: BLE001
+        return out, 1
+    if not buf_base:
+        return out, 1
+    n_unreadable = 0
+    for i, (off, sz) in enumerate(layout):
+        if sz != 8:
+            continue
+        if buf_size is not None and off + sz > buf_size:
+            n_unreadable = 1
+            continue
+        try:
+            val = int((ctypes.c_uint64 * 1).from_address(buf_base + off)[0])
+        except Exception:  # noqa: BLE001
+            n_unreadable = 1
+            continue
+        out.append((i, val))
+    return out, n_unreadable
+
+
+def _e4_walk(cu, worker=None):
+    """Walk every captured graph; return (records, counters). records: dicts
+    {gi, ni, kind, func, arg, val} for each size==8 kernel arg + each memcpy src/dst
+    that read as a nonzero value. NO classification here (pre/post classify against
+    their own live driver state). (gi, ni) are enumeration ordinals -- stable across
+    checkpoint/restore because the same process holds the same graph objects; func
+    is the guard against any residual (gi, ni) drift (-> node_mismatch).
+
+    Pass `worker`: without it this walks only the piecewise graphs, which is why
+    E4's original "pre_valid_post_invalid=0" was true and vacuous -- it inventoried
+    exactly the set the rebind had just patched and never saw a FULL graph."""
+    records = []
+    n_kernel_nodes = n_memcpy_nodes = 0
+    n_unreadable = n_extra_unreadable = n_no_layout = 0
+    fname_cache: dict = {}
+    pairs, _diag = _find_captured_graphs(worker)
+    for gi, (g, _e) in enumerate(pairs):
+        try:
+            nodes = _graph_nodes(cu, g)
+        except Exception:  # noqa: BLE001
+            continue
+        for ni, node in enumerate(nodes):
+            t = ctypes.c_int(-1)
+            if cu.cuGraphNodeGetType(node, ctypes.byref(t)) != 0:
+                continue
+            if t.value == _CU_NODE_TYPE_KERNEL:
+                params = _KernelNodeParams()
+                if cu.cuGraphKernelNodeGetParams_v2(
+                        node, ctypes.byref(params)) != 0:
+                    n_unreadable += 1
+                    continue
+                if not params.func:  # contextless kernel node (kern set, func NULL)
+                    n_unreadable += 1
+                    continue
+                fkey = int(params.func)
+                fn = fname_cache.get(fkey)
+                if fn is None:
+                    fn = _func_name(cu, params.func)
+                    fname_cache[fkey] = fn
+                layout = _func_param_layout(cu, params.func)
+                if not layout:
+                    n_no_layout += 1
+                    continue
+                n_kernel_nodes += 1
+                ptrs, ne = _e4_read_kernel_ptrs(cu, params, layout)
+                n_extra_unreadable += ne
+                for (ai, val) in ptrs:
+                    if val:
+                        records.append({"gi": gi, "ni": ni, "kind": "kernel",
+                                        "func": fn, "arg": ai, "val": val})
+            elif t.value == _CU_NODE_TYPE_MEMCPY:
+                p = _Memcpy3D()
+                if cu.cuGraphMemcpyNodeGetParams(node, ctypes.byref(p)) != 0:
+                    n_unreadable += 1
+                    continue
+                n_memcpy_nodes += 1
+                src = int(p.srcDevice)
+                dst = int(p.dstDevice)
+                if src:
+                    records.append({"gi": gi, "ni": ni, "kind": "memcpy",
+                                    "func": "<memcpy>", "arg": -1, "val": src})
+                if dst:
+                    records.append({"gi": gi, "ni": ni, "kind": "memcpy",
+                                    "func": "<memcpy>", "arg": -2, "val": dst})
+    counters = {"n_kernel_nodes": n_kernel_nodes, "n_memcpy_nodes": n_memcpy_nodes,
+                "n_unreadable": n_unreadable, "n_extra_unreadable": n_extra_unreadable,
+                "n_no_layout": n_no_layout, "n_records": len(records),
+                "n_unique_funcs": len(fname_cache)}
+    return records, counters
+
+
+def _e4_classify(cu, p, cache):
+    """Classify a device VA -> {valid, base, size, memtype}. cuMemGetAddressRange_v2
+    is primary truth (valid == mapped); cuPointerGetAttribute(MEMORY_TYPE) is a
+    secondary check. Cached by value."""
+    mask = (1 << 64) - 1
+    p = int(p) & mask
+    if p in cache:
+        return cache[p]
+    base = ctypes.c_uint64(0)
+    size = ctypes.c_size_t(0)
+    rc = cu.cuMemGetAddressRange_v2(ctypes.byref(base), ctypes.byref(size),
+                                    ctypes.c_uint64(p))
+    mt = ctypes.c_int(-1)
+    rc2 = cu.cuPointerGetAttribute(ctypes.byref(mt), 2, ctypes.c_uint64(p))
+    d = {"valid": (rc == 0),
+         "base": (int(base.value) & mask if rc == 0 else None),
+         "size": (int(size.value) if rc == 0 else None),
+         "memtype": (mt.value if rc2 == 0 else None),
+         "range_rc": rc, "attr_rc": rc2}
+    cache[p] = d
+    return d
+
+
+def _e4_torch_segments():
+    """Sorted [(base, end), ...] from torch.cuda.memory_snapshot(). LABEL set only
+    (a valid ptr outside these is 'outside_current_snapshot', not a fault -- non-torch
+    driver allocations exist). [] on any failure."""
+    try:
+        import torch
+        segs = []
+        for s in torch.cuda.memory_snapshot():
+            a = int(s.get("address", 0) or 0)
+            n = int(s.get("total_size", 0) or 0)
+            if a and n:
+                segs.append((a, a + n))
+        segs.sort()
+        return segs
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def _e4_ca_ranges(cu, ca):
+    """Sorted [(base, end), ...] for the NEW CA meta/buffer/rank_data allocations so
+    CA-owned pointers get a label instead of 'outside'. Best-effort."""
+    ranges = []
+    if ca is None:
+        return ranges
+    ptrs = [int(x) for x in (getattr(ca, "meta_ptrs", []) or [])]
+    ptrs += [int(x) for x in (getattr(ca, "buffer_ptrs", []) or [])]
+    rd = getattr(ca, "rank_data", None)
+    if rd is not None:
+        try:
+            ptrs.append(int(rd.data_ptr()))
+        except Exception:  # noqa: BLE001
+            pass
+    for p in ptrs:
+        base = ctypes.c_uint64(0)
+        size = ctypes.c_size_t(0)
+        if cu.cuMemGetAddressRange_v2(ctypes.byref(base), ctypes.byref(size),
+                                      ctypes.c_uint64(p)) == 0:
+            ranges.append((int(base.value), int(base.value) + int(size.value)))
+    ranges.sort()
+    return ranges
+
+
+def _e4_in_ranges(base, los, ranges):
+    """True if `base` falls within any labeled live range (torch segment or CA).
+    los is the pre-extracted sorted list of range starts for bisect."""
+    import bisect
+    if not ranges:
+        return False
+    i = bisect.bisect_right(los, base) - 1
+    return 0 <= i < len(ranges) and ranges[i][0] <= base < ranges[i][1]
+
+
+def e4_pre_inventory(worker) -> dict:
+    """E4 PRE hook (store_snapshot, cold capture, pre-freeze). Snapshot every
+    graph-baked size==8 device pointer while the kept graph is KNOWN-GOOD, keeping
+    only those classifying as VALID device pointers. Stores a compact tuple list on
+    the worker for the post-reinit reclassify. Read-only; never raises to the caller.
+    Consensus: codex resume8."""
+    out = {"step": "e4_pre_inventory"}
+    try:
+        import torch
+        torch.cuda.synchronize()  # surface any pending async error before the inventory
+        cu = _cu_ipc(_cu())
+        records, counters = _e4_walk(cu, worker)
+        cache: dict = {}
+        inv = []
+        n_valid = n_invalid = 0
+        for r in records:
+            c = _e4_classify(cu, r["val"], cache)
+            if not c["valid"]:
+                n_invalid += 1
+                continue
+            n_valid += 1
+            inv.append((r["gi"], r["ni"], r["kind"], r["func"], r["arg"],
+                        r["val"], c["base"], c["size"]))
+        setattr(worker, _E4_INV_ATTR, inv)
+        out["ok"] = True
+        out["counters"] = counters
+        out["n_pre_valid"] = n_valid
+        out["n_pre_invalid_skipped"] = n_invalid
+        out["n_unique_ptrs"] = len(cache)
+        log.info("CA_E4_PRE stored=%s valid=%s invalid_skipped=%s uniq_ptrs=%s "
+                 "kernels=%s memcpys=%s uniq_funcs=%s no_layout=%s unreadable=%s "
+                 "extra_unreadable=%s",
+                 len(inv), n_valid, n_invalid, len(cache),
+                 counters["n_kernel_nodes"], counters["n_memcpy_nodes"],
+                 counters["n_unique_funcs"], counters["n_no_layout"],
+                 counters["n_unreadable"], counters["n_extra_unreadable"])
+    except Exception as e:  # noqa: BLE001
+        out["ok"] = False
+        out["error"] = f"{type(e).__name__}: {e}"
+        log.warning("e4_pre_inventory failed: %s", out["error"])
+    return out
+
+
+def e4_post_inventory(worker) -> dict:
+    """E4 POST hook (rebind_after_reinit, post-reinit, after CA rewrite/refresh,
+    before warmup). Re-read each pre-snapshotted baked pointer at its (gi, ni, arg)
+    and bucket it. The rebind rewrites ONLY CA (cross_device_reduce) node params +
+    CA-buffer memcpy endpoints, so every OTHER baked pointer keeps its cold value; a
+    non-CA arg that was valid pre and is now unmapped (pre_valid_post_invalid) or now
+    maps to a different allocation (value_same_range_changed) is the stale baked VA
+    we are hunting. Read-only; never raises. Consensus: codex resume8."""
+    out = {"step": "e4_post_inventory"}
+    try:
+        import torch
+        inv = getattr(worker, _E4_INV_ATTR, None)
+        if not inv:
+            out["skipped"] = "no pre-inventory (e4_pre_inventory did not run?)"
+            log.warning("e4_post_inventory: %s", out["skipped"])
+            return out
+        torch.cuda.synchronize()
+        cu = _cu_ipc(_cu())
+        cur_records, cur_counters = _e4_walk(cu, worker)
+        cur = {}
+        for r in cur_records:
+            cur[(r["gi"], r["ni"], r["arg"])] = (r["func"], r["val"])
+        # Label set (secondary only): torch segments + new CA ranges, merged + sorted.
+        ca = _find_ca(worker)
+        label_ranges = _e4_torch_segments() + _e4_ca_ranges(cu, ca)
+        label_ranges.sort()
+        label_los = [r[0] for r in label_ranges]
+        cache: dict = {}
+        buckets = {k: 0 for k in (
+            "pre_valid_post_invalid", "value_same_range_changed", "value_changed",
+            "still_valid_same_range", "outside_current_snapshot", "ca_control",
+            "memcpy_pre_valid_post_invalid", "node_mismatch", "unreadable")}
+        hist: dict = {}     # bucket -> {func: count}
+        samples: dict = {}  # bucket -> [few dicts]
+        SAMP = 8
+        for (gi, ni, kind, func, arg, pre_val, pre_base, pre_size) in inv:
+            is_ca = ("cross_device_reduce" in func)
+            key = (gi, ni, arg)
+            if key not in cur:
+                b = "node_mismatch"
+            else:
+                cur_func, cur_val = cur[key]
+                if cur_func != func:
+                    b = "node_mismatch"
+                elif is_ca:
+                    b = "ca_control"
+                elif cur_val != pre_val:
+                    b = "value_changed"
+                else:
+                    c = _e4_classify(cu, cur_val, cache)
+                    if not c["valid"]:
+                        b = ("memcpy_pre_valid_post_invalid" if kind == "memcpy"
+                             else "pre_valid_post_invalid")
+                    elif c["base"] == pre_base and c["size"] == pre_size:
+                        b = ("still_valid_same_range"
+                             if _e4_in_ranges(pre_base, label_los, label_ranges)
+                             else "outside_current_snapshot")
+                    else:
+                        b = "value_same_range_changed"
+            buckets[b] += 1
+            hb = hist.setdefault(b, {})
+            hb[func] = hb.get(func, 0) + 1
+            sl = samples.setdefault(b, [])
+            if len(sl) < SAMP:
+                sl.append({"gi": gi, "ni": ni, "kind": kind, "func": func,
+                           "arg": arg, "pre_val": hex(pre_val),
+                           "pre_base": (hex(pre_base) if pre_base else None),
+                           "pre_size": pre_size})
+        out["ok"] = True
+        out["n_pre_entries"] = len(inv)
+        out["buckets"] = buckets
+        out["hist"] = {b: dict(sorted(h.items(), key=lambda kv: -kv[1])[:12])
+                       for b, h in hist.items()}
+        out["samples"] = samples
+        out["cur_counters"] = cur_counters
+        log.info("CA_E4_POST pre_entries=%s | pre_valid_post_invalid=%s "
+                 "value_same_range_changed=%s memcpy_pre_valid_post_invalid=%s "
+                 "outside_snapshot=%s node_mismatch=%s value_changed=%s "
+                 "still_valid=%s ca_control=%s unreadable=%s",
+                 len(inv), buckets["pre_valid_post_invalid"],
+                 buckets["value_same_range_changed"],
+                 buckets["memcpy_pre_valid_post_invalid"],
+                 buckets["outside_current_snapshot"], buckets["node_mismatch"],
+                 buckets["value_changed"], buckets["still_valid_same_range"],
+                 buckets["ca_control"], buckets["unreadable"])
+        # Detail the smoking-gun buckets: per-func histogram + samples.
+        for b in ("pre_valid_post_invalid", "value_same_range_changed",
+                  "memcpy_pre_valid_post_invalid"):
+            if buckets[b]:
+                log.info("CA_E4_POST bucket=%s funcs=%s samples=%s",
+                         b, out["hist"].get(b), out["samples"].get(b))
+    except Exception as e:  # noqa: BLE001
+        out["ok"] = False
+        out["error"] = f"{type(e).__name__}: {e}"
+        log.warning("e4_post_inventory failed: %s", out["error"])
+    return out
+
+
+# ---------------------------------------------------------------------------
+# E11 (SEMIP_E11_VALDIFF): preserved-vs-fresh baked-value diff (codex resume15 Q3).
+# Extends the E4 inventory beyond the size==8 filter -- reads EVERY kernel arg's raw
+# bytes (incl. 128-byte CUtensorMap/TMA descriptors) -- and diffs the preserved-rebound
+# graphs against an in-process FRESH recapture of the same descriptors. A KNOWN-GOOD
+# fresh capture is the comparand (not a mapping predicate), so it sidesteps the aliasing
+# blind spot that let E4/E8 pass a stale VA aliasing a re-reserved identical segment.
+# ---------------------------------------------------------------------------
+def _e11_read_all_args(cu, params, layout):
+    """(list_of_(arg_idx, offset, size, raw_bytes), n_unreadable) for EVERY param of a
+    kernel node -- E11 extends _e4_read_kernel_ptrs past the size==8 filter so by-value
+    struct args (the 128-byte CUtensorMap/TMA descriptor, and any other non-8 arg) are
+    captured as raw bytes. Same two arg conventions:
+      - kernelParams != NULL: kernelParams[i] is the ADDRESS of arg-i storage -> read
+        `size` bytes from it.
+      - kernelParams == NULL, extra != NULL: args packed in one buffer at layout
+        offsets (CU_LAUNCH_PARAM_BUFFER_POINTER/SIZE) -> read `size` bytes at off."""
+    out = []
+    n_unreadable = 0
+    kp = params.kernelParams
+    if kp:
+        for i, (off, sz) in enumerate(layout):
+            if sz <= 0 or sz > 4096:  # sanity bound; real kernel args are tiny
+                continue
+            addr = kp[i]
+            if not addr:
+                continue
+            try:
+                raw = bytes((ctypes.c_ubyte * sz).from_address(int(addr)))
+            except Exception:  # noqa: BLE001
+                n_unreadable += 1
+                continue
+            out.append((i, off, sz, raw))
+        return out, n_unreadable
+    extra = params.extra
+    if not extra:
+        return out, n_unreadable
+    buf_base = 0
+    buf_size = None
+    try:
+        j = 0
+        while j < 64:
+            key = extra[j]
+            if not key or int(key) == _CU_LAUNCH_PARAM_END:
+                break
+            k = int(key)
+            nxt = extra[j + 1]
+            if k == _CU_LAUNCH_PARAM_BUFFER_POINTER:
+                buf_base = int(nxt) if nxt else 0
+            elif k == _CU_LAUNCH_PARAM_BUFFER_SIZE:
+                buf_size = (int((ctypes.c_size_t * 1).from_address(int(nxt))[0])
+                            if nxt else None)
+            j += 2
+    except Exception:  # noqa: BLE001
+        return out, n_unreadable + 1
+    if not buf_base:
+        return out, n_unreadable + 1
+    for i, (off, sz) in enumerate(layout):
+        if sz <= 0 or sz > 4096:
+            continue
+        if buf_size is not None and off + sz > buf_size:
+            n_unreadable += 1
+            continue
+        try:
+            raw = bytes((ctypes.c_ubyte * sz).from_address(buf_base + off))
+        except Exception:  # noqa: BLE001
+            n_unreadable += 1
+            continue
+        out.append((i, off, sz, raw))
+    return out, n_unreadable
+
+
+def _e11_desc_by_handle(worker) -> dict:
+    """{raw cudaGraph_t handle -> (num_tokens, num_reqs, uniform_token_count)} from the
+    dense model runner's ModelCudaGraphManager (self.graphs keyed by
+    BatchExecutionDescriptor). Lets the walk tag the faulting decode graph (the smallest
+    desc, nt==nr==1) and its siblings. Empty if the runner has no such manager."""
+    desc_by_handle = {}
+    try:
+        mr = getattr(worker, "model_runner", None)
+        mgr = getattr(mr, "cudagraph_manager", None)
+        graphs = getattr(mgr, "graphs", None)
+        if isinstance(graphs, dict):
+            for desc, g in graphs.items():
+                try:
+                    h = int(g.raw_cuda_graph())
+                except Exception:  # noqa: BLE001
+                    continue
+                desc_by_handle[h] = (getattr(desc, "num_tokens", None),
+                                     getattr(desc, "num_reqs", None),
+                                     getattr(desc, "uniform_token_count", None))
+    except Exception:  # noqa: BLE001
+        pass
+    return desc_by_handle
+
+
+def _e11_walk_one(cu, handle, fname_cache) -> tuple:
+    """Walk one cudaGraph_t handle -> (sig_tuple, node_recs). sig = ordered
+    (node_type, func); node_recs carry the FULL baked kernel-arg inventory (ALL sizes,
+    raw bytes). Read-only. Returns (None, None) if node enumeration fails."""
+    try:
+        nodes = _graph_nodes(cu, handle)
+    except Exception:  # noqa: BLE001
+        return None, None
+    node_recs = []
+    sig = []
+    for ni, node in enumerate(nodes):
+        t = ctypes.c_int(-1)
+        if cu.cuGraphNodeGetType(node, ctypes.byref(t)) != 0:
+            continue
+        if t.value == _CU_NODE_TYPE_KERNEL:
+            params = _KernelNodeParams()
+            if cu.cuGraphKernelNodeGetParams_v2(
+                    node, ctypes.byref(params)) != 0:
+                continue
+            if not params.func:
+                continue
+            fkey = int(params.func)
+            fn = fname_cache.get(fkey)
+            if fn is None:
+                fn = _func_name(cu, params.func)
+                fname_cache[fkey] = fn
+            sig.append((0, fn))
+            layout = _func_param_layout(cu, params.func)
+            if not layout:
+                continue
+            args, _nu = _e11_read_all_args(cu, params, layout)
+            node_recs.append({"ni": ni, "kind": "kernel", "func": fn,
+                              "args": args})
+        elif t.value == _CU_NODE_TYPE_MEMCPY:
+            p = _Memcpy3D()
+            if cu.cuGraphMemcpyNodeGetParams(node, ctypes.byref(p)) != 0:
+                continue
+            sig.append((1, "<memcpy>"))
+            args = [(-1, 0, 8, int(p.srcDevice).to_bytes(8, "little")),
+                    (-2, 0, 8, int(p.dstDevice).to_bytes(8, "little"))]
+            node_recs.append({"ni": ni, "kind": "memcpy", "func": "<memcpy>",
+                              "args": args})
+        else:
+            sig.append((int(t.value), ""))
+    return tuple(sig), node_recs
+
+
+def _e11_walk(worker) -> list:
+    """E11: dump the FULL baked kernel-arg inventory (ALL sizes, raw bytes) of every
+    captured graph, tagged with the vLLM decode descriptor when known. Returns a list of
+    per-graph dicts:
+      {gi, handle, desc, sig, nodes: [{ni, kind, func, args: [(ai, off, sz, raw)]}]}
+
+    PRIMARY SOURCE = the dense runner's ModelCudaGraphManager (mr.cudagraph_manager.graphs,
+    desc->CUDAGraph). This is where the FAULTING FULL decode graph desc=(1,1,1) lives (the
+    E9 rfg hook replays self.graphs[desc]); it carries the desc natively; and crucially
+    capture_model() REPOPULATES it on the fresh side. The earlier version enumerated
+    _find_captured_graphs() (the CUDAGraphWrapper piecewise registry) instead -- but
+    _semip_cleargraph EMPTIES those wrapper entries and the manager-driven recapture does
+    NOT refill them, so the fresh dump came back EMPTY -> matched pairs=0 and the (1,1,1)
+    graph was never even walked (NO_FAULTING_DESC_MATCHED). We now walk the manager
+    directly. Fall back to the wrapper scan (desc=None, sig-matched) only if no manager
+    graphs are present (non-dense / piecewise-only models). Read-only."""
+    cu = _cu()
+    fname_cache: dict = {}
+    graphs_out = []
+    seen_handles = set()
+
+    # Primary: the ModelCudaGraphManager desc->CUDAGraph mapping.
+    mgr_pairs = []  # (handle, desc)
+    try:
+        mr = getattr(worker, "model_runner", None)
+        mgr = getattr(mr, "cudagraph_manager", None)
+        graphs = getattr(mgr, "graphs", None)
+        if isinstance(graphs, dict):
+            for desc, g in graphs.items():
+                try:
+                    h = int(g.raw_cuda_graph())
+                except Exception:  # noqa: BLE001
+                    continue
+                d = (getattr(desc, "num_tokens", None),
+                     getattr(desc, "num_reqs", None),
+                     getattr(desc, "uniform_token_count", None))
+                mgr_pairs.append((h, d))
+    except Exception:  # noqa: BLE001
+        pass
+    for gi, (h, d) in enumerate(mgr_pairs):
+        if not h or h in seen_handles:
+            continue
+        sig, node_recs = _e11_walk_one(cu, h, fname_cache)
+        if sig is None:
+            continue
+        seen_handles.add(h)
+        graphs_out.append({"gi": gi, "handle": h, "desc": d,
+                           "sig": sig, "nodes": node_recs})
+
+    # Fallback: wrapper/piecewise graphs (desc=None) only if the manager gave nothing.
+    if not graphs_out:
+        pairs, _diag = _find_captured_graphs()
+        for gi, (g, _e) in enumerate(pairs):
+            if not g or int(g) in seen_handles:
+                continue
+            sig, node_recs = _e11_walk_one(cu, int(g), fname_cache)
+            if sig is None:
+                continue
+            seen_handles.add(int(g))
+            graphs_out.append({"gi": 1000 + gi, "handle": int(g), "desc": None,
+                               "sig": sig, "nodes": node_recs})
+    return graphs_out
+
+
+def _e11_match_graphs(pres: list, fresh: list) -> list:
+    """Pair preserved graphs to fresh graphs: by decode desc first (strong -- pins the
+    faulting (1,1,1) preserved to fresh (1,1,1)), then by structural signature for the
+    rest. Returns [(pres_g, fresh_g, how), ...] for matched pairs only."""
+    from collections import deque
+    fresh_by_desc: dict = {}
+    fresh_by_sig: dict = {}
+    for fg in fresh:
+        if fg["desc"] is not None:
+            fresh_by_desc.setdefault(fg["desc"], deque()).append(fg)
+        fresh_by_sig.setdefault(fg["sig"], deque()).append(fg)
+    used = set()          # id() of fresh graphs already paired
+    matched_pres = set()  # id() of preserved graphs already paired
+    matches = []
+    # desc pass first so a desc match is never consumed by a sig match.
+    for pg in pres:
+        if pg["desc"] is None:
+            continue
+        q = fresh_by_desc.get(pg["desc"])
+        while q and id(q[0]) in used:
+            q.popleft()
+        if q:
+            fg = q.popleft()
+            used.add(id(fg))
+            matched_pres.add(id(pg))
+            matches.append((pg, fg, "desc"))
+    for pg in pres:
+        if id(pg) in matched_pres:
+            continue
+        q = fresh_by_sig.get(pg["sig"])
+        while q and id(q[0]) in used:
+            q.popleft()
+        if q:
+            fg = q.popleft()
+            used.add(id(fg))
+            matches.append((pg, fg, "sig"))
+    return matches
+
+
+def _e11_diff_pair(cu, cache, pg, fg) -> dict:
+    """Diff one matched (preserved, fresh) graph pair. Match nodes by ordered func-name
+    queue (sig already matched -> lists align; func queue absorbs any residual reorder),
+    args by arg index. Returns per-graph diff stats; 8-byte diffs classified (mapped?
+    same base?) as annotation, non-8 struct diffs (TMA/CUtensorMap) recorded raw."""
+    from collections import defaultdict, deque
+    res = {"desc": pg["desc"], "how": None,
+           "n_nodes_pres": len(pg["nodes"]), "n_nodes_fresh": len(fg["nodes"]),
+           "n_args": 0, "n_equal": 0,
+           "n_diff8": 0, "n_diff8_pres_invalid": 0, "n_diff8_same_base": 0,
+           "n_diff8_both_valid_diff_base": 0,
+           "n_diff_other": 0, "node_mismatch": 0,
+           "diff8": [], "diff_other": [],
+           # (func, arg) keys that differed -- used for the cross-graph uniqueness
+           # control (a benign graph-pool scratch diff recurs across every graph using
+           # that kernel; a stale persistent-buffer diff is unique to the faulting graph).
+           "diff_keys": set(), "diff_keys_other": set()}
+    fq = defaultdict(deque)
+    for nrec in fg["nodes"]:
+        fq[nrec["func"]].append(nrec)
+    for pnode in pg["nodes"]:
+        q = fq.get(pnode["func"])
+        if not q:
+            res["node_mismatch"] += 1
+            continue
+        fnode = q.popleft()
+        fa = {a[0]: a for a in fnode["args"]}
+        for (ai, off, sz, raw) in pnode["args"]:
+            fresh_arg = fa.get(ai)
+            if fresh_arg is None:
+                continue
+            res["n_args"] += 1
+            fraw = fresh_arg[3]
+            if raw == fraw:
+                res["n_equal"] += 1
+                continue
+            if sz == 8:
+                pv = int.from_bytes(raw, "little")
+                fv = int.from_bytes(fraw, "little")
+                pc = _e4_classify(cu, pv, cache)
+                fc = _e4_classify(cu, fv, cache)
+                res["n_diff8"] += 1
+                if not pc["valid"]:
+                    res["n_diff8_pres_invalid"] += 1
+                elif fc["valid"] and pc["base"] == fc["base"]:
+                    res["n_diff8_same_base"] += 1
+                else:
+                    res["n_diff8_both_valid_diff_base"] += 1
+                res["diff8"].append(
+                    (pnode["func"], pnode["ni"], ai, pv, fv,
+                     bool(pc["valid"]), bool(fc["valid"])))
+                res["diff_keys"].add((pnode["func"], ai))
+            else:
+                res["n_diff_other"] += 1
+                # Annotation only (codex: do not interpret TMA layout): scan the struct's
+                # 8-byte words and classify any that maps as a device VA -- a stale global
+                # address baked inside a TMA descriptor would surface here.
+                words = []
+                for w in range(0, sz - 7, 8):
+                    pv = int.from_bytes(raw[w:w + 8], "little")
+                    fv = int.from_bytes(fraw[w:w + 8], "little")
+                    if pv == fv:
+                        continue
+                    pc = _e4_classify(cu, pv, cache)
+                    fc = _e4_classify(cu, fv, cache)
+                    words.append((w, pv, fv, bool(pc["valid"]), bool(fc["valid"])))
+                res["diff_other"].append(
+                    (pnode["func"], pnode["ni"], ai, sz,
+                     raw.hex(), fraw.hex(), words))
+                res["diff_keys_other"].add((pnode["func"], ai))
+    return res
+
+
+def _e11_diff_and_report(pres: list, fresh: list) -> dict:
+    """E11 top-level diff + report (codex resume15 Q3). Matches graphs (desc then sig),
+    diffs each matched pair, aggregates buckets, and focuses the detailed dump on the
+    FAULTING decode graph desc=(1,1,1) with sibling manager graphs as controls -- a
+    stale baked resource unique to the decode graph shows a diff there that the siblings
+    (using the same kernels) do not. Writes a crash-safe summary marker + verbose per-
+    graph detail to the worker log. Read-only. Returns a compact summary dict."""
+    cu = _cu_ipc(_cu())
+    cache: dict = {}
+    matches = _e11_match_graphs(pres, fresh)
+    per_graph = []
+    tot = {"n_pairs": len(matches), "n_pres": len(pres), "n_fresh": len(fresh),
+           "n_args": 0, "n_equal": 0, "n_diff8": 0, "n_diff8_pres_invalid": 0,
+           "n_diff8_same_base": 0, "n_diff8_both_valid_diff_base": 0,
+           "n_diff_other": 0, "node_mismatch": 0, "n_desc_matched": 0}
+    faulting = None
+    for (pg, fg, how) in matches:
+        r = _e11_diff_pair(cu, cache, pg, fg)
+        r["how"] = how
+        per_graph.append(r)
+        if how == "desc":
+            tot["n_desc_matched"] += 1
+        for k in ("n_args", "n_equal", "n_diff8", "n_diff8_pres_invalid",
+                  "n_diff8_same_base", "n_diff8_both_valid_diff_base",
+                  "n_diff_other", "node_mismatch"):
+            tot[k] += r[k]
+        d = r["desc"]
+        if (d is not None and isinstance(d[0], int) and isinstance(d[1], int)
+                and d[0] == 1 and d[1] == 1):
+            faulting = r
+
+    # Cross-graph uniqueness control (codex resume15 Q3, THE decisive lens): a benign
+    # graph-pool scratch diff at (func, arg) recurs across EVERY graph that uses that
+    # kernel (fresh recapture uses a new mempool, so all scratch VAs move); a stale
+    # persistent-buffer diff that the rebind failed to rewrite is UNIQUE to the faulting
+    # decode graph. Count, per differing (func, arg) key, how many graphs show it.
+    from collections import Counter
+    key8_graphcount: Counter = Counter()
+    keyoth_graphcount: Counter = Counter()
+    for r in per_graph:
+        for k in r["diff_keys"]:
+            key8_graphcount[k] += 1
+        for k in r["diff_keys_other"]:
+            keyoth_graphcount[k] += 1
+
+    # crash-safe headline marker. n_pres/n_fresh + the desc-tagged counts are FIRST so a
+    # pairs=0 result is immediately diagnosable (empty side vs match failure).
+    n_pres_desc = sum(1 for g in pres if g["desc"] is not None)
+    n_fresh_desc = sum(1 for g in fresh if g["desc"] is not None)
+    _reuse_diag_marker(
+        "e11", "pres=%d(desc=%d) fresh=%d(desc=%d) pairs=%d desc_matched=%d args=%d "
+        "equal=%d diff8=%d (pres_invalid=%d same_base=%d both_valid_diff_base=%d) "
+        "diff_other=%d node_mismatch=%d"
+        % (tot["n_pres"], n_pres_desc, tot["n_fresh"], n_fresh_desc,
+           tot["n_pairs"], tot["n_desc_matched"], tot["n_args"], tot["n_equal"],
+           tot["n_diff8"], tot["n_diff8_pres_invalid"], tot["n_diff8_same_base"],
+           tot["n_diff8_both_valid_diff_base"], tot["n_diff_other"],
+           tot["node_mismatch"]))
+    log.info("E11 VALDIFF TOTALS pres_desc=%d fresh_desc=%d %s",
+             n_pres_desc, n_fresh_desc, tot)
+
+    # faulting-graph detail (the smoking gun, if any)
+    faulting_uniq8: list = []
+    faulting_uniqoth: list = []
+    if faulting is not None:
+        # keys that differ in the faulting graph AND in NO other matched graph -> the
+        # prime suspects (a stale persistent rebind unique to decode, not pool scratch).
+        faulting_uniq8 = sorted(
+            k for k in faulting["diff_keys"] if key8_graphcount[k] == 1)
+        faulting_uniqoth = sorted(
+            k for k in faulting["diff_keys_other"] if keyoth_graphcount[k] == 1)
+        _reuse_diag_marker(
+            "e11fault", "desc=%s args=%d equal=%d diff8=%d "
+            "(pres_invalid=%d same_base=%d both_valid_diff_base=%d) diff_other=%d "
+            "node_mismatch=%d UNIQUE(diff8=%s diff_other=%s)"
+            % (faulting["desc"], faulting["n_args"], faulting["n_equal"],
+               faulting["n_diff8"], faulting["n_diff8_pres_invalid"],
+               faulting["n_diff8_same_base"],
+               faulting["n_diff8_both_valid_diff_base"],
+               faulting["n_diff_other"], faulting["node_mismatch"],
+               faulting_uniq8, faulting_uniqoth))
+        log.info("E11 FAULT UNIQUE diff8=%s diff_other=%s (keys differing ONLY in the "
+                 "faulting graph -- prime stale-rebind suspects)",
+                 faulting_uniq8, faulting_uniqoth)
+        log.info("E11 FAULTING desc=%s stats={args:%d equal:%d diff8:%d "
+                 "pres_invalid:%d same_base:%d both_valid_diff_base:%d diff_other:%d "
+                 "node_mismatch:%d}", faulting["desc"], faulting["n_args"],
+                 faulting["n_equal"], faulting["n_diff8"],
+                 faulting["n_diff8_pres_invalid"], faulting["n_diff8_same_base"],
+                 faulting["n_diff8_both_valid_diff_base"], faulting["n_diff_other"],
+                 faulting["node_mismatch"])
+        for (func, ni, ai, pv, fv, pvld, fvld) in faulting["diff8"][:64]:
+            log.info("E11 FAULT diff8 func=%s ni=%d arg=%d pres=0x%x(valid=%s) "
+                     "fresh=0x%x(valid=%s)", func, ni, ai, pv, pvld, fv, fvld)
+        for (func, ni, ai, sz, phex, fhex, words) in faulting["diff_other"][:32]:
+            log.info("E11 FAULT diff_other func=%s ni=%d arg=%d sz=%d words=%s "
+                     "pres=%s fresh=%s", func, ni, ai, sz, words, phex, fhex)
+    else:
+        _reuse_diag_marker("e11fault", "NO_FAULTING_DESC_MATCHED "
+                           "(no matched graph with desc nt==nr==1)")
+
+    # sibling manager graphs (desc != None) as controls
+    for r in per_graph:
+        if r["desc"] is not None and r is not faulting:
+            log.info("E11 SIBLING desc=%s how=%s args=%d diff8=%d "
+                     "(pres_invalid=%d both_valid_diff_base=%d) diff_other=%d",
+                     r["desc"], r["how"], r["n_args"], r["n_diff8"],
+                     r["n_diff8_pres_invalid"], r["n_diff8_both_valid_diff_base"],
+                     r["n_diff_other"])
+
+    return {"ok": True, "totals": tot,
+            "faulting": (None if faulting is None else {
+                **{k: faulting[k] for k in (
+                    "desc", "n_args", "n_equal", "n_diff8",
+                    "n_diff8_pres_invalid", "n_diff8_same_base",
+                    "n_diff8_both_valid_diff_base", "n_diff_other",
+                    "node_mismatch")},
+                "unique_diff8": [list(k) for k in faulting_uniq8],
+                "unique_diff_other": [list(k) for k in faulting_uniqoth]})}
+
+
+# ---------------------------------------------------------------------------
+# E8 (SEMIP_E8_NODE_INV): node-class inventory over every captured graph. E4 proved
+# KERNEL args + MEMCPY endpoints valid post-reinit; E7 pinned the fault to a fresh
+# FULL-graph re-instantiate (H_topology). So the stale VA is in a node class E4 never
+# walked. This histograms node types and classifies the baked target of the skipped
+# classes (MEMSET.dst, MEM_FREE.dptr) + counts MEM_ALLOC (graph-owned mempool) and
+# recurses one level into CHILD_GRAPH. Read-only; never raises. codex resume12.
+# ---------------------------------------------------------------------------
+def _e8_memset_params(cu, node, params) -> bool:
+    """Fill _MemsetNodeParams for a MEMSET node. driver 13000 exposes only the base
+    cuGraphMemsetNodeGetParams (no _v2), so the 6-field v1 struct is exact. Returns
+    True on rc==0."""
+    for sym in ("cuGraphMemsetNodeGetParams", "cuGraphMemsetNodeGetParams_v2"):
+        fn = getattr(cu, sym, None)
+        if fn is None:
+            continue
+        try:
+            if fn(node, ctypes.byref(params)) == 0:
+                return True
+        except Exception:  # noqa: BLE001
+            continue
+    return False
+
+
+def _e8_memfree_dptr(cu, node, dptr) -> bool:
+    fn = getattr(cu, "cuGraphMemFreeNodeGetParams", None)
+    if fn is None:
+        return False
+    try:
+        return fn(node, ctypes.byref(dptr)) == 0
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _e8_child_graph(cu, node, sub) -> bool:
+    fn = getattr(cu, "cuGraphChildGraphNodeGetGraph", None)
+    if fn is None:
+        return False
+    try:
+        return fn(node, ctypes.byref(sub)) == 0
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _e8_collect_graphs_tagged(worker=None):
+    """(kind, cudaGraph_t_int) for every captured torch.cuda.CUDAGraph, tagged by
+    where it came from: 'wrapper_full' (CUDAGraphWrapper), 'piecewise'
+    (BreakableCUDAGraphWrapper), or 'manager_full' (the runner's
+    cudagraph_manager.graphs). Returns (pairs, diag).
+
+    The third kind is the one that matters and it needs `worker`. The wrapper kinds
+    used to be labelled 'full'/'piecewise' by wrapper class, but with breakable
+    cudagraphs enabled the real FULL graphs sit in NO wrapper -- they are bare
+    torch.cuda.CUDAGraph objects in the manager dict (resume18). So the old 'full'
+    bucket was mislabelled and E8's histogram never covered a FULL graph, which is
+    exactly the gap to close before calling the CA rewrite complete for them."""
+    pairs = []
+    diag = {"n_wrappers": 0, "n_full_wrappers": 0, "n_pw_wrappers": 0,
+            "n_manager_graphs": 0, "n_graphs": 0, "err": None}
+    try:
+        import torch
+        cls = torch.cuda.CUDAGraph
+        tagged = []
+        try:
+            from vllm.compilation.cuda_graph import CUDAGraphWrapper
+            tagged += [("wrapper_full", w) for w in CUDAGraphWrapper._all_instances]
+        except Exception as ex:  # noqa: BLE001
+            diag["err"] = f"import CUDAGraphWrapper: {type(ex).__name__}: {ex}"
+        try:
+            from vllm.compilation.breakable_cudagraph import (
+                BreakableCUDAGraphWrapper)
+            tagged += [("piecewise", w)
+                       for w in BreakableCUDAGraphWrapper._all_instances]
+        except Exception:  # noqa: BLE001
+            pass
+        diag["n_wrappers"] = len(tagged)
+        diag["n_full_wrappers"] = sum(1 for k, _ in tagged if k == "wrapper_full")
+        diag["n_pw_wrappers"] = sum(1 for k, _ in tagged if k == "piecewise")
+        seen = set()
+        for kind, w in tagged:
+            for attr in ("concrete_cudagraph_entries", "entries"):
+                m = getattr(w, attr, None)
+                if not isinstance(m, dict):
+                    continue
+                for entry in m.values():
+                    vals = (list(vars(entry).values())
+                            if hasattr(entry, "__dict__") else [])
+                    objs = []
+                    for v in vals:
+                        if isinstance(v, cls):
+                            objs.append(v)
+                        elif isinstance(v, (list, tuple)):
+                            objs += [it for it in v if isinstance(it, cls)]
+                    for o in objs:
+                        if id(o) in seen:
+                            continue
+                        seen.add(id(o))
+                        try:
+                            g = int(o.raw_cuda_graph())
+                        except Exception:  # noqa: BLE001 - no topology kept
+                            continue
+                        if g:
+                            pairs.append((kind, g))
+        # The FULL graphs: in no registry, so reachable only via the manager.
+        # `_graph_manager_holders` returns (managers, why); `why` is only useful
+        # to the main enumerator's diag, so drop it here.
+        for mgr in _graph_manager_holders(worker)[0]:
+            graphs = getattr(mgr, "graphs", None)
+            if not isinstance(graphs, dict):
+                continue
+            for o in graphs.values():
+                if not isinstance(o, cls) or id(o) in seen:
+                    continue
+                seen.add(id(o))
+                try:
+                    g = int(o.raw_cuda_graph())
+                except Exception:  # noqa: BLE001
+                    continue
+                if g:
+                    diag["n_manager_graphs"] += 1
+                    pairs.append(("manager_full", g))
+        diag["n_graphs"] = len(pairs)
+    except Exception as e:  # noqa: BLE001
+        diag["err"] = f"{type(e).__name__}: {e}"
+    return pairs, diag
+
+
+def e8_node_inventory(worker) -> dict:
+    """E8 POST hook (rebind_after_reinit, post-reinit, after CA rewrite/refresh,
+    before warmup). Histogram node types across EVERY captured graph (split
+    full-vs-piecewise), then classify the baked target of the node classes E4 skipped:
+    MEMSET.dst and MEM_FREE.dptr against the live VA map (via _e4_classify), COUNT
+    MEM_ALLOC nodes (graph-owned cudaMallocAsync mempool -- presence alone is decisive:
+    instantiate re-reserves VA), and recurse ONE level into CHILD_GRAPH nodes. Goal:
+    name the node class carrying the stale VA that survives the KERNEL/MEMCPY-only E4
+    rebind. Read-only; never raises. Consensus: codex resume12."""
+    out = {"step": "e8_node_inventory"}
+    try:
+        import torch
+        torch.cuda.synchronize()
+        cu = _cu_ipc(_cu())
+        pairs, cdiag = _e8_collect_graphs_tagged(worker)
+        out["collect"] = cdiag
+        # Human-readable inside-live-alloc label set (same basis as E4 POST): torch
+        # segments + the NEW CA ranges. A valid ptr outside these is 'outside' (a
+        # non-torch/non-CA driver allocation), NOT a fault -- only invalid==unmapped is.
+        ca = _find_ca(worker)
+        label_ranges = _e4_torch_segments() + _e4_ca_ranges(cu, ca)
+        label_ranges.sort()
+        label_los = [r[0] for r in label_ranges]
+        cache: dict = {}
+        hist: dict = {}     # kind -> {type_name: count}
+        memset = {"n": 0, "invalid": 0, "outside": 0, "samples": []}
+        memfree = {"n": 0, "invalid": 0, "outside": 0, "samples": []}
+        memalloc = {"n": 0}
+        child = {"n": 0, "recursed": 0}
+        SAMP = 12
+
+        def _classify_ptr(p):
+            c = _e4_classify(cu, p, cache)
+            inside = bool(c["valid"]
+                          and _e4_in_ranges(c["base"], label_los, label_ranges))
+            return c, inside
+
+        def _walk(kind, g, depth):
+            kh = hist.setdefault(kind, {})
+            try:
+                nodes = _graph_nodes(cu, g)
+            except Exception:  # noqa: BLE001
+                return
+            for node in nodes:
+                t = ctypes.c_int(-1)
+                if cu.cuGraphNodeGetType(node, ctypes.byref(t)) != 0:
+                    continue
+                tv = t.value
+                tn = _CU_NODE_TYPE_NAMES.get(tv, "type%d" % tv)
+                kh[tn] = kh.get(tn, 0) + 1
+                if tv == _CU_NODE_TYPE_MEMSET:
+                    p = _MemsetNodeParams()
+                    if _e8_memset_params(cu, node, p):
+                        memset["n"] += 1
+                        dst = int(p.dst)
+                        if dst:
+                            c, inside = _classify_ptr(dst)
+                            if not c["valid"]:
+                                memset["invalid"] += 1
+                            elif not inside:
+                                memset["outside"] += 1
+                            if (len(memset["samples"]) < SAMP
+                                    and (not c["valid"] or not inside)):
+                                memset["samples"].append(
+                                    {"kind": kind, "dst": hex(dst),
+                                     "valid": c["valid"],
+                                     "base": (hex(c["base"]) if c["base"]
+                                              else None),
+                                     "size": c["size"], "inside": inside})
+                elif tv == _CU_NODE_TYPE_MEM_FREE:
+                    dptr = ctypes.c_uint64(0)
+                    if _e8_memfree_dptr(cu, node, dptr):
+                        memfree["n"] += 1
+                        p = int(dptr.value)
+                        if p:
+                            c, inside = _classify_ptr(p)
+                            if not c["valid"]:
+                                memfree["invalid"] += 1
+                            elif not inside:
+                                memfree["outside"] += 1
+                            if (len(memfree["samples"]) < SAMP
+                                    and (not c["valid"] or not inside)):
+                                memfree["samples"].append(
+                                    {"kind": kind, "dptr": hex(p),
+                                     "valid": c["valid"], "inside": inside})
+                elif tv == _CU_NODE_TYPE_MEM_ALLOC:
+                    # COUNT only: CUDA_MEM_ALLOC_NODE_PARAMS is deeply nested; a
+                    # mis-sized struct passed to the getter would let the driver write
+                    # past our buffer inside the frozen rebind. Count is the decisive
+                    # signal (mempool world -> fix likely recapture-FULL). Reflect dptr
+                    # in a follow-up only if this is >0.
+                    memalloc["n"] += 1
+                elif tv == _CU_NODE_TYPE_GRAPH and depth == 0:
+                    child["n"] += 1
+                    sub = ctypes.c_void_p(0)
+                    if _e8_child_graph(cu, node, sub) and sub.value:
+                        child["recursed"] += 1
+                        _walk(kind + "/child", int(sub.value), depth + 1)
+
+        for kind, g in pairs:
+            _walk(kind, g, 0)
+
+        out["ok"] = True
+        out["node_hist"] = {k: dict(sorted(v.items(), key=lambda kv: -kv[1]))
+                            for k, v in hist.items()}
+        out["memset"] = memset
+        out["mem_free"] = memfree
+        out["mem_alloc"] = memalloc
+        out["child_graph"] = child
+        log.info("E8_NODE_INV graphs=%s (full_wrappers=%s pw_wrappers=%s) "
+                 "node_hist=%s",
+                 cdiag.get("n_graphs"), cdiag.get("n_full_wrappers"),
+                 cdiag.get("n_pw_wrappers"), out["node_hist"])
+        log.info("E8_NODE_INV memset(n=%s invalid=%s outside=%s) "
+                 "mem_free(n=%s invalid=%s outside=%s) mem_alloc(n=%s) "
+                 "child_graph(n=%s recursed=%s)",
+                 memset["n"], memset["invalid"], memset["outside"],
+                 memfree["n"], memfree["invalid"], memfree["outside"],
+                 memalloc["n"], child["n"], child["recursed"])
+        if memset["samples"]:
+            log.info("E8_NODE_INV memset SUSPECTS: %s", memset["samples"])
+        if memfree["samples"]:
+            log.info("E8_NODE_INV mem_free SUSPECTS: %s", memfree["samples"])
+    except Exception as e:  # noqa: BLE001
+        out["ok"] = False
+        out["error"] = f"{type(e).__name__}: {e}"
+        log.warning("e8_node_inventory failed: %s", out["error"])
+    return out
+
+
+# ---------------------------------------------------------------------------
+# E5a (SEMIP_CA_E5_REINSTANTIATE): re-instantiate the kept cudaGraph_t into a FRESH
+# cudaGraphExec_t and launch THAT in place of the preserved (possibly stale) exec.
+# See _ca_e5_reinstantiate_enabled. The working reuse path is byte-untouched when the
+# gate is off; all state lives in _E5_STATE and is only populated by the gated call.
+# ---------------------------------------------------------------------------
+_E5_STATE = {"map": {}, "orig_replay": None, "cu": None, "keep": [],
+             "n_launched": 0, "n_fallthrough": 0}
+
+
+def _e5_collect_graph_objs():
+    """Return the torch.cuda.CUDAGraph OBJECTS vLLM 0.24 holds (not the (g,e) int pairs
+    _find_captured_graphs returns), because E5a must intercept each object's .replay()
+    by identity. Mirrors _find_captured_graphs' freeze-immune wrapper enumeration --
+    DELIBERATELY duplicated so all E5 risk stays isolated to the gated path. Returns
+    (objs, diag)."""
+    objs = []
+    diag = {"n_wrappers": 0, "n_entries": 0, "n_objs": 0, "src": None, "err": None}
+    try:
+        import torch
+        cls = torch.cuda.CUDAGraph
+        wrappers = []
+        try:
+            from vllm.compilation.cuda_graph import CUDAGraphWrapper
+            wrappers += list(CUDAGraphWrapper._all_instances)
+        except Exception as ex:  # noqa: BLE001
+            diag["err"] = f"import CUDAGraphWrapper: {type(ex).__name__}: {ex}"
+        try:
+            from vllm.compilation.breakable_cudagraph import (
+                BreakableCUDAGraphWrapper)
+            wrappers += list(BreakableCUDAGraphWrapper._all_instances)
+        except Exception:  # noqa: BLE001
+            pass
+        diag["n_wrappers"] = len(wrappers)
+        diag["src"] = "vllm_wrappers"
+        seen = set()
+        for w in wrappers:
+            for attr in ("concrete_cudagraph_entries", "entries"):
+                m = getattr(w, attr, None)
+                if not isinstance(m, dict):
+                    continue
+                for entry in m.values():
+                    diag["n_entries"] += 1
+                    vals = (list(vars(entry).values())
+                            if hasattr(entry, "__dict__") else [])
+                    for v in vals:
+                        if isinstance(v, cls):
+                            if id(v) not in seen:
+                                seen.add(id(v)); objs.append(v)
+                        elif isinstance(v, (list, tuple)):
+                            for it in v:
+                                if isinstance(it, cls) and id(it) not in seen:
+                                    seen.add(id(it)); objs.append(it)
+        diag["n_objs"] = len(objs)
+    except Exception as e:  # noqa: BLE001
+        diag["err"] = f"{type(e).__name__}: {e}"
+    return objs, diag
+
+
+def _e5_install_replay_patch(cu):
+    """Install a one-time class-level torch.cuda.CUDAGraph.replay override: for any
+    object whose id() is in _E5_STATE['map'], launch the FRESH exec via cuGraphLaunch
+    on the CURRENT stream (matching vLLM's single-stream capture/replay) instead of the
+    preserved exec. Objects not in the map -- and any synchronous launch error -- fall
+    through to the original replay, so a graph we did not re-instantiate degrades to
+    normal reuse rather than crashing. (The IMA under test is ASYNC: cuGraphLaunch
+    returns 0 and the fault surfaces at the next sync, exactly as with the preserved
+    exec -- so H_exec-wrong still reproduces, it does not silently fall back.)"""
+    import torch
+    if _E5_STATE["orig_replay"] is not None:
+        return  # already installed this process
+    orig = torch.cuda.CUDAGraph.replay
+    _E5_STATE["orig_replay"] = orig
+
+    def _replay(self):
+        ne = _E5_STATE["map"].get(id(self))
+        if ne:
+            try:
+                s = torch.cuda.current_stream().cuda_stream
+                rc = cu.cuGraphLaunch(ctypes.c_void_p(ne), ctypes.c_void_p(s))
+                if rc == 0:
+                    n = _E5_STATE["n_launched"] = _E5_STATE["n_launched"] + 1
+                    if n == 1:
+                        log.info("E5 FIRST FRESH LAUNCH ok (id=%s exec=0x%x) -- "
+                                 "patch engaged, replay routed to fresh exec",
+                                 id(self), ne)
+                    elif n % 512 == 0:
+                        log.info("E5 fresh launches so far: %d", n)
+                    return
+                log.warning("E5 cuGraphLaunch(fresh) rc=%s -> fallback", rc)
+            except Exception as ex:  # noqa: BLE001
+                log.warning("E5 replay override failed: %s -> fallback", ex)
+        else:
+            nf = _E5_STATE["n_fallthrough"] = _E5_STATE["n_fallthrough"] + 1
+            if nf == 1:
+                log.info("E5 replay FALLTHROUGH (unmapped id=%s) -- this graph "
+                         "replays via the PRESERVED exec (not covered by E5a)",
+                         id(self))
+        return orig(self)
+
+    torch.cuda.CUDAGraph.replay = _replay
+
+
+def e5_reinstantiate_and_swap(worker) -> dict:
+    """Build a FRESH cudaGraphExec_t from each kept (already-rebound) cudaGraph_t and
+    route replay to it. Read-mostly: creates new execs + swaps the LAUNCHED handle for
+    the gated graphs; never destroys/mutates the preserved execs or the graph topology.
+    Runs AFTER the normal CA rewrite/refresh (so the kept cudaGraph_t CA nodes are
+    already topology-patched -- ckpt-wake addr_map is non-empty) and BEFORE the warmup
+    replay. Returns counters."""
+    out = {"step": "e5_reinstantiate", "gate": "SEMIP_CA_E5_REINSTANTIATE"}
+    try:
+        import torch
+        cu = _cu()
+        _E5_STATE["cu"] = cu
+        objs, diag = _e5_collect_graph_objs()
+        out["discovery"] = diag
+        n_ok = n_topo_fail = n_uninst = n_inst_fail = 0
+        errs = []
+        for o in objs:
+            try:
+                g = int(o.raw_cuda_graph())
+            except Exception:  # noqa: BLE001 - no kept topology (keep_graph False)
+                n_topo_fail += 1
+                continue
+            try:
+                _ = int(o.raw_cuda_graph_exec())  # skip not-yet-instantiated shapes
+            except Exception:  # noqa: BLE001
+                n_uninst += 1
+                continue
+            new_exec = ctypes.c_void_p()
+            rc = cu.cuGraphInstantiateWithFlags(ctypes.byref(new_exec),
+                                                ctypes.c_void_p(g),
+                                                ctypes.c_uint64(0))
+            if rc != 0 or not new_exec.value:
+                n_inst_fail += 1
+                if len(errs) < 6:
+                    errs.append(f"instantiate rc={rc}")
+                continue
+            try:  # optional pre-upload; the first launch would upload anyway
+                st = torch.cuda.current_stream().cuda_stream
+                cu.cuGraphUpload(new_exec, ctypes.c_void_p(st))
+            except Exception:  # noqa: BLE001
+                pass
+            _E5_STATE["map"][id(o)] = int(new_exec.value)
+            _E5_STATE["keep"].append((o, new_exec))  # strong refs (obj + handle)
+            n_ok += 1
+        out["n_objs"] = len(objs)
+        out["n_reinstantiated"] = n_ok
+        out["n_topo_fail"] = n_topo_fail
+        out["n_uninstantiated"] = n_uninst
+        out["n_instantiate_fail"] = n_inst_fail
+        if errs:
+            out["errors"] = errs
+        if n_ok:
+            _e5_install_replay_patch(cu)
+            out["replay_patched"] = True
+        out["ok"] = True
+        log.info("E5 REINSTANTIATE: objs=%d reinstantiated=%d topo_fail=%d "
+                 "uninst=%d inst_fail=%d patched=%s", len(objs), n_ok, n_topo_fail,
+                 n_uninst, n_inst_fail, out.get("replay_patched", False))
+    except Exception as e:  # noqa: BLE001
+        out["ok"] = False
+        out["error"] = f"{type(e).__name__}: {e}"
+        log.warning("e5_reinstantiate_and_swap failed: %s", out["error"])
+    return out
+
+
+# ---------------------------------------------------------------------------
+# E6 (SEMIP_REUSE_DIAG): pure-diagnostic replay counters. codex resume10
+# consensus: E5a's class-level torch.cuda.CUDAGraph.replay patch NEVER fired
+# during the faulting post-rebind warmup waves because the PIECEWISE path
+# launches segments via bound methods captured at cold-start capture_end()
+# (vllm/compilation/breakable_cudagraph.py:190 -- BreakableCUDAGraphCapture
+# .segments is a list of bound CUDAGraph.replay callables, consumed by
+# BreakableCUDAGraphCapture.replay() at :212 via entry.capture.replay() at
+# :423). A post-restore class reassignment cannot intercept an already-bound
+# method. E6 counts, WITHOUT changing behavior, how many piecewise replays
+# (patch the dynamically-dispatched BreakableCUDAGraphCapture.replay method)
+# and FULL replays (count-only patch of torch.cuda.CUDAGraph.replay) run before
+# the IMA -> names the failing surface. The working reuse path is byte-untouched
+# when the gate is off; all state lives in _REUSE_DIAG_STATE.
+# ---------------------------------------------------------------------------
+_REUSE_DIAG_STATE = {"pw_calls": 0, "pw_seg_calls": 0, "full_calls": 0,
+                     "rfg_calls": 0, "pw_patched": False, "full_patched": False,
+                     "rfg_patched": False}
+
+# E8 (resume12 Q3): descriptor keys (num_tokens, num_reqs, uniform_token_count)
+# already seen by run_fullgraph, so each marker can flag first-vs-repeat replay for
+# that desc -- disambiguates C-(i) one bad static desc from C-(ii) progressive
+# corruption. Behavior-neutral; only read/written in the run_fullgraph diag patch.
+_SEEN_DESCS: set = set()
+
+# E7 (resume11 Q3): id() of every torch.cuda.CUDAGraph that already had a live
+# cudaGraphExec at rebind time (the "130 preserved execs"). Populated in
+# _find_captured_graphs when reuse-diag is on. A FULL replay whose id() is NOT in
+# this set is a FRESH lazy-instantiate of one of the 3185 uninstantiated shapes ->
+# distinguishes H_exec (stale preserved exec) from H_topology (fresh exec built
+# from a preserved-but-rebound graph). Behavior-neutral; only read for logging.
+_PRESERVED_EXEC_IDS = set()
+
+# E9 (resume13 Q3): handle to the live GPUModelRunner, stashed in
+# rebind_after_reinit (same worker process) so the run_fullgraph diag hook -- which
+# only receives `self`=CudaGraphManager, not the runner -- can reach the eager-written
+# index tensors (input_buffers.seq_lens, block_tables.*) and the KV-cache config to
+# bounds-check the H4 level-2 indirection just before the faulting replay. Set only
+# when SEMIP_E9_H4=1; otherwise stays None (hook is a no-op). Read-only use.
+_E9_RUNNER = None
+# One-shot latch: only dump the FIRST time we see the faulting decode desc, so we
+# don't add a per-step host<->device sync to every subsequent replay.
+_E9_DUMPED: set = set()
+
+
+def _reuse_diag_enabled() -> bool:
+    return os.environ.get("SEMIP_REUSE_DIAG", "") == "1"
+
+
+def _reuse_diag_marker(kind: str, detail: str = "") -> None:
+    """E7: crash-safe (os.write + os.fsync) one-line marker so the LAST replay
+    surface executed before an async IMA / abrupt terminate survives even when the
+    worker's buffered stdout is lost. Written BEFORE the wrapped replay launches, so
+    under CUDA_LAUNCH_BLOCKING=1 the final line names the faulting surface. One file
+    per worker pid. Best-effort; never raises into the replay path."""
+    if not _reuse_diag_enabled():
+        return
+    try:
+        path = "/semiplog/save/reuse_diag_%d.marker" % os.getpid()
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o666)
+        try:
+            os.write(fd, ("%s %s\n" % (kind, detail)).encode())
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _e9_h4_dump(key, seq: int) -> None:
+    """E9 (resume13 Q3): H4 level-2-indirection bounds-check. Immediately BEFORE the
+    faulting FULL replay of the smallest decode desc, read the eager-written decode
+    index tensors off the live GPUModelRunner and bounds-check them against the
+    KV-cache capacity:
+      * block_table  = block_tables.input_block_tables[g][req]  (what the FULL graph
+                       actually reads; each entry must be a valid physical block id in
+                       [0, kv_cache_config.num_blocks));
+      * slot_mapping = block_tables.slot_mappings[g][:num_tokens] (write slot per token;
+                       must be in [0, num_blocks * block_size));
+      * seq_lens     = input_buffers.seq_lens[req]              (must be sane / > 0);
+      * used         = block_tables.num_blocks.np[g, req]       (host UVA -> no sync).
+    E8 proved every baked NODE POINTER is mapped+in-range, so if any of these CONTENTS
+    are OOB it names H4 as the fault (a valid pointer indexing a stale/OOB location).
+    All tensors read here are small, post-reinit-valid torch/UVA buffers -- NOT the
+    paged KV the graph faults on -- and are read while the CUDA context is still clean
+    (before the replay), so this dump never itself faults. Crash-safe marker survives
+    the subsequent IMA. Read-only. Caller wraps in try/except; we also self-guard."""
+    runner = _E9_RUNNER
+    if runner is None:
+        _reuse_diag_marker("e9h4", "seq=%d skip=no_runner" % seq)
+        return
+    try:
+        kvc = getattr(runner, "kv_cache_config", None)
+        total_blocks = int(getattr(kvc, "num_blocks", -1)) if kvc is not None else -1
+        bt = getattr(runner, "block_tables", None)
+        ib = getattr(runner, "input_buffers", None)
+        if bt is None or ib is None:
+            _reuse_diag_marker("e9h4", "seq=%d skip=no_bt_or_ib bt=%s ib=%s"
+                               % (seq, bt is not None, ib is not None))
+            return
+        ngroups = getattr(bt, "num_kv_cache_groups", 1)
+        bsz = getattr(bt, "block_sizes", None)
+        block_size = int(bsz[0]) if bsz else -1
+        total_slots = (total_blocks * block_size
+                       if (total_blocks > 0 and block_size > 0) else -1)
+        # req-0 used-block count -- host UVA numpy view, no device sync.
+        try:
+            used = int(bt.num_blocks.np[0, 0])
+        except Exception:  # noqa: BLE001
+            used = -1
+        # bounded window of the physical block ids the FULL graph reads for req 0.
+        row = bt.input_block_tables[0][0]
+        width = int(row.shape[0])
+        win = used if (0 < used <= width) else min(width, 128)
+        win = max(win, 8)
+        ids = row[:win].detach().to("cpu")
+        bmin = int(ids.min().item()); bmax = int(ids.max().item())
+        b_oob = (int(((ids < 0) | (ids >= total_blocks)).sum().item())
+                 if total_blocks > 0 else -1)
+        # slot mapping for the decode token(s) of this desc (group 0).
+        ntok = key[0] if (isinstance(key[0], int) and key[0] > 0) else 1
+        sm = bt.slot_mappings[0][:max(ntok, 1)].detach().to("cpu")
+        smin = int(sm.min().item()); smax = int(sm.max().item())
+        s_oob = (int(((sm < 0) | (sm >= total_slots)).sum().item())
+                 if total_slots > 0 else -1)
+        # seq_lens for req 0.
+        try:
+            seq_len0 = int(ib.seq_lens[:1].detach().to("cpu")[0].item())
+        except Exception:  # noqa: BLE001
+            seq_len0 = -1
+        _reuse_diag_marker(
+            "e9h4",
+            "seq=%d desc=(nt=%s,nr=%s,utc=%s) ngroups=%s total_blocks=%d "
+            "block_size=%d total_slots=%d used=%d win=%d blk[min=%d,max=%d,oob=%d] "
+            "slot[min=%d,max=%d,oob=%d] seq_len0=%d"
+            % (seq, key[0], key[1], key[2], ngroups, total_blocks, block_size,
+               total_slots, used, win, bmin, bmax, b_oob, smin, smax, s_oob,
+               seq_len0))
+        log.info("REUSE_DIAG E9 H4 desc=%s total_blocks=%d block_size=%d used=%d "
+                 "blk[%d..%d oob=%d] slot[%d..%d oob=%d] seq_len0=%d",
+                 key, total_blocks, block_size, used, bmin, bmax, b_oob,
+                 smin, smax, s_oob, seq_len0)
+    except Exception as ex:  # noqa: BLE001 - never perturb the replay path
+        _reuse_diag_marker("e9h4", "seq=%d error=%r" % (seq, ex))
+
+
+def install_reuse_diag_counters() -> dict:
+    """Install count-only patches on the PIECEWISE and FULL replay entry points so
+    we can see, from the worker log, which replay kind runs during the post-rebind
+    warmup waves (and thus which one carries the IMA). Behavior-preserving: every
+    patched method still calls the original. Idempotent per process."""
+    import torch
+    st = _REUSE_DIAG_STATE
+    # PIECEWISE: BreakableCUDAGraphCapture.replay is a plain class method, invoked
+    # via entry.capture.replay() (dynamic lookup) -> a class patch IS honored here,
+    # unlike the bound-method segments it iterates internally.
+    try:
+        from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphCapture
+        if not st["pw_patched"]:
+            _orig_pw = BreakableCUDAGraphCapture.replay
+
+            def _diag_pw_replay(self):
+                n = st["pw_calls"] = st["pw_calls"] + 1
+                try:
+                    nseg = len(self.segments)
+                    st["pw_seg_calls"] += nseg
+                except Exception:  # noqa: BLE001
+                    nseg = -1
+                # E7: crash-safe marker BEFORE the launch -> last line names the
+                # faulting surface under CUDA_LAUNCH_BLOCKING=1.
+                _reuse_diag_marker("piecewise", "seq=%d segments=%d" % (n, nseg))
+                if n == 1:
+                    log.info("REUSE_DIAG FIRST piecewise replay (segments=%s) -- "
+                             "PIECEWISE replay IS on the warmup path", nseg)
+                elif n % 256 == 0:
+                    log.info("REUSE_DIAG piecewise replays so far: %d (seg_calls=%d)",
+                             n, st["pw_seg_calls"])
+                return _orig_pw(self)
+
+            BreakableCUDAGraphCapture.replay = _diag_pw_replay
+            st["pw_patched"] = True
+    except Exception as ex:  # noqa: BLE001
+        log.warning("REUSE_DIAG piecewise patch failed: %s", ex)
+    # FULL: entry.cudagraph.replay() (cuda_graph.py:360) is a dynamic lookup on the
+    # torch CUDAGraph instance -> a class patch IS honored. Skip if E5a already owns
+    # this attr (its n_launched/n_fallthrough already count FULL replays).
+    try:
+        if not st["full_patched"] and not _ca_e5_reinstantiate_enabled():
+            _orig_full = torch.cuda.CUDAGraph.replay
+
+            def _diag_full_replay(self):
+                n = st["full_calls"] = st["full_calls"] + 1
+                # E7 (Q3): was this exec preserved pre-rebind (H_exec) or freshly
+                # lazy-instantiated post-reinit (H_topology)?
+                preserved = id(self) in _PRESERVED_EXEC_IDS
+                # E9 (resume13 Q3): log id(self) on EVERY low-level full replay.
+                # self.graphs[desc] IS this torch.cuda.CUDAGraph, so id(self) here
+                # matches the rfg marker's gid -- letting us see whether the faulting
+                # decode graph (its gid from the rfg line) already replayed OK during
+                # warmup (input-dependent fault, H4) or faulted on first instantiate.
+                _reuse_diag_marker(
+                    "full", "seq=%d preserved_exec=%s gid=0x%x"
+                    % (n, preserved, id(self)))
+                if n == 1:
+                    log.info("REUSE_DIAG FIRST full-graph replay -- FULL replay IS "
+                             "on the warmup path (preserved_exec=%s)", preserved)
+                return _orig_full(self)
+
+            torch.cuda.CUDAGraph.replay = _diag_full_replay
+            st["full_patched"] = True
+    except Exception as ex:  # noqa: BLE001
+        log.warning("REUSE_DIAG full patch failed: %s", ex)
+    # E8 (resume12 Q3): the torch.cuda.CUDAGraph.replay hook above sees only `self`,
+    # not the batch descriptor. Patch the LEVEL ABOVE it -- CudaGraphManager.run_fullgraph
+    # (base class; the 0.24 subclass calls super()) -- to write a crash-safe marker
+    # naming the exact `desc` (num_tokens, num_reqs, uniform_token_count), the graph
+    # object id + whether its exec was preserved pre-rebind, and first-vs-repeat for
+    # that desc. Under CUDA_LAUNCH_BLOCKING=1 the LAST "rfg" marker names the faulting
+    # descriptor, so we can tell one bad static desc (C-i) from progressive corruption
+    # (C-ii) and map the 66 FULL replays to distinct shapes. Marker BEFORE super().
+    try:
+        from vllm.v1.worker.gpu.cudagraph_utils import CudaGraphManager
+        if not st["rfg_patched"]:
+            _orig_rfg = CudaGraphManager.run_fullgraph
+
+            def _diag_run_fullgraph(self, desc):
+                n = st["rfg_calls"] = st["rfg_calls"] + 1
+                try:
+                    key = (getattr(desc, "num_tokens", None),
+                           getattr(desc, "num_reqs", None),
+                           getattr(desc, "uniform_token_count", None))
+                    g = None
+                    try:
+                        g = self.graphs.get(desc)
+                    except Exception:  # noqa: BLE001
+                        g = None
+                    gid = id(g) if g is not None else 0
+                    preserved = gid in _PRESERVED_EXEC_IDS
+                    first = key not in _SEEN_DESCS
+                    _SEEN_DESCS.add(key)
+                    _reuse_diag_marker(
+                        "rfg", "seq=%d desc=(nt=%s,nr=%s,utc=%s) gid=0x%x "
+                        "preserved_exec=%s first=%s"
+                        % (n, key[0], key[1], key[2], gid, preserved, first))
+                    if first:
+                        log.info("REUSE_DIAG rfg FIRST replay of desc=%s "
+                                 "(gid=0x%x preserved_exec=%s seq=%d)",
+                                 key, gid, preserved, n)
+                    # E9 (resume13 Q3): H4 bounds-check on the FIRST replay of each
+                    # small decode-shaped desc (nt==nr, <=8) -- captures the E7/E8
+                    # faulting (1,1,1) -- dumped BEFORE the (possibly faulting) replay.
+                    # Latched per key so we add the host<->device sync at most once per
+                    # desc, never on the steady-state replay path.
+                    if (_e9_h4_enabled()
+                            and isinstance(key[0], int) and isinstance(key[1], int)
+                            and key[0] == key[1] and 0 < key[0] <= 8
+                            and key not in _E9_DUMPED):
+                        _E9_DUMPED.add(key)
+                        _e9_h4_dump(key, n)
+                except Exception:  # noqa: BLE001 - never perturb the replay path
+                    pass
+                return _orig_rfg(self, desc)
+
+            CudaGraphManager.run_fullgraph = _diag_run_fullgraph
+            st["rfg_patched"] = True
+    except Exception as ex:  # noqa: BLE001
+        log.warning("REUSE_DIAG run_fullgraph patch failed: %s", ex)
+    return {"pw_patched": st["pw_patched"], "full_patched": st["full_patched"],
+            "rfg_patched": st["rfg_patched"]}
+
+
+def rebind_after_reinit(worker) -> dict:
+    """Post-reinit hook (Path 2 / force-copy). The captured graph bakes only
+    meta_ptrs (CA kernel nodes) and the static buffer_ptrs[rank] (copy memcpy
+    node); the per-buffer RankData is rank_data slot 0, which the new CA's
+    register_buffer already refilled at the same (stable) VA. So we just rewrite
+    meta_ptrs + buffer_ptrs old->new across the captured graphs."""
+    if not enabled():
+        return {"enabled": False}
+    out: dict = {"enabled": True, "step": "rebind_after_reinit"}
+    snap = getattr(worker, _SNAP_ATTR, None)
+    if snap is None:
+        out["skipped"] = "no snapshot (snapshot step did not run?)"
+        log.warning("rebind_after_reinit: %s", out["skipped"])
+        return out
+    ca = _find_ca(worker)
+    if ca is None:
+        out["skipped"] = "no ca_comm post-reinit"
+        log.warning("rebind_after_reinit: %s", out["skipped"])
+        return out
+    old_meta = list(snap.get("meta_ptrs", []))
+    new_meta = list(getattr(ca, "meta_ptrs", []) or [])
+    old_buf = list(snap.get("buffer_ptrs", []))
+    new_buf = list(getattr(ca, "buffer_ptrs", []) or [])
+    out["meta_old"] = [hex(x) for x in old_meta]
+    out["meta_new"] = [hex(x) for x in new_meta]
+    out["buf_old"] = [hex(x) for x in old_buf]
+    out["buf_new"] = [hex(x) for x in new_buf]
+    old_rd = int(snap.get("rank_data", 0) or 0)
+    new_rd = (int(ca.rank_data.data_ptr())
+              if getattr(ca, "rank_data", None) is not None else 0)
+    out["rank_data_old"] = hex(old_rd)
+    out["rank_data_new"] = hex(new_rd)
+    out["rank_data_moved"] = (old_rd != new_rd)
+    # DIAG: distribution of the CA kernels' baked _dp slot offsets in the KEPT
+    # graph. offset 0 == copy path (slot-0 staging); >0 == registered peer slots.
+    # Tells us whether force-copy actually took during the kept-graph capture
+    # (copy_only=True is the goal for the copy-path approach).
+    try:
+        _slots = _collect_dp_slots(
+            _cu(), new_rd,
+            int(ca.rank_data.numel() * ca.rank_data.element_size()), worker)
+        out["dp_slots_distinct"] = len(_slots)
+        out["dp_slot_min"] = (min(_slots) if _slots else None)
+        out["dp_slot_max"] = (max(_slots) if _slots else None)
+        out["dp_copy_only"] = (_slots == [0])
+        log.info("CA _dp slot dist: distinct=%d min=%s max=%s copy_only=%s",
+                 len(_slots), out.get("dp_slot_min"), out.get("dp_slot_max"),
+                 out.get("dp_copy_only"))
+    except Exception as _de:  # noqa: BLE001
+        out["dp_diag_err"] = f"{type(_de).__name__}: {_de}"
+    addr_map = {}
+    for o, n in zip(old_meta, new_meta):
+        addr_map[int(o)] = int(n)
+    for o, n in zip(old_buf, new_buf):
+        addr_map[int(o)] = int(n)
+    if old_rd and new_rd and old_rd != new_rd:
+        addr_map[old_rd] = new_rd
+    try:
+        out["rewrite"] = rewrite_addrs_in_graphs(worker, addr_map)
+        out["ok"] = bool(out["rewrite"].get("ok"))
+        # Copy-path (now unconditional): all captured CA kernels reduce the
+        # symmetric staging buffer; replicate the refreshed slot-0 into the
+        # stale used slots (no IPC / peer derivation needed).
+        out["refresh_copy"] = refresh_copy_path_slots(worker)
+        out["ok"] = out["ok"] and bool(out["refresh_copy"].get("ok"))
+        log.info("rebind_after_reinit: rank=%s rewrite=%s refresh=%s",
+                 getattr(ca, "rank", "?"), out["rewrite"],
+                 out.get("refresh_copy"))
+        # E4 POST reclassify (SEMIP_CA_E4_INVENTORY=1): re-read the pre-snapshotted
+        # baked pointers now (post-reinit, after CA rewrite/refresh, BEFORE warmup)
+        # and bucket each. Runs before probe_ca_signal_pads so it captures the stale-
+        # pointer state even if the probe's leader sync surfaces the async IMA first.
+        # Read-only; e4_post_inventory never raises, so it cannot flip out["ok"].
+        if _ca_e4_inventory_enabled():
+            out["e4"] = e4_post_inventory(worker)
+        # E8 node-class inventory (SEMIP_E8_NODE_INV=1): histogram node types over
+        # every captured graph + classify the MEMSET/MEM_FREE/MEM_ALLOC/CHILD_GRAPH
+        # classes E4 never walked. Same window as E4 POST (post-reinit, after CA
+        # rewrite/refresh, before warmup). Read-only; never flips out["ok"]. resume12.
+        if _e8_node_inventory_enabled():
+            out["e8"] = e8_node_inventory(worker)
+        # CA one-shot Signal-pad diagnostic + optional local zero (env-gated,
+        # default OFF). Investigating why reused one-shot all-reduce graphs
+        # sometimes deadlock / silently die after restore: measures whether the
+        # fresh Signal is zero-initialized, validates the graph-baked sg/self_sg
+        # ptrs, and can zero this rank's Signal before the warmup replay. See
+        # probe_ca_signal_pads / _ca_zero_signal_enabled.
+        if (_ca_pad_probe_enabled() or _ca_zero_signal_enabled()
+                or _ca_e3_dump_enabled()):
+            out["ca_pad_probe"] = probe_ca_signal_pads(
+                worker, do_zero=_ca_zero_signal_enabled())
+        # E5a (SEMIP_CA_E5_REINSTANTIATE=1): re-instantiate the kept, now-rebound
+        # cudaGraph_t into a FRESH exec and route replay to it (H_exec discriminator).
+        # Runs LAST in the rebind body -> after rewrite/refresh/E4/probe and BEFORE the
+        # warmup replay that follows rebind_after_reinit, so the fresh exec is the one
+        # launched. Read-mostly; never flips out["ok"].
+        if _ca_e5_reinstantiate_enabled():
+            out["e5"] = e5_reinstantiate_and_swap(worker)
+        # E6 (SEMIP_REUSE_DIAG=1): install count-only piecewise/FULL replay
+        # counters BEFORE the post-rebind warmup waves so the worker log names
+        # which replay kind runs (and carries the IMA). Behavior-preserving.
+        if _reuse_diag_enabled():
+            out["reuse_diag"] = install_reuse_diag_counters()
+        # E9 (resume13 Q3): stash the live GPUModelRunner so the run_fullgraph diag
+        # hook (which only receives self=CudaGraphManager) can reach the eager-written
+        # decode index tensors + KV-cache config for the H4 bounds-check. Same worker
+        # process; read-only handle. Only when SEMIP_E9_H4=1.
+        if _e9_h4_enabled():
+            global _E9_RUNNER
+            _E9_RUNNER = getattr(worker, "model_runner", None)
+            out["e9_runner"] = _E9_RUNNER is not None
+        # FIX (stale-snapshot drift): keep the snapshot in sync with what the
+        # graphs NOW bake. Each rebind rewrites the baked meta/buffer ptrs
+        # old->new; leaving snap at the cold-start values means the NEXT rebind
+        # (e.g. the disk-wake after this ckpt-wake) builds addr_map from stale keys
+        # that no longer match the graphs' baked (previous-rebind) values -> 0
+        # patched -> signals NOT rewritten. That is benign only while reinit
+        # reproduces the same VAs; when it does not, the stale signal ptrs crash
+        # the worker (the intermittent disk-wake death). Syncing snap here makes
+        # every subsequent rebind map baked->current correctly regardless of reinit
+        # determinism.
+        #
+        # PER-CATEGORY, not one coupled guard: meta_ptrs (rewritten in KERNEL
+        # sg/self_sg nodes -> kernel_nodes_patched) and buffer_ptrs (rewritten in
+        # MEMCPY nodes -> memcpy_nodes_patched) are INDEPENDENT create_shared_buffer
+        # allocations that can move independently (only rank_data is VA-pinned).
+        # Gating both on kernel_nodes_patched would skip the buffer sync whenever
+        # the buffer moves but meta reproduces its VA -> the same drift, on the copy
+        # path. Each field is synced ONLY when (a) that category actually moved
+        # (new != old) and (b) its own rewrite counter fired; the len/non-empty
+        # guard stops a degenerate reinit (empty ca.meta_ptrs while kernel patches
+        # came from a _dp match) from clobbering snap with [] and latching the crash.
+        rw = out.get("rewrite") or {}
+        if out["ok"]:
+            synced = []
+            if (new_meta and len(new_meta) == len(old_meta) and new_meta != old_meta
+                    and int(rw.get("kernel_nodes_patched", 0)) > 0):
+                snap["meta_ptrs"] = list(new_meta)
+                synced.append("meta")
+            if (new_buf and len(new_buf) == len(old_buf) and new_buf != old_buf
+                    and int(rw.get("memcpy_nodes_patched", 0)) > 0):
+                snap["buffer_ptrs"] = list(new_buf)
+                synced.append("buffer")
+            if (new_rd and new_rd != old_rd
+                    and int(rw.get("kernel_nodes_patched", 0)) > 0):
+                snap["rank_data"] = new_rd
+                synced.append("rank_data")
+            if synced:
+                setattr(worker, _SNAP_ATTR, snap)
+                out["snapshot_synced"] = synced
+    except Exception as e:  # noqa: BLE001
+        out["ok"] = False
+        out["error"] = f"{type(e).__name__}: {e}"
+        log.warning("rebind_after_reinit failed: %s", out["error"])
+    return out

--- a/arctic_inference/semi_persistence/demuxer.py
+++ b/arctic_inference/semi_persistence/demuxer.py
@@ -90,10 +90,20 @@ class Demuxer:
         self._thread.start()
 
     def stop(self, timeout: float = 5.0) -> None:
-        """Signal the consumer thread to exit and join it."""
+        """Signal the consumer thread to exit and join it.
+
+        Safe to call from the demuxer thread itself: a ``teardown`` result
+        is applied on this thread (``_apply_result`` -> ``Instance._reset``
+        -> ``_close_queues`` -> ``stop``), and joining the current thread
+        raises ``RuntimeError``.  In that case we only set the stop flag
+        and leave the join to the natural loop exit -- once ``_handle``
+        returns, ``_loop`` observes ``_stop`` and the thread ends on its
+        own.
+        """
         self._stop.set()
-        if self._thread is not None:
-            self._thread.join(timeout=timeout)
+        t = self._thread
+        if t is not None and t is not threading.current_thread():
+            t.join(timeout=timeout)
             self._thread = None
 
     # -- send-side bookkeeping -------------------------------------------------

--- a/arctic_inference/semi_persistence/example_full.py
+++ b/arctic_inference/semi_persistence/example_full.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+
+import os
+import shutil
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+os.environ.setdefault("NCCL_NVLS_ENABLE", "0")
+os.environ.setdefault("VLLM_ALLREDUCE_USE_SYMM_MEM", "0")
+os.environ.setdefault("FLASHINFER_CACHE_DIR", f"/tmp/flashinfer-uid{os.geteuid()}")
+
+from instance import Instance
+
+MODELS_DIR = "/data-fast/hf_models"
+IMAGE_ROOT = "/data-fast/image-cache/reproduce_example_full"
+PROMPT = "Hi canyou introduce yourself?"
+SAMPLING = {"max_tokens": 32, "ignore_eos": True, "temperature": 0.0}
+
+# label, model_id, tp, gpu_memory_utilization, gpus, extra
+MODEL_SPECS = [
+    # 122b / 397b are hybrid-Mamba: vLLM 0.24's cudagraph check needs
+    # max_num_seqs <= available Mamba cache blocks, so cap it (else init fails).
+    # The near-card-filling models (122b/235b/397b) need util=0.9 to fit weights.
+    ("Qwen3.5-122b-a10b-tp2", "Qwen/Qwen3.5-122B-A10B",  2, 0.9, [0, 1], {"max_num_seqs": 128}),
+    ("Qwen3-32b-tp4",         "Qwen/Qwen3-32B",          4, 0.8, [0, 1, 2, 3], {}),
+    ("Qwen3-235B-A22B-tp4",   "Qwen/Qwen3-235B-A22B",    4, 0.9, [0, 1, 2, 3], {}),
+    ("Qwen3.5-397b-a17b-tp8", "Qwen/Qwen3.5-397B-A17B",  8, 0.9, list(range(8)),
+     {"max_num_seqs": 128,
+      "kernel_config": {"moe_backend": "triton",
+                        "enable_flashinfer_autotune": False}}),
+    ("Qwen3.5-2B-tp1",        "Qwen/Qwen3.5-2B",         1, 0.2, [0], {}),
+    ("Llama3.1-8B-tp1",       "meta-llama/Llama-3.1-8B", 1, 0.4, [0], {}),
+    ("Qwen3.5-27B-tp1",       "Qwen/Qwen3.5-27B",        1, 0.8, [0], {}),
+    ("Qwen3-30B-A3B-tp1",     "Qwen/Qwen3-30B-A3B",      1, 0.8, [0], {}),
+]
+
+
+def cleanup(inst):
+    try:
+        inst._cmd_queue.put(("teardown", {}))
+        worker = getattr(inst, "_worker", None)
+        if worker is not None:
+            worker.join(timeout=15)
+            if worker.is_alive():
+                worker.kill()
+    except Exception:
+        pass
+    Instance._all.pop(inst.instance_id, None)
+
+
+def run_one(label, model_id, tp, util, gpus, extra):
+    local = os.path.join(MODELS_DIR, model_id)
+    config = {"model": local if os.path.exists(local) else model_id,
+              "gpu_memory_utilization": util, "enforce_eager": False,
+              "tensor_parallel_size": tp, **extra}
+    model_dir = os.path.join(IMAGE_ROOT, label)
+    shutil.rmtree(model_dir, ignore_errors=True)
+    os.makedirs(model_dir, exist_ok=True)
+    print(f"\n{'=' * 70}\n{label}  {model_id}  tp={tp}  gpus={gpus}\n{'=' * 70}",
+          flush=True)
+
+    inst = Instance(dict(config), model_dir)
+    times = {}
+    try:
+        # -> up
+        print("== up ==", flush=True)
+        inst.init(gpus=gpus).attach().repin().stage()
+        inst.generate([PROMPT], SAMPLING).wait()
+        print(f"  answer after cold start: {str(inst.last_generate_result)[:80]!r}",
+              flush=True)
+
+        # saved -> up
+        print("\n== saved -> up ==", flush=True)
+        inst.save_weights().detach().wait()
+
+        t0 = time.perf_counter()
+        inst.sleep().wait()
+        t1 = time.perf_counter()
+        times["sleep"] = t1 - t0
+
+        # cuda_checkpoint already does cleargraph + destroy_nccl when tp>1.
+        t0 = time.perf_counter()
+        inst.cuda_checkpoint().wait()
+        t1 = time.perf_counter()
+        times["checkpoint_cuda"] = t1 - t0
+
+        inst.criu_dump().wait()
+        cleanup(inst)
+        time.sleep(2)
+        image_dir = os.path.join(model_dir, "image")
+        if os.path.isdir(image_dir):
+            size = sum(f.stat().st_size for f in os.scandir(image_dir) if f.is_file())
+            print(f"  image on disk: {size / 2**30:.2f} GiB", flush=True)
+
+        inst = Instance(dict(config), model_dir)
+        inst.criu_restore().wait()
+
+        t0 = time.perf_counter()
+        inst.cuda_restore(gpus=gpus).wait()
+        t1 = time.perf_counter()
+        times["restore_cuda"] = t1 - t0
+
+        t0 = time.perf_counter()
+        inst.reinit_nccl().wait()
+        t1 = time.perf_counter()
+        times["reinit_nccl"] = t1 - t0
+
+        inst.attach().load_weights().wait()
+
+        t0 = time.perf_counter()
+        inst.wake_up_weights().wait()
+        t1 = time.perf_counter()
+        times["wake_up_weights"] = t1 - t0
+
+        inst.repin().plan_restore_weights().wait()
+
+        t0 = time.perf_counter()
+        inst.restore_weights().wait()
+        t1 = time.perf_counter()
+        times["restore_weights"] = t1 - t0
+
+        t0 = time.perf_counter()
+        inst.wake_up_kv_cache().wait()
+        t1 = time.perf_counter()
+        times["wake_up_kv_cache"] = t1 - t0
+
+        t0 = time.perf_counter()
+        inst.recapture_graphs().wait()
+        t1 = time.perf_counter()
+        times["recapture_graphs"] = t1 - t0
+
+        inst.generate([PROMPT], SAMPLING).wait()
+        print(f"  answer after saved: {str(inst.last_generate_result)[:80]!r}",
+              flush=True)
+        print("  times:", {k: round(v, 3) for k, v in times.items()}, flush=True)
+    finally:
+        cleanup(inst)
+
+
+def main():
+    if os.geteuid() != 0:
+        sys.exit("CUDA checkpoint process must run as root ")
+    want = set(sys.argv[1:])
+    known = {s[0] for s in MODEL_SPECS}
+    if want - known:
+        sys.exit(f"unknown label(s); known: {sorted(known)}")
+    specs = [s for s in MODEL_SPECS if not want or s[0] in want]
+
+    failed = []
+    for spec in specs:
+        t0 = time.time()
+        try:
+            run_one(*spec)
+            print(f"[{spec[0]}] OK in {time.time() - t0:.0f}s", flush=True)
+        except Exception as e:
+            failed.append(spec[0])
+            short = str(e).split("\n", 1)[0][:120]
+            print(f"[{spec[0]}] FAILED after {time.time() - t0:.0f}s: "
+                  f"{type(e).__name__}: {short}", flush=True)
+    print(f"\ndone: {len(specs) - len(failed)}/{len(specs)} ok", flush=True)
+    print("== run finished ==", flush=True)
+    sys.exit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/arctic_inference/semi_persistence/example_full.py
+++ b/arctic_inference/semi_persistence/example_full.py
@@ -26,10 +26,7 @@ MODEL_SPECS = [
     ("Qwen3.5-122b-a10b-tp2", "Qwen/Qwen3.5-122B-A10B",  2, 0.9, [0, 1], {"max_num_seqs": 128}),
     ("Qwen3-32b-tp4",         "Qwen/Qwen3-32B",          4, 0.8, [0, 1, 2, 3], {}),
     ("Qwen3-235B-A22B-tp4",   "Qwen/Qwen3-235B-A22B",    4, 0.9, [0, 1, 2, 3], {}),
-    ("Qwen3.5-397b-a17b-tp8", "Qwen/Qwen3.5-397B-A17B",  8, 0.9, list(range(8)),
-     {"max_num_seqs": 128,
-      "kernel_config": {"moe_backend": "triton",
-                        "enable_flashinfer_autotune": False}}),
+    ("Qwen3.5-397b-a17b-tp8", "Qwen/Qwen3.5-397B-A17B",  8, 0.9, list(range(8)), {"max_num_seqs": 128, "kernel_config": {"moe_backend": "triton", "enable_flashinfer_autotune": False}}),
     ("Qwen3.5-2B-tp1",        "Qwen/Qwen3.5-2B",         1, 0.2, [0], {}),
     ("Llama3.1-8B-tp1",       "meta-llama/Llama-3.1-8B", 1, 0.4, [0], {}),
     ("Qwen3.5-27B-tp1",       "Qwen/Qwen3.5-27B",        1, 0.8, [0], {}),
@@ -38,15 +35,12 @@ MODEL_SPECS = [
 
 
 def cleanup(inst):
-    try:
-        inst._cmd_queue.put(("teardown", {}))
-        worker = getattr(inst, "_worker", None)
-        if worker is not None:
-            worker.join(timeout=15)
-            if worker.is_alive():
-                worker.kill()
-    except Exception:
-        pass
+    inst._cmd_queue.put(("teardown", {}))
+    worker = getattr(inst, "_worker", None)
+    if worker is not None:
+        worker.join(timeout=15)
+        if worker.is_alive():
+            worker.kill()
     Instance._all.pop(inst.instance_id, None)
 
 
@@ -63,80 +57,77 @@ def run_one(label, model_id, tp, util, gpus, extra):
 
     inst = Instance(dict(config), model_dir)
     times = {}
-    try:
-        # -> up
-        print("== up ==", flush=True)
-        inst.init(gpus=gpus).attach().repin().stage()
-        inst.generate([PROMPT], SAMPLING).wait()
-        print(f"  answer after cold start: {str(inst.last_generate_result)[:80]!r}",
-              flush=True)
 
-        # saved -> up
-        print("\n== saved -> up ==", flush=True)
-        inst.save_weights().detach().wait()
+    print("== up ==", flush=True)
+    inst.init(gpus=gpus).attach().repin().stage()
+    inst.generate([PROMPT], SAMPLING).wait()
+    print(f"  answer after cold start: {str(inst.last_generate_result)[:80]!r}",
+          flush=True)
 
-        t0 = time.perf_counter()
-        inst.sleep().wait()
-        t1 = time.perf_counter()
-        times["sleep"] = t1 - t0
+    print("\n== saved -> up ==", flush=True)
+    inst.save_weights().detach().wait()
 
-        # cuda_checkpoint already does cleargraph + destroy_nccl when tp>1.
-        t0 = time.perf_counter()
-        inst.cuda_checkpoint().wait()
-        t1 = time.perf_counter()
-        times["checkpoint_cuda"] = t1 - t0
+    t0 = time.perf_counter()
+    inst.sleep().wait()
+    t1 = time.perf_counter()
+    times["sleep"] = t1 - t0
 
-        inst.criu_dump().wait()
-        cleanup(inst)
-        time.sleep(2)
-        image_dir = os.path.join(model_dir, "image")
-        if os.path.isdir(image_dir):
-            size = sum(f.stat().st_size for f in os.scandir(image_dir) if f.is_file())
-            print(f"  image on disk: {size / 2**30:.2f} GiB", flush=True)
+    # cuda_checkpoint already does cleargraph + destroy_nccl when tp>1.
+    t0 = time.perf_counter()
+    inst.cuda_checkpoint().wait()
+    t1 = time.perf_counter()
+    times["checkpoint_cuda"] = t1 - t0
 
-        inst = Instance(dict(config), model_dir)
-        inst.criu_restore().wait()
+    inst.criu_dump().wait()
+    cleanup(inst)
+    time.sleep(2)
+    image_dir = os.path.join(model_dir, "image")
+    if os.path.isdir(image_dir):
+        size = sum(f.stat().st_size for f in os.scandir(image_dir) if f.is_file())
+        print(f"  image on disk: {size / 2**30:.2f} GiB", flush=True)
 
-        t0 = time.perf_counter()
-        inst.cuda_restore(gpus=gpus).wait()
-        t1 = time.perf_counter()
-        times["restore_cuda"] = t1 - t0
+    inst = Instance(dict(config), model_dir)
+    inst.criu_restore().wait()
 
-        t0 = time.perf_counter()
-        inst.reinit_nccl().wait()
-        t1 = time.perf_counter()
-        times["reinit_nccl"] = t1 - t0
+    t0 = time.perf_counter()
+    inst.cuda_restore(gpus=gpus).wait()
+    t1 = time.perf_counter()
+    times["restore_cuda"] = t1 - t0
 
-        inst.attach().load_weights().wait()
+    t0 = time.perf_counter()
+    inst.reinit_nccl().wait()
+    t1 = time.perf_counter()
+    times["reinit_nccl"] = t1 - t0
 
-        t0 = time.perf_counter()
-        inst.wake_up_weights().wait()
-        t1 = time.perf_counter()
-        times["wake_up_weights"] = t1 - t0
+    inst.attach().load_weights().wait()
 
-        inst.repin().plan_restore_weights().wait()
+    t0 = time.perf_counter()
+    inst.wake_up_weights().wait()
+    t1 = time.perf_counter()
+    times["wake_up_weights"] = t1 - t0
 
-        t0 = time.perf_counter()
-        inst.restore_weights().wait()
-        t1 = time.perf_counter()
-        times["restore_weights"] = t1 - t0
+    inst.repin().plan_restore_weights().wait()
 
-        t0 = time.perf_counter()
-        inst.wake_up_kv_cache().wait()
-        t1 = time.perf_counter()
-        times["wake_up_kv_cache"] = t1 - t0
+    t0 = time.perf_counter()
+    inst.restore_weights().wait()
+    t1 = time.perf_counter()
+    times["restore_weights"] = t1 - t0
 
-        t0 = time.perf_counter()
-        inst.recapture_graphs().wait()
-        t1 = time.perf_counter()
-        times["recapture_graphs"] = t1 - t0
+    t0 = time.perf_counter()
+    inst.wake_up_kv_cache().wait()
+    t1 = time.perf_counter()
+    times["wake_up_kv_cache"] = t1 - t0
 
-        inst.generate([PROMPT], SAMPLING).wait()
-        print(f"  answer after saved: {str(inst.last_generate_result)[:80]!r}",
-              flush=True)
-        print("  times:", {k: round(v, 3) for k, v in times.items()}, flush=True)
-    finally:
-        cleanup(inst)
+    t0 = time.perf_counter()
+    inst.recapture_graphs().wait()
+    t1 = time.perf_counter()
+    times["recapture_graphs"] = t1 - t0
+
+    inst.generate([PROMPT], SAMPLING).wait()
+    print(f"  answer after saved: {str(inst.last_generate_result)[:80]!r}",
+          flush=True)
+    print("  times:", {k: round(v, 3) for k, v in times.items()}, flush=True)
+    cleanup(inst)
 
 
 def main():

--- a/arctic_inference/semi_persistence/instance.py
+++ b/arctic_inference/semi_persistence/instance.py
@@ -104,6 +104,17 @@ class Instance:
         self.total_gpu_bytes = 0
         self._image_dir = None
         self._weights_dir = None
+        # Multi-GPU (tensor-parallel) state.  TP is wired from the vLLM config
+        # (``tensor_parallel_size``, default 1) at construction, not inferred
+        # from the GPU count at ``init`` -- so ``n_gpus`` is authoritative here
+        # and ``gpus`` (the physical GPU list) is only a placement argument
+        # validated against it.  ``max_pinned_bytes_per_worker`` is the largest
+        # per-worker staging shard (used to size the restore chunk budget at
+        # TP>1, where the aggregate ``pinned_cpu_bytes`` overstates the per-GPU
+        # budget).
+        self.gpus = None
+        self.n_gpus = int(vllm_config.get("tensor_parallel_size", 1) or 1)
+        self.max_pinned_bytes_per_worker = 0
 
         self._cmd_queue = None
         self._result_queue = None
@@ -188,9 +199,11 @@ class Instance:
         self._close_queues()
         self.state = "created"
         self.gpu = None
+        self.gpus = None
         self.log.set_gpu(None)
         self.pid = None
         self.pinned_cpu_bytes = 0
+        self.max_pinned_bytes_per_worker = 0
 
     def _send(self, cmd, **kwargs):
         self._cmd_queue.put((cmd, kwargs))
@@ -268,17 +281,41 @@ class Instance:
 
     # -- Primitives (non-blocking, return self) --------------------------------
 
-    def init(self, gpu: int):
+    def init(self, gpus=None, gpu=None):
+        """Cold start the engine on the given physical GPU(s).
+
+        ``gpus`` is placement only and must have exactly
+        ``tensor_parallel_size`` entries; TP size itself comes from the vLLM
+        config.  A scalar ``gpu=`` (or positional ``init(0)``) still works
+        for TP=1.
+        """
+        if gpus is None:
+            gpus = [gpu] if gpu is not None else []
+        elif isinstance(gpus, int):
+            gpus = [gpus]
+        gpus = list(gpus)
+        if not gpus:
+            raise RuntimeError("init requires a gpu/gpus")
+        # TP is wired from the vLLM config, not inferred from the GPU count.
+        tp = self.n_gpus
+        if len(gpus) != tp:
+            raise RuntimeError(
+                f"init: {len(gpus)} gpu(s) given ({gpus}) but "
+                f"tensor_parallel_size={tp}; the gpu list must have exactly "
+                f"tensor_parallel_size entries")
+        self.gpus = gpus
+        gpu = gpus[0]
         self.gpu = gpu
         self.log.set_gpu(gpu)
         # Snapshot the GPU's physical capacity once per instance lifetime.
         # Safe under the orchestrator contract that init always takes a
         # full L1 slot (no shared tenants), so .total matches what vLLM
-        # uses internally for its gpu_memory_utilization budget.
+        # uses internally for its gpu_memory_utilization budget.  Every GPU
+        # in a TP group has the same capacity, so gpus[0] is representative.
         pynvml.nvmlInit()
         h = pynvml.nvmlDeviceGetHandleByIndex(gpu)
         self.total_gpu_bytes = int(pynvml.nvmlDeviceGetMemoryInfo(h).total)
-        self._log("init")
+        self._log(f"init(gpus={gpus})")
         self._ensure_queues()
         # model_dir threads through to the vLLM child so it points its
         # compile cache at <model_dir>/compilation (embedding the JIT/compile
@@ -286,11 +323,18 @@ class Instance:
         # at restore).
         self._worker = _spawn_ctx.Process(
             target=worker_loop,
-            args=(self.instance_id, gpu, self._cmd_queue, self._result_queue,
-                  self._completed_counter, self.model_dir),
+            args=(self.instance_id, list(gpus), self._cmd_queue,
+                  self._result_queue, self._completed_counter, self.model_dir),
         )
         self._worker.start()
-        return self._send("init", vllm_config=self.vllm_config)
+        # For TP>1: place the group on these physical GPUs via a custom worker
+        # (all GPUs visible + SEMIP_GPU_MAP).  tensor_parallel_size already
+        # comes from the user's vllm_config; we only inject the worker class.
+        # TP1 keeps the vanilla single-GPU path untouched.
+        vllm_config = dict(self.vllm_config)
+        if tp > 1:
+            vllm_config.setdefault("worker_cls", "_semip_worker.SemipGPUWorker")
+        return self._send("init", vllm_config=vllm_config)
 
     def attach(self):
         self._log("attach")
@@ -353,7 +397,42 @@ class Instance:
 
     def cuda_checkpoint(self):
         self._log("cuda_checkpoint")
+        # TP>1: drop/preserve graphs then tear down NCCL (CRIU cannot restore
+        # live communicators / CustomAllreduce IPC) before the CUDA checkpoint.
+        # graph_mode="reuse" preserves the captured graphs; destroy_nccl uses
+        # the graph-preserving unilateral-abort teardown.  Both are no-ops at
+        # TP=1, but the gate keeps the single-GPU path free of extra commands.
+        if self.n_gpus > 1:
+            self._send("cleargraph", graph_mode="reuse")
+            self._send("destroy_nccl", graph_mode="reuse")
         return self._send("cuda_checkpoint")
+
+    def reinit_nccl(self):
+        """Rebuild NCCL / the torch process group after a CRIU restore.
+
+        Must run immediately after ``cuda_restore`` and before any
+        collective (attach, weight restore, graph replay).  No-op at TP=1.
+        """
+        self._log("reinit_nccl")
+        return self._send("reinit_nccl")
+
+    def destroy_nccl(self, graph_mode="reuse"):
+        """Tear down NCCL and CustomAllreduce IPC.  No-op at TP=1."""
+        self._log(f"destroy_nccl(graph_mode={graph_mode})")
+        return self._send("destroy_nccl", graph_mode=graph_mode)
+
+    def cleargraph(self, graph_mode="reuse"):
+        """Drop CUDA-graph exec handles.  ``reuse`` preserves them."""
+        self._log(f"cleargraph(graph_mode={graph_mode})")
+        return self._send("cleargraph", graph_mode=graph_mode)
+
+    def recapture_graphs(self, graph_mode="reuse"):
+        """Rebind (``reuse``) or recapture (``full``) the decode graphs.
+
+        Run after ``wake_up_kv_cache``.  No-op at TP=1.
+        """
+        self._log(f"recapture_graphs(graph_mode={graph_mode})")
+        return self._send("recapture_graphs", graph_mode=graph_mode)
 
     def criu_dump(self, filename: str | None = None):
         """CRIU-dump the child process tree to disk (destructive).
@@ -375,7 +454,10 @@ class Instance:
             meta_extra={"vllm_config":      self.vllm_config,
                         "model_dir":        self.model_dir,
                         "total_gpu_bytes":  self.total_gpu_bytes,
-                        "pinned_cpu_bytes": self.pinned_cpu_bytes})
+                        "pinned_cpu_bytes": self.pinned_cpu_bytes,
+                        "n_gpus":           self.n_gpus,
+                        "max_pinned_bytes_per_worker":
+                            self.max_pinned_bytes_per_worker})
 
     def criu_restore(self, filename: str | None = None):
         """Restore a live process from a CRIU image on disk.
@@ -420,21 +502,57 @@ class Instance:
             self.total_gpu_bytes = int(meta.get("total_gpu_bytes", 0))
             self.pinned_cpu_bytes = int(meta.get(
                 "pinned_cpu_bytes", meta.get("pinned_bytes", 0)))
+            # TP size is authoritative from this instance's vllm_config
+            # (already equal to the image's, per the mismatch check above);
+            # meta["n_gpus"] is only a fallback for images predating
+            # config-wired TP.  Placement and the per-worker budget are
+            # hydrated from the image, with a legacy rank -> [rank] shim.
+            self.n_gpus = int(
+                self.vllm_config.get("tensor_parallel_size",
+                                     meta.get("n_gpus", 1)) or 1)
+            self.max_pinned_bytes_per_worker = int(
+                meta.get("max_pinned_bytes_per_worker", 0))
+            _meta_gpus = meta.get("gpus") or (
+                [meta["rank"]] if "rank" in meta else None)
+            if _meta_gpus:
+                self.gpus = list(_meta_gpus)
         self._log(f"criu_restore({filename})")
         self._image_dir = filename
         self._close_queues()
         self._ensure_queues()
         self._worker = _spawn_ctx.Process(
             target=worker_loop,
-            args=(self.instance_id, 0, self._cmd_queue, self._result_queue,
+            args=(self.instance_id, list(self.gpus) if self.gpus else [0],
+                  self._cmd_queue, self._result_queue,
                   self._completed_counter, self.model_dir),
         )
         self._worker.start()
         return self._send("criu_restore", filename=filename)
 
-    def cuda_restore(self, gpu: int):
-        self._log(f"cuda_restore(gpu={gpu})")
-        return self._send("cuda_restore", gpu=gpu)
+    def cuda_restore(self, gpu=None, gpus=None):
+        """Restore the checkpointed CUDA state onto the given physical GPU(s).
+
+        With neither argument, falls back to the placement hydrated from
+        ``meta.json``, so a restore can re-place the group on a different
+        physical GPU set.  The count is validated against
+        ``tensor_parallel_size``; TP size cannot change across a restore.
+        """
+        if gpus is None:
+            gpus = [gpu] if gpu is not None else list(self.gpus or [])
+        elif isinstance(gpus, int):
+            gpus = [gpus]
+        gpus = list(gpus)
+        if not gpus:
+            raise RuntimeError(
+                "cuda_restore requires a gpu/gpus (none given and no "
+                "placement recorded in the image)")
+        if len(gpus) != self.n_gpus:
+            raise RuntimeError(
+                f"cuda_restore: {len(gpus)} gpu(s) given ({gpus}) but "
+                f"tensor_parallel_size={self.n_gpus}")
+        self.gpus = gpus
+        self._log(f"cuda_restore(gpus={gpus})")
+        return self._send("cuda_restore", gpus=gpus)
 
     def stage(self):
         self._log("stage")
@@ -478,13 +596,19 @@ class Instance:
         """
         if max_buffer_bytes is not None:
             mb = int(max_buffer_bytes)
-        elif self.total_gpu_bytes <= 0 or self.pinned_cpu_bytes <= 0:
-            mb = None
         else:
-            util = self.vllm_config["gpu_memory_utilization"]
-            allotment = int(self.total_gpu_bytes * util)
-            mb = int(0.9 * min(self.pinned_cpu_bytes,
-                               allotment - self.pinned_cpu_bytes))
+            # At TP>1 the chunk budget is per-GPU, so use the largest
+            # per-worker staging shard, not the TP-aggregate
+            # ``pinned_cpu_bytes`` (which would overstate it ~N-fold and
+            # shrink chunks needlessly, or spuriously fail the
+            # "param exceeds chunk_size" check).
+            pinned = self.max_pinned_bytes_per_worker or self.pinned_cpu_bytes
+            if self.total_gpu_bytes <= 0 or pinned <= 0:
+                mb = None
+            else:
+                util = self.vllm_config["gpu_memory_utilization"]
+                allotment = int(self.total_gpu_bytes * util)
+                mb = int(0.9 * min(pinned, allotment - pinned))
         self._log(f"plan_restore_weights(max_buffer_bytes={mb})")
         return self._send("plan_restore_weights", max_buffer_bytes=mb)
 
@@ -576,8 +700,16 @@ class Instance:
         elif cmd == "attach":
             self.pinned_cpu_bytes = info.get(
                 "pinned_cpu_bytes", self.pinned_cpu_bytes)
+            self.max_pinned_bytes_per_worker = info.get(
+                "max_pinned_bytes_per_worker",
+                self.max_pinned_bytes_per_worker)
+        elif cmd == "plan_restore_weights":
+            self.max_pinned_bytes_per_worker = info.get(
+                "max_pinned_bytes_per_worker",
+                self.max_pinned_bytes_per_worker)
         elif cmd == "detach":
             self.pinned_cpu_bytes = 0
+            self.max_pinned_bytes_per_worker = 0
         elif cmd == "cuda_checkpoint":
             self.gpu = None
             self.log.set_gpu(None)
@@ -587,11 +719,20 @@ class Instance:
             self.state = "checkpointed"
         elif cmd == "criu_restore":
             self.pid = info.get("pid")
+            # Placement echo from the child; n_gpus stays config-authoritative.
+            _g = info.get("gpus")
+            if _g:
+                self.gpus = list(_g)
             self.gpu = None
             self.log.set_gpu(None)
             self.state = "checkpointed"
         elif cmd == "cuda_restore":
-            self.gpu = info.get("gpu", self.gpu)
+            gpus = info.get("gpus")
+            if gpus:
+                self.gpus = list(gpus)
+                self.gpu = gpus[0]
+            else:
+                self.gpu = info.get("gpu", self.gpu)
             self.log.set_gpu(self.gpu)
             self.state = "alive"
         elif cmd == "generate":

--- a/arctic_inference/semi_persistence/instance.py
+++ b/arctic_inference/semi_persistence/instance.py
@@ -652,6 +652,10 @@ class Instance:
         print(f"{bar}\n", flush=True)
         return self if self is not None else cls
 
+    # Chainable alias used by the scripts; reads better mid-chain than
+    # ``status`` and works both bound and unbound, as ``status`` does.
+    print_status = status
+
     @staticmethod
     def _print_instance(inst, pid_gpu_bytes):
         model = inst.vllm_config.get("model", "?")

--- a/arctic_inference/semi_persistence/instance.py
+++ b/arctic_inference/semi_persistence/instance.py
@@ -7,16 +7,23 @@ are non-blocking and return self for chaining.
 Instances can be saved to disk via CRIU after CUDA checkpoint, then
 restored (possibly on a different GPU):
 
-    inst.unpin().sleep().checkpoint_cuda().save_image(filename="/data-fast/ckpt/m").wait()
-    inst.restore_cuda(gpu=2).wake_up_weights().repin() \
+    inst.unpin().sleep().cuda_checkpoint().criu_dump(filename="/data-fast/ckpt/m").wait()
+    inst.cuda_restore(gpu=2).wake_up_weights().repin() \
         .plan_restore_weights().restore_weights().wake_up_kv_cache().wait()
 
-On a later run, load_image() restores from the on-disk image:
+On a later run, criu_restore() restores from the on-disk image:
 
     inst = Instance(vllm_config)
-    inst.load_image("/data-fast/ckpt/m").plan_restore_weights().wait()
-    inst.restore_cuda(gpu=0).wake_up_weights().repin() \
+    inst.criu_restore("/data-fast/ckpt/m").plan_restore_weights().wait()
+    inst.cuda_restore(gpu=0).wake_up_weights().repin() \
         .restore_weights().wake_up_kv_cache().wait()
+
+Passing ``model_dir`` instead lets the image path be implicit; it then
+defaults to ``<model_dir>/image`` and the filename argument can be
+omitted:
+
+    inst = Instance(vllm_config, "/data-fast/image-cache/qwen")
+    inst.unpin().sleep().cuda_checkpoint().criu_dump().wait()
 """
 from __future__ import annotations
 
@@ -64,9 +71,14 @@ class Instance:
 
     _all: weakref.WeakValueDictionary[int, "Instance"] = weakref.WeakValueDictionary()
 
-    def __init__(self, vllm_config: dict):
+    def __init__(self, vllm_config: dict, model_dir: str | None = None):
         self.gpu = None
         self.vllm_config = vllm_config
+        # Optional per-model directory.  When set, the image lives at
+        # ``<model_dir>/image`` and ``criu_dump`` / ``criu_restore`` can be
+        # called without a filename.  When unset, callers pass explicit
+        # paths (the orchestrator does).
+        self.model_dir = model_dir
         self.instance_id = _alloc_instance_id()
         Instance._all[self.instance_id] = self
         self.log = semip_logging.instance(self.instance_id, self.gpu)
@@ -184,6 +196,14 @@ class Instance:
         self._demuxer.notify_send(cmd)
         return self
 
+    def _resolve_image_dir(self, filename=None):
+        """Pick the image directory: explicit arg, then model_dir, then last used."""
+        if filename is not None:
+            return filename
+        if self.model_dir is not None:
+            return os.path.join(self.model_dir, "image")
+        return self._image_dir
+
     @property
     def _pending_count(self) -> int:
         """Number of cmds in flight; readers include the dashboard.
@@ -283,7 +303,7 @@ class Instance:
         ``(prompt_token_ids, output_token_ids_so_far,
         sampling_params, t0, first_token_ts)`` into a child-local
         list, then ``engine.abort_request(eids)`` so subsequent
-        ``unpin()`` / ``sleep()`` / ``checkpoint_cuda()`` are safe.
+        ``unpin()`` / ``sleep()`` / ``cuda_checkpoint()`` are safe.
         Pending ``generate_done`` messages are deferred until
         ``resume()`` re-adds the requests via prefill and drives them
         to completion.
@@ -310,38 +330,46 @@ class Instance:
         self._log("resume")
         return self._send("resume")
 
-    def checkpoint_cuda(self):
-        self._log("checkpoint_cuda")
-        return self._send("checkpoint_cuda")
+    def cuda_checkpoint(self):
+        self._log("cuda_checkpoint")
+        return self._send("cuda_checkpoint")
 
-    def save_image(self, filename: str):
+    def criu_dump(self, filename: str | None = None):
         """CRIU-dump the child process tree to disk (destructive).
 
-        Must be called after checkpoint_cuda() (GPU resources released).
+        Must be called after cuda_checkpoint() (GPU resources released).
         The child process is killed after a successful dump.  The
-        on-disk image is later restored via load_image().
+        on-disk image is later restored via criu_restore().
+
+        If filename is None, uses ``<model_dir>/image``.
         """
-        self._log(f"save_image({filename})")
+        filename = self._resolve_image_dir(filename)
+        if filename is None:
+            raise RuntimeError(
+                "criu_dump() requires a filename or a model_dir")
+        self._log(f"criu_dump({filename})")
         self._image_dir = filename
         return self._send(
-            "save_image", filename=filename,
+            "criu_dump", filename=filename,
             meta_extra={"vllm_config":      self.vllm_config,
                         "total_gpu_bytes":  self.total_gpu_bytes,
                         "pinned_cpu_bytes": self.pinned_cpu_bytes})
 
-    def load_image(self, filename: str | None = None):
+    def criu_restore(self, filename: str | None = None):
         """Restore a live process from a CRIU image on disk.
 
-        If filename is None, uses the image from the last save_image().
+        If filename is None, uses ``<model_dir>/image`` when a model_dir
+        was given, else the image from the last criu_dump().
         Validates that the image's vllm_config matches this instance's
         config (raises RuntimeError on mismatch).  Spawns a new worker
-        and CRIU-restores the child.  After load_image completes the
-        instance is in 'checkpointed' state, ready for restore_cuda(gpu).
+        and CRIU-restores the child.  After criu_restore completes the
+        instance is in 'checkpointed' state, ready for cuda_restore(gpu).
         """
+        filename = self._resolve_image_dir(filename)
         if filename is None:
-            filename = self._image_dir
-        if filename is None:
-            raise RuntimeError("load_image() requires a filename or prior save_image()")
+            raise RuntimeError(
+                "criu_restore() requires a filename, a model_dir, or a "
+                "prior criu_dump()")
         meta_path = os.path.join(filename, "meta.json")
         if os.path.isfile(meta_path):
             with open(meta_path) as f:
@@ -359,7 +387,7 @@ class Instance:
             self.total_gpu_bytes = int(meta.get("total_gpu_bytes", 0))
             self.pinned_cpu_bytes = int(meta.get(
                 "pinned_cpu_bytes", meta.get("pinned_bytes", 0)))
-        self._log(f"load_image({filename})")
+        self._log(f"criu_restore({filename})")
         self._image_dir = filename
         self._close_queues()
         self._ensure_queues()
@@ -369,11 +397,11 @@ class Instance:
                   self._completed_counter),
         )
         self._worker.start()
-        return self._send("load_image", filename=filename)
+        return self._send("criu_restore", filename=filename)
 
-    def restore_cuda(self, gpu: int):
-        self._log(f"restore_cuda(gpu={gpu})")
-        return self._send("restore_cuda", gpu=gpu)
+    def cuda_restore(self, gpu: int):
+        self._log(f"cuda_restore(gpu={gpu})")
+        return self._send("cuda_restore", gpu=gpu)
 
     def stage(self):
         self._log("stage")
@@ -471,19 +499,19 @@ class Instance:
                 "pinned_cpu_bytes", self.pinned_cpu_bytes)
         elif cmd == "detach":
             self.pinned_cpu_bytes = 0
-        elif cmd == "checkpoint_cuda":
+        elif cmd == "cuda_checkpoint":
             self.gpu = None
             self.log.set_gpu(None)
             self.state = "checkpointed"
-        elif cmd == "save_image":
+        elif cmd == "criu_dump":
             self._image_dir = info.get("image_dir", self._image_dir)
             self.state = "checkpointed"
-        elif cmd == "load_image":
+        elif cmd == "criu_restore":
             self.pid = info.get("pid")
             self.gpu = None
             self.log.set_gpu(None)
             self.state = "checkpointed"
-        elif cmd == "restore_cuda":
+        elif cmd == "cuda_restore":
             self.gpu = info.get("gpu", self.gpu)
             self.log.set_gpu(self.gpu)
             self.state = "alive"

--- a/arctic_inference/semi_persistence/instance.py
+++ b/arctic_inference/semi_persistence/instance.py
@@ -280,10 +280,14 @@ class Instance:
         self.total_gpu_bytes = int(pynvml.nvmlDeviceGetMemoryInfo(h).total)
         self._log("init")
         self._ensure_queues()
+        # model_dir threads through to the vLLM child so it points its
+        # compile cache at <model_dir>/compilation (embedding the JIT/compile
+        # artifacts next to the image, whose recorded mmap paths must resolve
+        # at restore).
         self._worker = _spawn_ctx.Process(
             target=worker_loop,
             args=(self.instance_id, gpu, self._cmd_queue, self._result_queue,
-                  self._completed_counter),
+                  self._completed_counter, self.model_dir),
         )
         self._worker.start()
         return self._send("init", vllm_config=self.vllm_config)
@@ -369,6 +373,7 @@ class Instance:
         return self._send(
             "criu_dump", filename=filename,
             meta_extra={"vllm_config":      self.vllm_config,
+                        "model_dir":        self.model_dir,
                         "total_gpu_bytes":  self.total_gpu_bytes,
                         "pinned_cpu_bytes": self.pinned_cpu_bytes})
 
@@ -396,6 +401,17 @@ class Instance:
                 raise RuntimeError(
                     f"vllm_config mismatch: instance has {self.vllm_config} "
                     f"but image at {filename} was saved with {saved_config}")
+            # CRIU records the compile-cache .so/cubin mmaps by absolute
+            # path, so an image is bound to the model_dir it was dumped
+            # with; restoring under a different one leaves those mappings
+            # unresolvable ("Can't open file ...").
+            saved_model_dir = meta.get("model_dir")
+            if saved_model_dir and saved_model_dir != self.model_dir:
+                raise RuntimeError(
+                    f"model_dir mismatch: instance has {self.model_dir} but "
+                    f"image at {filename} was dumped with {saved_model_dir}; "
+                    f"the image bakes absolute compile-cache paths, so it "
+                    f"must be restored under the same model_dir")
             # Hydrate budget inputs from meta.json; the child holds the
             # real pinned buffer that survived CRIU.  Old images without
             # ``total_gpu_bytes`` degrade to single-chunk behavior in
@@ -411,7 +427,7 @@ class Instance:
         self._worker = _spawn_ctx.Process(
             target=worker_loop,
             args=(self.instance_id, 0, self._cmd_queue, self._result_queue,
-                  self._completed_counter),
+                  self._completed_counter, self.model_dir),
         )
         self._worker.start()
         return self._send("criu_restore", filename=filename)

--- a/arctic_inference/semi_persistence/instance.py
+++ b/arctic_inference/semi_persistence/instance.py
@@ -341,6 +341,10 @@ class Instance:
         return self._send("attach")
 
     def attach_pinned(self):
+        """Not supported on the worker-local staging path; the child raises.
+
+        Use ``attach()`` followed by ``repin()`` instead.
+        """
         self._log("attach_pinned")
         return self._send("attach_pinned")
 

--- a/arctic_inference/semi_persistence/instance.py
+++ b/arctic_inference/semi_persistence/instance.py
@@ -103,6 +103,7 @@ class Instance:
         self.pinned_cpu_bytes = 0
         self.total_gpu_bytes = 0
         self._image_dir = None
+        self._weights_dir = None
 
         self._cmd_queue = None
         self._result_queue = None
@@ -203,6 +204,22 @@ class Instance:
         if self.model_dir is not None:
             return os.path.join(self.model_dir, "image")
         return self._image_dir
+
+    def _resolve_weights_dir(self, weights_dir=None):
+        """Pick the weights directory: explicit arg, then model_dir, then
+        a ``weights`` sibling of the image directory.
+
+        The sibling fallback keeps ``save_weights`` usable for callers that
+        pass explicit image paths (the orchestrator) rather than a model_dir.
+        """
+        if weights_dir is not None:
+            return weights_dir
+        if self.model_dir is not None:
+            return os.path.join(self.model_dir, "weights")
+        if self._image_dir is not None:
+            return os.path.join(os.path.dirname(self._image_dir.rstrip("/")),
+                                "weights")
+        return None
 
     @property
     def _pending_count(self) -> int:
@@ -415,11 +432,20 @@ class Instance:
         self._log("wake_up_kv_cache")
         return self._send("wake_up_kv_cache")
 
-    def plan_restore_weights(self):
+    def plan_restore_weights(self, max_buffer_bytes=None):
         """Precompute the chunk plan that the next restore_weights() will consume.
 
-        Self-computes the staging budget from instance state populated by
-        ``init`` (cold start) or by ``load`` reading meta.json (restore):
+        If ``max_buffer_bytes`` is given, it is passed through verbatim as
+        the staging-buffer cap.  Use this to force small chunks when
+        restoring an image whose checkpointed ``restore_weights`` does not
+        release the staging buffer back to the CUDA driver before the KV
+        cache is mapped (older images lack the ``torch.cuda.empty_cache()``
+        fix): a small staging buffer stays negligible even if it lingers in
+        torch's caching allocator, leaving room for ``wake_up_kv_cache``.
+
+        Otherwise self-computes the staging budget from instance state
+        populated by ``init`` (cold start) or by ``criu_restore`` reading
+        meta.json (restore):
 
             allotment = self.total_gpu_bytes * gpu_memory_utilization
             budget    = min(self.pinned_cpu_bytes,
@@ -434,7 +460,9 @@ class Instance:
         ``max_buffer_bytes=None`` to the child, yielding the single-chunk
         fallback (today's behavior).
         """
-        if self.total_gpu_bytes <= 0 or self.pinned_cpu_bytes <= 0:
+        if max_buffer_bytes is not None:
+            mb = int(max_buffer_bytes)
+        elif self.total_gpu_bytes <= 0 or self.pinned_cpu_bytes <= 0:
             mb = None
         else:
             util = self.vllm_config["gpu_memory_utilization"]
@@ -461,6 +489,41 @@ class Instance:
         """
         self._log("restore_weights")
         return self._send("restore_weights")
+
+    def save_weights(self, shard_bytes=None, io_workers=None,
+                     weights_dir=None):
+        """Write the staged pinned buffer to <model_dir>/weights/ as shards.
+
+        Call after ``stage()`` (buffer populated) and before ``detach()``,
+        so ``criu_dump()`` runs against a detached (tiny) process image.
+        ``shard_bytes`` / ``io_workers`` override the child defaults
+        (``None`` leaves the child default in place).
+        """
+        weights_dir = self._resolve_weights_dir(weights_dir)
+        if weights_dir is None:
+            raise RuntimeError(
+                "save_weights() requires a weights_dir, a model_dir, or a "
+                "prior criu_dump()")
+        self._weights_dir = weights_dir
+        self._log(f"save_weights({weights_dir})")
+        return self._send("save_weights", weights_dir=weights_dir,
+                          shard_bytes=shard_bytes, io_workers=io_workers)
+
+    def load_weights(self, io_workers=None, weights_dir=None):
+        """Read <model_dir>/weights/ shards back into the pinned buffer.
+
+        Requires a prior ``attach()`` on the restore side (rebuilds the
+        index and allocates the buffer).  Feeds ``restore_weights()``.
+        """
+        weights_dir = self._resolve_weights_dir(weights_dir)
+        if weights_dir is None:
+            raise RuntimeError(
+                "load_weights() requires a weights_dir, a model_dir, or a "
+                "prior criu_restore()")
+        self._weights_dir = weights_dir
+        self._log(f"load_weights({weights_dir})")
+        return self._send("load_weights", weights_dir=weights_dir,
+                          io_workers=io_workers)
 
     def generate(self, prompts, sampling_params):
         self._log(f"generate({len(prompts)} prompts)")

--- a/arctic_inference/semi_persistence/orchestrator.py
+++ b/arctic_inference/semi_persistence/orchestrator.py
@@ -78,7 +78,7 @@ class _CmdAck(threading.Event):
 class WorkerCmdFailed(RuntimeError):
     """Raised by ``_send_cmd_with_ack`` when the child process reports
     a failure for a non-generate command (e.g. ``wake_up_kv_cache``
-    OOM, ``restore_cuda`` failure, ``repin`` failure).
+    OOM, ``cuda_restore`` failure, ``repin`` failure).
 
     Distinct from a generic ``RuntimeError`` so the pipeline can
     distinguish "engine state is now inconsistent, fail every
@@ -472,7 +472,7 @@ class Orchestrator(OrchestratorBase):
 
         Raises ``ValueError`` if *gpu* is not visible to NVML.  Allowing
         a non-existent index into the pool is unrecoverable: the slot
-        allocator will eventually hand it out, ``restore_cuda(gpu=N)``
+        allocator will eventually hand it out, ``cuda_restore(gpu=N)``
         will crash inside ``_build_restore_args`` (out-of-range UUID
         lookup), and the dependent ``repin`` already pipelined to the
         vLLM child will deadlock the instance.  Fail loudly here
@@ -801,15 +801,15 @@ class Orchestrator(OrchestratorBase):
                 # listeners before any cmd is sent so their callbacks
                 # are live for the very first ack.  The demuxer is
                 # created lazily in _ensure_queues (driven by
-                # load_image below); add_cmd_listener buffers
+                # criu_restore below); add_cmd_listener buffers
                 # registrations until then.
                 Orchestrator._install_listeners(model_id, inst)
                 # load() reads meta.json and hydrates total_gpu_bytes /
                 # pinned_cpu_bytes on the instance; plan_restore_weights
                 # uses those to build the chunk plan in the child once.
-                inst.load_image(entry["image_dir"]).plan_restore_weights().wait()
+                inst.criu_restore(entry["image_dir"]).plan_restore_weights().wait()
                 # Mirror onto the registry entry to keep registry-as-truth
-                # even though Instance.load_image already set self.* from meta.
+                # even though Instance.criu_restore already set self.* from meta.
                 inst.pinned_cpu_bytes = entry.get("pinned_cpu_bytes", 0)
                 inst.total_gpu_bytes = entry.get("total_gpu_bytes", 0)
                 entry["instance"] = inst
@@ -852,7 +852,7 @@ class Orchestrator(OrchestratorBase):
             # so it doesn't invert against the demuxer's generate
             # listener, which takes gen_lock first and then the
             # model lock.
-            Orchestrator._send_cmd_with_ack(model_id, "restore_cuda", gpu)
+            Orchestrator._send_cmd_with_ack(model_id, "cuda_restore", gpu)
             Orchestrator._send_cmd_with_ack(model_id, "repin")
             with Orchestrator._locks_ordered(model_id):
                 Orchestrator._set_state(model_id, "sleep")
@@ -893,12 +893,12 @@ class Orchestrator(OrchestratorBase):
                         # model_lock -> gen_lock inversion against
                         # the demuxer's generate listener.
                         Orchestrator._send_cmd_with_ack(model_id, "unpin")
-                        Orchestrator._send_cmd_with_ack(model_id, "checkpoint_cuda")
+                        Orchestrator._send_cmd_with_ack(model_id, "cuda_checkpoint")
                         with Orchestrator._locks_ordered(model_id):
                             entry["gpu"] = None
                             Orchestrator._set_state(model_id, "checkpoint")
                         Orchestrator._send_cmd_with_ack(
-                            model_id, "restore_cuda", slot.gpu_id)
+                            model_id, "cuda_restore", slot.gpu_id)
                         Orchestrator._send_cmd_with_ack(model_id, "repin")
                         with Orchestrator._locks_ordered(model_id):
                             entry["gpu"] = slot.gpu_id
@@ -1172,7 +1172,7 @@ class Orchestrator(OrchestratorBase):
 
         if from_state == "sleep" and to_state == "checkpoint":
             Orchestrator._send_cmd_with_ack(model_id, "unpin")
-            Orchestrator._send_cmd_with_ack(model_id, "checkpoint_cuda")
+            Orchestrator._send_cmd_with_ack(model_id, "cuda_checkpoint")
             with Orchestrator._locks_ordered(model_id):
                 if entry.get("slot") is not None:
                     Slots.deallocate(entry["slot"])
@@ -1303,7 +1303,7 @@ class Orchestrator(OrchestratorBase):
                 # the q_rec stays at ``state="waiting"`` / ``t_done=None``
                 # forever and the dashboard's ``wait_s`` counter ticks
                 # up indefinitely -- a Phase-1 failure (e.g.
-                # ``WorkerCmdFailed`` from ``restore_cuda`` OOM while
+                # ``WorkerCmdFailed`` from ``cuda_restore`` OOM while
                 # walking checkpoint->sleep) never reaches the Phase-2
                 # ``q_rec["state"] = "generating"`` assignment and is
                 # not in ``_inflight``, so ``_on_generate_done`` /

--- a/arctic_inference/semi_persistence/pipeline.py
+++ b/arctic_inference/semi_persistence/pipeline.py
@@ -52,8 +52,8 @@ announce_state=None)``:
   ``entry["pinned_cpu_bytes"]``, ``entry["total_gpu_bytes"]``.
 * **Calls**: ``Orchestrator._set_state``, ``_locks_ordered``,
   ``_install_listeners`` (saved -> checkpoint),
-  ``_send_cmd_with_ack`` (every cmd: ``restore_cuda``, ``repin``,
-  ``unpin``, ``checkpoint_cuda``, ``wake_up_weights``,
+  ``_send_cmd_with_ack`` (every cmd: ``cuda_restore``, ``repin``,
+  ``unpin``, ``cuda_checkpoint``, ``wake_up_weights``,
   ``restore_weights``, ``wake_up_kv_cache``),
   ``_evict_for_phase2`` (Phase-2 HBM eviction; replaced by
   ``EvictForPeerOp`` cross-pipeline submit when ``_use_pipeline``),
@@ -71,7 +71,7 @@ announce_state=None)``:
   (set to None on sleep -> checkpoint), ``entry["instance"]`` (set to
   None on checkpoint -> saved).
 * **Calls**: ``Orchestrator._set_state``, ``_locks_ordered``,
-  ``_send_cmd_with_ack`` (``sleep``, ``unpin``, ``checkpoint_cuda``).
+  ``_send_cmd_with_ack`` (``sleep``, ``unpin``, ``cuda_checkpoint``).
 * **Touches**: ``Slots.deallocate(slot)``,
   ``entry["instance"].teardown().wait().remove()`` (checkpoint -> saved).
 
@@ -675,8 +675,8 @@ class RegisterOp(Op):
         ``entry["slot"]``).
       - ``Instance(vllm_config)`` cold-start sequence:
         ``init(gpu).attach().repin().stage().unpin().sleep()
-        .checkpoint_cuda().wait()``, then
-        ``save_image(image_dir).wait()``, then ``_send("exit")`` +
+        .cuda_checkpoint().wait()``, then
+        ``criu_dump(image_dir).wait()``, then ``_send("exit")`` +
         ``_reset()``.
 
     Preserves fixes for: none (cold-start has no Known Issues entry --
@@ -738,8 +738,8 @@ class RegisterOp(Op):
         entry["state_since"] = _time.perf_counter()
 
         with orch._locks_ordered(mid):
-            inst.init(gpu).attach().repin().stage().unpin().sleep().checkpoint_cuda().wait()
-            inst.save_image(image_dir).wait()
+            inst.init(gpu).attach().repin().stage().unpin().sleep().cuda_checkpoint().wait()
+            inst.criu_dump(image_dir).wait()
             log.info("%s: image saved to %s", mid, image_dir)
 
             inst._send("exit")
@@ -953,7 +953,7 @@ class EvictForPeerOp(Op):
         the old branch returned early on ``entry["paused"]`` but the
         acquirer's Phase-2 loop did ``remaining -= share`` anyway, so
         the acquirer believed the HBM was freed and OOM'd inside
-        ``restore_cuda`` (CUresult=2).  Now we walk the paused peer
+        ``cuda_restore`` (CUresult=2).  Now we walk the paused peer
         down to ``sleep`` like any other incumbent.  This is safe by
         construction: the vllm_child ``sleep`` handler explicitly
         documents the invariant "while ``_paused`` is True,
@@ -981,7 +981,7 @@ class EvictForPeerOp(Op):
         been walked from ``up`` to ``checkpoint`` by an unrelated op
         (a client ``move(checkpoint)``, a parallel eviction from a
         different acquirer, etc.).  Sending ``sleep`` to a worker
-        whose vllm_child has been ``checkpoint_cuda``'d (CUDA context
+        whose vllm_child has been ``cuda_checkpoint``'d (CUDA context
         CRIU-frozen) drives vLLM's ``sleep`` handler into
         ``torch.cuda.synchronize(0)`` -> ``cuCtxSynchronize`` ->
         **segfault**, killing the vllm_child and wedging the entire

--- a/arctic_inference/semi_persistence/reproduce/README.md
+++ b/arctic_inference/semi_persistence/reproduce/README.md
@@ -1,0 +1,19 @@
+# reproduce
+
+`example_full.py` walks each model through a cold start, then the `saved -> up`
+trip (sleep, CUDA checkpoint, CRIU dump/restore, NCCL reinit, weight restore,
+graph recapture). It covers TP1 / TP2 / TP4 / TP8.
+
+Must run as **root** (CRIU and `cuda-checkpoint`). From this package directory:
+
+```bash
+python ./reproduce/example_full.py                 # all models
+python ./reproduce/example_full.py Qwen3.5-2B-tp1  # one label
+```
+
+Weights are read from `/data-fast/hf_models/<org>/<name>` when that path exists,
+otherwise from Hugging Face. Images go under
+`/data-fast/image-cache/reproduce_example_full/<label>`.
+
+Each model prints per-primitive seconds after `saved -> up`. The same numbers
+are printed again under `== times ==` at the end of the run.

--- a/arctic_inference/semi_persistence/reproduce/example_full.py
+++ b/arctic_inference/semi_persistence/reproduce/example_full.py
@@ -9,7 +9,6 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 os.environ.setdefault("NCCL_NVLS_ENABLE", "0")
 os.environ.setdefault("VLLM_ALLREDUCE_USE_SYMM_MEM", "0")
-os.environ.setdefault("FLASHINFER_CACHE_DIR", f"/tmp/flashinfer-uid{os.geteuid()}")
 
 from instance import Instance
 

--- a/arctic_inference/semi_persistence/reproduce/example_full.py
+++ b/arctic_inference/semi_persistence/reproduce/example_full.py
@@ -5,7 +5,7 @@ import shutil
 import sys
 import time
 
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 os.environ.setdefault("NCCL_NVLS_ENABLE", "0")
 os.environ.setdefault("VLLM_ALLREDUCE_USE_SYMM_MEM", "0")
@@ -128,6 +128,7 @@ def run_one(label, model_id, tp, util, gpus, extra):
           flush=True)
     print("  times:", {k: round(v, 3) for k, v in times.items()}, flush=True)
     cleanup(inst)
+    return times
 
 
 def main():
@@ -140,16 +141,22 @@ def main():
     specs = [s for s in MODEL_SPECS if not want or s[0] in want]
 
     failed = []
+    recap = []
     for spec in specs:
         t0 = time.time()
         try:
-            run_one(*spec)
+            times = run_one(*spec)
+            recap.append((spec[0], times))
             print(f"[{spec[0]}] OK in {time.time() - t0:.0f}s", flush=True)
         except Exception as e:
             failed.append(spec[0])
             short = str(e).split("\n", 1)[0][:120]
             print(f"[{spec[0]}] FAILED after {time.time() - t0:.0f}s: "
                   f"{type(e).__name__}: {short}", flush=True)
+    print("\n== times ==", flush=True)
+    for label, times in recap:
+        print(f"  {label}: { {k: round(v, 3) for k, v in times.items()} }",
+              flush=True)
     print(f"\ndone: {len(specs) - len(failed)}/{len(specs)} ok", flush=True)
     print("== run finished ==", flush=True)
     sys.exit(1 if failed else 0)

--- a/arctic_inference/semi_persistence/scripts/imgdiff.py
+++ b/arctic_inference/semi_persistence/scripts/imgdiff.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Check a CRIU image's file-backed mappings against the local filesystem.
+
+    sudo python3 scripts/imgdiff.py /data-fast/image-cache/qwen_27b/image
+
+Use this before attempting a cross-node restore.  CRIU records every
+file-backed mapping by absolute path *and* size and re-validates the size
+when it reopens the file (criu/files-reg.c: "File %s has bad size %"), so
+one mapped file of a different length aborts the whole restore.  There is
+no up-front check for this the way there is for ``vllm_config`` and
+``model_dir``, and CRIU stops at the first bad mapping rather than
+reporting them all -- hence this script.  See *Cross-node restore also
+needs a byte-identical environment* in ``skills/semi-p_DESIGN.md``.
+
+CRIU compares only the size, so this also compares the ELF build-ID CRIU
+recorded: a same-size but different-build library would pass CRIU's check
+and then map the wrong text pages into the restored process.
+
+Unlike everything else in ``scripts/``, this needs no GPU, no vLLM and no
+``sys.path`` bootstrap -- it imports nothing from the package.  It does
+need ``crit`` (from the CRIU install) and root to read the image.
+
+Observed files.img JSON shape (crit 4.2.1):
+  { "magic": "FILES",
+    "entries": [
+      { "type": "REG", "id": 1,
+        "reg": { "id": 1, "flags": "", "pos": 0, "fown": {...},
+                 "name": "/abs/path", "size": 30598912, "mode": 33261,
+                 "build_id": [4064338300, 3061931570, ...] } },
+      { "type": "MEMFD", "id": 2, "memfd": {...} },
+      ...
+    ] }
+The payload lives under a key equal to lowercase(type).  "size" is optional
+(absent for /dev/null, append-mode logs and directories).  "build_id" is
+optional and is an array of little-endian uint32 words.
+
+Files that were unlinked at dump time are carried inside the image itself as
+"ghost" files (remap-fpath.img -> remap_type GHOST, contents in
+ghost-file-*.img).  CRIU recreates those at restore, so they are reported
+separately and never counted as something to sync.
+"""
+
+import json
+import os
+import stat
+import struct
+import subprocess
+import sys
+from collections import defaultdict
+
+S_IFMT = 0o170000
+S_IFREG = 0o100000
+PT_NOTE = 4
+NT_GNU_BUILD_ID = 3
+
+
+def decode_files_img(path):
+    cmd = ["crit", "decode", "-i", path]
+    if os.geteuid() != 0:
+        cmd = ["sudo", "-n"] + cmd
+    res = subprocess.run(cmd, capture_output=True)
+    if res.returncode != 0:
+        sys.exit("crit decode failed (rc=%d):\n%s"
+                 % (res.returncode, res.stderr.decode("utf-8", "replace")))
+    return json.loads(res.stdout.decode("utf-8", "replace"))
+
+
+def ghost_ids(img_path):
+    """Ids remapped to a GHOST file: CRIU recreates these, do not sync them."""
+    remap = os.path.join(os.path.dirname(img_path), "remap-fpath.img")
+    if not os.path.exists(remap):
+        return set()
+    cmd = ["crit", "decode", "-i", remap]
+    if os.geteuid() != 0:
+        cmd = ["sudo", "-n"] + cmd
+    res = subprocess.run(cmd, capture_output=True)
+    if res.returncode != 0:
+        return set()
+    doc = json.loads(res.stdout.decode("utf-8", "replace"))
+    return {e["orig_id"] for e in doc.get("entries", [])
+            if e.get("remap_type") == "GHOST" and "orig_id" in e}
+
+
+def reg_entries(doc):
+    """Yield the 'reg' payload of every REG entry carrying a name and a size."""
+    for ent in doc.get("entries", []):
+        etype = ent.get("type")
+        if etype != "REG":
+            continue
+        payload = ent.get(etype.lower())
+        if not isinstance(payload, dict):
+            continue
+        if "name" not in payload or "size" not in payload:
+            continue
+        # Only real regular files are size-checked by CRIU.
+        mode = payload.get("mode")
+        if mode is not None and (mode & S_IFMT) != S_IFREG:
+            continue
+        yield payload
+
+
+def abspath(name):
+    """CRIU stores names rooted at the mount; normalise to an absolute path."""
+    if not name.startswith("/"):
+        name = "/" + name
+    return os.path.normpath(name)
+
+
+def image_build_id(reg):
+    words = reg.get("build_id")
+    if not words:
+        return None
+    return b"".join(struct.pack("<I", w & 0xFFFFFFFF) for w in words).hex()
+
+
+def local_build_id(path):
+    """Read NT_GNU_BUILD_ID out of the local ELF, or None if unavailable."""
+    try:
+        with open(path, "rb") as fh:
+            hdr = fh.read(64)
+            if len(hdr) < 64 or hdr[:4] != b"\x7fELF":
+                return None
+            is64 = hdr[4] == 2
+            little = hdr[5] == 1
+            end = "<" if little else ">"
+            if is64:
+                phoff = struct.unpack_from(end + "Q", hdr, 0x20)[0]
+                phentsize = struct.unpack_from(end + "H", hdr, 0x36)[0]
+                phnum = struct.unpack_from(end + "H", hdr, 0x38)[0]
+            else:
+                phoff = struct.unpack_from(end + "I", hdr, 0x1C)[0]
+                phentsize = struct.unpack_from(end + "H", hdr, 0x2A)[0]
+                phnum = struct.unpack_from(end + "H", hdr, 0x2C)[0]
+            if not phoff or not phnum:
+                return None
+            fh.seek(phoff)
+            phdrs = fh.read(phentsize * phnum)
+            for i in range(phnum):
+                ph = phdrs[i * phentsize:(i + 1) * phentsize]
+                if len(ph) < phentsize:
+                    break
+                ptype = struct.unpack_from(end + "I", ph, 0)[0]
+                if ptype != PT_NOTE:
+                    continue
+                if is64:
+                    off = struct.unpack_from(end + "Q", ph, 0x08)[0]
+                    fsz = struct.unpack_from(end + "Q", ph, 0x20)[0]
+                else:
+                    off = struct.unpack_from(end + "I", ph, 0x04)[0]
+                    fsz = struct.unpack_from(end + "I", ph, 0x10)[0]
+                fh.seek(off)
+                notes = fh.read(fsz)
+                pos = 0
+                while pos + 12 <= len(notes):
+                    namesz, descsz, ntype = struct.unpack_from(end + "III", notes, pos)
+                    pos += 12
+                    name = notes[pos:pos + namesz]
+                    pos += (namesz + 3) & ~3
+                    desc = notes[pos:pos + descsz]
+                    pos += (descsz + 3) & ~3
+                    if ntype == NT_GNU_BUILD_ID and name.rstrip(b"\x00") == b"GNU":
+                        return desc.hex()
+    except OSError:
+        return None
+    return None
+
+
+def classify(path, expected):
+    try:
+        st = os.stat(path)           # follow symlinks: CRIU opens the target
+    except FileNotFoundError:
+        return "ABSENT", None, None
+    except NotADirectoryError:
+        return "ABSENT", None, None
+    except OSError as exc:
+        return "UNREADABLE", None, str(exc)
+    if not stat.S_ISREG(st.st_mode):
+        return "NOT-A-REGULAR-FILE", st.st_size, None
+    if st.st_size != expected:
+        return "SIZE MISMATCH", st.st_size, None
+    return "OK", st.st_size, None
+
+
+def tree_roots(paths, depth=2):
+    roots = set()
+    for p in paths:
+        parts = [c for c in p.split("/") if c]
+        roots.add("/" + "/".join(parts[:depth]) if parts else "/")
+    return sorted(roots)
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit("usage: imgdiff.py <image-dir-or-files.img>")
+    target = sys.argv[1]
+    img = target if target.endswith(".img") else os.path.join(target, "files.img")
+
+    print("=" * 78)
+    print("CRIU image: %s" % img)
+    print("=" * 78)
+
+    doc = decode_files_img(img)
+    ghosts = ghost_ids(img)
+    type_counts = defaultdict(int)
+    for ent in doc.get("entries", []):
+        type_counts[ent.get("type")] += 1
+    print("total entries in files.img : %d" % len(doc.get("entries", [])))
+    print("entry types                : %s"
+          % ", ".join("%s=%d" % (k, v) for k, v in sorted(type_counts.items())))
+
+    results = []
+    seen = set()
+    bid_mismatch = []
+    bid_checked = 0
+    ghost_rows = []
+    for reg in reg_entries(doc):
+        path = abspath(reg["name"])
+        expected = reg["size"]
+        if (path, expected) in seen:
+            continue
+        seen.add((path, expected))
+        if reg.get("id") in ghosts:
+            ghost_rows.append((path, expected))
+            continue
+        status, local, err = classify(path, expected)
+        results.append((status, path, expected, local, err))
+        # Content check for files that passed the size check.
+        want_bid = image_build_id(reg)
+        if status == "OK" and want_bid:
+            got_bid = local_build_id(path)
+            if got_bid is not None:
+                bid_checked += 1
+                if got_bid != want_bid:
+                    bid_mismatch.append((path, want_bid, got_bid))
+
+    checked = len(results)
+    print("regular-file mappings with a recorded size (deduped): %d" % checked)
+    print("of those, ELF build-IDs verifiable and compared      : %d" % bid_checked)
+    print()
+
+    if ghost_rows:
+        print("-" * 78)
+        print("GHOST files carried inside the image (CRIU recreates, DO NOT sync)  (%d)"
+              % len(ghost_rows))
+        print("-" * 78)
+        for path, expected in sorted(ghost_rows):
+            print("  %s  (%d bytes, contents stored in ghost-file-*.img)" % (path, expected))
+        print()
+
+    buckets = defaultdict(list)
+    for r in results:
+        buckets[r[0]].append(r)
+
+    bad_paths = []
+    for status in ("SIZE MISMATCH", "ABSENT", "NOT-A-REGULAR-FILE", "UNREADABLE"):
+        rows = sorted(buckets.get(status, []), key=lambda r: r[1])
+        if not rows:
+            continue
+        print("-" * 78)
+        print("%s  (%d)" % (status, len(rows)))
+        print("-" * 78)
+        for _, path, expected, local, err in rows:
+            bad_paths.append(path)
+            if status == "ABSENT":
+                print("  %s\n      image expects %d bytes, local: MISSING" % (path, expected))
+            elif status == "UNREADABLE":
+                print("  %s\n      image expects %d bytes, local: %s" % (path, expected, err))
+            else:
+                print("  %s\n      image expects %d bytes, local %d bytes (delta %+d)"
+                      % (path, expected, local, local - expected))
+        print()
+
+    if bid_mismatch:
+        print("-" * 78)
+        print("BUILD-ID MISMATCH (size matches, contents differ)  (%d)" % len(bid_mismatch))
+        print("-" * 78)
+        for path, want, got in sorted(bid_mismatch):
+            bad_paths.append(path)
+            print("  %s\n      image build-id %s\n      local build-id %s" % (path, want, got))
+        print()
+
+    print("=" * 78)
+    print("SUMMARY for %s" % img)
+    print("=" * 78)
+    print("  OK                 : %d" % (len(buckets.get("OK", [])) - len(bid_mismatch)))
+    print("  SIZE MISMATCH      : %d" % len(buckets.get("SIZE MISMATCH", [])))
+    print("  ABSENT             : %d" % len(buckets.get("ABSENT", [])))
+    print("  BUILD-ID MISMATCH  : %d" % len(bid_mismatch))
+    print("  NOT-A-REGULAR-FILE : %d" % len(buckets.get("NOT-A-REGULAR-FILE", [])))
+    print("  UNREADABLE         : %d" % len(buckets.get("UNREADABLE", [])))
+    print("  GHOST (in-image)   : %d  [not a problem]" % len(ghost_rows))
+    print("  ------------------------")
+    print("  TOTAL CHECKED      : %d" % checked)
+    print("  TOTAL PROBLEMS     : %d" % len(bad_paths))
+    print()
+
+    if bad_paths:
+        print("Distinct top-level trees needing sync from the dump node:")
+        for root in tree_roots(bad_paths, depth=2):
+            n = sum(1 for p in bad_paths if p.startswith(root + "/"))
+            print("  %-50s (%d file(s))" % (root, n))
+        print()
+        print("Distinct parent directories of affected files:")
+        for d in sorted({os.path.dirname(p) for p in bad_paths}):
+            n = sum(1 for p in bad_paths if os.path.dirname(p) == d)
+            print("  %-70s (%d)" % (d, n))
+        print()
+    else:
+        print("No problems found: every recorded mapping matches this node.")
+
+
+if __name__ == "__main__":
+    main()

--- a/arctic_inference/semi_persistence/scripts/main_test.py
+++ b/arctic_inference/semi_persistence/scripts/main_test.py
@@ -15,8 +15,8 @@ def main():
 
     Instance.print_status()
 
-    instance_1.init(gpu=0).attach().sleep()
-    instance_2.init(gpu=1).attach().sleep()
+    instance_1.init(gpu=0).attach().repin().stage().unpin().sleep()
+    instance_2.init(gpu=1).attach().repin().stage().unpin().sleep()
 
     instance_1.wait()
     instance_2.wait()
@@ -32,7 +32,8 @@ def main():
 
     # -- Create instance 3 on GPU 0 after instance 1 finishes -----------------
 
-    instance_3.after(instance_1).init(gpu=0).attach().sleep()
+    instance_1.wait()
+    instance_3.init(gpu=0).attach().repin().stage().unpin().sleep()
 
     instance_3.wait()
     instance_2.wait()
@@ -52,18 +53,18 @@ def main():
     # -- Restore instance 1 and 2 ---------------------------------------------
 
     instance_1.cuda_restore(gpu=0)
-    instance_1.wake_up(["weights"])
-    instance_1.stage("/data-fast/Qwen/Qwen3-1.7B")
+    instance_1.wake_up_weights()
+    instance_1.repin()
     instance_1.restore_weights()
     instance_1.detach()
-    instance_1.wake_up(["kv_cache"])
+    instance_1.wake_up_kv_cache()
 
     instance_2.cuda_restore(gpu=1)
-    instance_2.wake_up(["weights"])
-    instance_2.stage("/data-fast/nvidia/Llama-3.1-70B-Instruct-FP8")
+    instance_2.wake_up_weights()
+    instance_2.repin()
     instance_2.restore_weights()
     instance_2.detach()
-    instance_2.wake_up(["kv_cache"])
+    instance_2.wake_up_kv_cache()
 
     instance_1.wait()
     instance_2.wait()
@@ -76,13 +77,13 @@ def main():
 
     instance_1.sleep().cuda_checkpoint()
 
-    instance_3.after(instance_1)
+    instance_1.wait()
     instance_3.cuda_restore(gpu=0)
-    instance_3.wake_up(["weights"])
-    instance_3.stage("/data-fast/Qwen/Qwen3-32B")
+    instance_3.wake_up_weights()
+    instance_3.repin()
     instance_3.restore_weights()
     instance_3.detach()
-    instance_3.wake_up(["kv_cache"])
+    instance_3.wake_up_kv_cache()
     instance_3.wait()
 
     #    GPU 0     GPU 1
@@ -99,16 +100,18 @@ def main():
 
     instance_2.sleep().detach().cuda_checkpoint()
 
-    instance_4.after(instance_2).init(gpu=1).attach()
-    instance_5.after(instance_4).init(gpu=1).attach()
+    instance_2.wait()
+    instance_4.init(gpu=1).attach().repin().stage().unpin()
+    instance_4.wait()
+    instance_5.init(gpu=1).attach().repin().stage().unpin()
     instance_4.sleep().cuda_checkpoint()
     instance_5.sleep().cuda_checkpoint()
     instance_4.wait()
     instance_5.wait()
 
     # Restore instance 4 and 5 on the same GPU
-    instance_4.cuda_restore(gpu=1).wake_up(["weights"]).stage("/data-fast/Qwen/Qwen2.5-7B").restore_weights().detach().wake_up(["kv_cache"])
-    instance_5.cuda_restore(gpu=1).wake_up(["weights"]).stage("/data-fast/Qwen/Qwen3-1.7B").restore_weights().detach().wake_up(["kv_cache"])
+    instance_4.cuda_restore(gpu=1).wake_up_weights().repin().restore_weights().detach().wake_up_kv_cache()
+    instance_5.cuda_restore(gpu=1).wake_up_weights().repin().restore_weights().detach().wake_up_kv_cache()
 
     instance_4.wait()
     instance_5.wait()

--- a/arctic_inference/semi_persistence/scripts/main_test.py
+++ b/arctic_inference/semi_persistence/scripts/main_test.py
@@ -23,8 +23,8 @@ def main():
 
     Instance.print_status()
 
-    instance_1.checkpoint_cuda()
-    instance_2.checkpoint_cuda()
+    instance_1.cuda_checkpoint()
+    instance_2.cuda_checkpoint()
     instance_1.wait()
     instance_2.wait()
 
@@ -39,7 +39,7 @@ def main():
 
     Instance.print_status()
 
-    instance_3.checkpoint_cuda()
+    instance_3.cuda_checkpoint()
     instance_3.wait()
 
     Instance.print_status()
@@ -51,14 +51,14 @@ def main():
 
     # -- Restore instance 1 and 2 ---------------------------------------------
 
-    instance_1.restore_cuda(gpu=0)
+    instance_1.cuda_restore(gpu=0)
     instance_1.wake_up(["weights"])
     instance_1.stage("/data-fast/Qwen/Qwen3-1.7B")
     instance_1.restore_weights()
     instance_1.detach()
     instance_1.wake_up(["kv_cache"])
 
-    instance_2.restore_cuda(gpu=1)
+    instance_2.cuda_restore(gpu=1)
     instance_2.wake_up(["weights"])
     instance_2.stage("/data-fast/nvidia/Llama-3.1-70B-Instruct-FP8")
     instance_2.restore_weights()
@@ -74,10 +74,10 @@ def main():
 
     # -- Swap active model on GPU 0: hibernate 1, restore 3 -------------------
 
-    instance_1.sleep().checkpoint_cuda()
+    instance_1.sleep().cuda_checkpoint()
 
     instance_3.after(instance_1)
-    instance_3.restore_cuda(gpu=0)
+    instance_3.cuda_restore(gpu=0)
     instance_3.wake_up(["weights"])
     instance_3.stage("/data-fast/Qwen/Qwen3-32B")
     instance_3.restore_weights()
@@ -97,18 +97,18 @@ def main():
     instance_4 = Instance(vllm_config_4)
     instance_5 = Instance(vllm_config_5)
 
-    instance_2.sleep().detach().checkpoint_cuda()
+    instance_2.sleep().detach().cuda_checkpoint()
 
     instance_4.after(instance_2).init(gpu=1).attach()
     instance_5.after(instance_4).init(gpu=1).attach()
-    instance_4.sleep().checkpoint_cuda()
-    instance_5.sleep().checkpoint_cuda()
+    instance_4.sleep().cuda_checkpoint()
+    instance_5.sleep().cuda_checkpoint()
     instance_4.wait()
     instance_5.wait()
 
     # Restore instance 4 and 5 on the same GPU
-    instance_4.restore_cuda(gpu=1).wake_up(["weights"]).stage("/data-fast/Qwen/Qwen2.5-7B").restore_weights().detach().wake_up(["kv_cache"])
-    instance_5.restore_cuda(gpu=1).wake_up(["weights"]).stage("/data-fast/Qwen/Qwen3-1.7B").restore_weights().detach().wake_up(["kv_cache"])
+    instance_4.cuda_restore(gpu=1).wake_up(["weights"]).stage("/data-fast/Qwen/Qwen2.5-7B").restore_weights().detach().wake_up(["kv_cache"])
+    instance_5.cuda_restore(gpu=1).wake_up(["weights"]).stage("/data-fast/Qwen/Qwen3-1.7B").restore_weights().detach().wake_up(["kv_cache"])
 
     instance_4.wait()
     instance_5.wait()

--- a/arctic_inference/semi_persistence/scripts/test_copy.py
+++ b/arctic_inference/semi_persistence/scripts/test_copy.py
@@ -53,19 +53,19 @@ def main():
     # inst.stage()
     # inst.unpin()
     # inst.sleep()
-    # inst.checkpoint_cuda()
-    # inst.save_image(IMAGE)
+    # inst.cuda_checkpoint()
+    # inst.criu_dump(IMAGE)
     # inst.wait()
 
     def run_one(i, config, image):
         inst = Instance(config)
-        inst.load_image(image)
+        inst.criu_restore(image)
 
         level = 1 if config["gpu_memory_utilization"] > 0.5 else 2
         slot = Slots.allocate(level)
         Slots.status()
 
-        inst.restore_cuda(gpu=slot.gpu_id)
+        inst.cuda_restore(gpu=slot.gpu_id)
         inst.wake_up_weights()
         inst.repin()
         inst.restore_weights()

--- a/arctic_inference/semi_persistence/scripts/test_env.py
+++ b/arctic_inference/semi_persistence/scripts/test_env.py
@@ -8,7 +8,7 @@ Exercises the per-model env-var path end to end:
 2. Reserved keys in ``_env`` (``CUDA_VISIBLE_DEVICES``,
    ``VLLM_ENABLE_V1_MULTIPROCESSING``, ``USE_LIBUV``) do *not* override
    the values the child sets at the top of ``vllm_child_loop``.
-3. The on-disk ``meta.json`` from ``save_image`` preserves ``_env`` in
+3. The on-disk ``meta.json`` from ``criu_dump`` preserves ``_env`` in
    the persisted ``vllm_config`` so the orchestrator can rediscover it
    on reboot and client-side dedup stays honest.
 
@@ -99,8 +99,8 @@ def main() -> None:
     assert "SEMIP_PROBE_VAR" in env_a and env_a["SEMIP_PROBE_VAR"] != env_b["SEMIP_PROBE_VAR"]
 
     image_dir = os.path.join(IMAGE_ROOT, "model_a")
-    inst_a.attach().repin().stage().unpin().sleep().checkpoint_cuda()
-    inst_a.save_image(image_dir).wait()
+    inst_a.attach().repin().stage().unpin().sleep().cuda_checkpoint()
+    inst_a.criu_dump(image_dir).wait()
 
     with open(os.path.join(image_dir, "meta.json")) as f:
         meta = json.load(f)

--- a/arctic_inference/semi_persistence/scripts/test_image.py
+++ b/arctic_inference/semi_persistence/scripts/test_image.py
@@ -11,7 +11,7 @@ def main():
 
     if cache_hit:
         print(f"[test] cache HIT — loading from {IMAGE_CACHE}")
-        inst.load_image(IMAGE_CACHE).wait().print_status()
+        inst.criu_restore(IMAGE_CACHE).wait().print_status()
     else:
         print(f"[test] cache MISS — cold-starting on gpu=0, saving image")
         inst.init(gpu=2).wait().print_status()
@@ -20,11 +20,11 @@ def main():
         inst.stage().wait().print_status()
         inst.unpin().wait().print_status()
         inst.sleep().wait().print_status()
-        inst.checkpoint_cuda().wait().print_status()
-        inst.save_image(IMAGE_CACHE).wait().print_status()
+        inst.cuda_checkpoint().wait().print_status()
+        inst.criu_dump(IMAGE_CACHE).wait().print_status()
         print(f"[test] image saved — continuing with same instance")
 
-    inst.restore_cuda(gpu=3).wait().print_status()
+    inst.cuda_restore(gpu=3).wait().print_status()
     inst.wake_up_weights().wait().print_status()
     inst.repin().wait().print_status()
     inst.restore_weights().wait().print_status()
@@ -32,7 +32,7 @@ def main():
     inst.generate(["Hello, world!"],{}).wait().print_status()
     inst.unpin().wait().print_status()
     inst.sleep().wait().print_status()
-    inst.checkpoint_cuda().wait().print_status()
+    inst.cuda_checkpoint().wait().print_status()
 
     inst.teardown().wait().remove()
 

--- a/arctic_inference/semi_persistence/scripts/test_tp2.py
+++ b/arctic_inference/semi_persistence/scripts/test_tp2.py
@@ -1,0 +1,79 @@
+"""Tensor-parallel (TP=2 + expert parallel) save/restore with GPU migration.
+
+Exercises the TP>1 primitives on a MoE model: the cold start captures on
+one pair of GPUs, and the restore places the group on a different pair.
+
+The TP-specific steps are the only difference from the single-GPU flow in
+``test_weights.py``:
+
+  * ``cuda_checkpoint()`` auto-inserts ``cleargraph`` + ``destroy_nccl``
+    when tensor_parallel_size > 1, so the caller does not.
+  * ``reinit_nccl()`` must run immediately after ``cuda_restore`` and
+    before any collective (attach, weight restore, graph replay).
+  * ``recapture_graphs("reuse")`` runs after ``wake_up_kv_cache`` and
+    rebinds the preserved decode graphs' baked addresses.
+
+TP size comes from the vLLM config; the ``gpus`` argument is placement
+only and must have exactly tensor_parallel_size entries.
+
+Run twice: the first run cold-starts and saves, the second restores.
+"""
+import os
+
+from arctic_inference.semi_persistence import Instance
+
+# TP2 + EP
+config_qwen_35b = {"model": "Qwen/Qwen3.6-35B-A3B", "gpu_memory_utilization": 0.7,
+                   "tensor_parallel_size": 2, "enable_expert_parallel": True}
+
+MODEL_DIR = "/data-fast/image-cache/tp2test"
+
+conversation = ["Write an essay about the importance of higher education."]
+sampling_params = {"temperature": 0.0, "max_tokens": 800}
+
+
+def init(inst: Instance, gpus):
+    inst.init(gpus=gpus)
+    inst.generate(conversation, sampling_params)
+    inst.attach()
+    inst.stage()
+    inst.save_weights()
+    inst.detach()
+    inst.sleep()
+    inst.cuda_checkpoint()  # TP>1: cleargraph + destroy_nccl inside
+    inst.criu_dump()  # destroys the instance
+
+
+def load_(inst: Instance, gpus):
+    inst.criu_restore()
+    inst.attach()
+    inst.load_weights()
+    inst.cuda_restore(gpus=gpus)
+    inst.reinit_nccl()  # TP>1: rebuild NCCL after CRIU
+    inst.wake_up_weights()
+    inst.repin()
+    inst.restore_weights()
+    inst.wake_up_kv_cache()
+    inst.recapture_graphs("reuse")  # TP>1: rebind preserved graphs
+    inst.generate(conversation, sampling_params)
+
+
+def main():
+    inst1 = Instance(config_qwen_35b, os.path.join(MODEL_DIR, "qwen_35b"))
+    cache_hit = os.path.isfile(
+        os.path.join(MODEL_DIR, "qwen_35b", "image", "meta.json"))
+
+    if cache_hit:
+        print("[test] cache HIT — loading from image")
+        load_(inst1, [0, 1])   # migrate onto 0,1 if the image was dumped elsewhere
+    else:
+        print("[test] cache MISS — cold-starting, saving image")
+        init(inst1, [2, 3])
+
+    print("[test] waiting for instances to finish")
+    inst1.wait()
+    inst1.teardown()
+
+
+if __name__ == "__main__":
+    main()

--- a/arctic_inference/semi_persistence/scripts/test_tp2.py
+++ b/arctic_inference/semi_persistence/scripts/test_tp2.py
@@ -8,8 +8,10 @@ The TP-specific steps are the only difference from the single-GPU flow in
 
   * ``cuda_checkpoint()`` auto-inserts ``cleargraph`` + ``destroy_nccl``
     when tensor_parallel_size > 1, so the caller does not.
-  * ``reinit_nccl()`` must run immediately after ``cuda_restore`` and
-    before any collective (attach, weight restore, graph replay).
+  * ``reinit_nccl()`` must run after ``cuda_restore``, and before anything
+    that runs the model or replays a captured graph (``recapture_graphs``,
+    ``generate``).  ``attach`` and ``load_weights`` are CPU-only per rank,
+    so they are not constrained by it and run first below.
   * ``recapture_graphs("reuse")`` runs after ``wake_up_kv_cache`` and
     rebinds the preserved decode graphs' baked addresses.
 

--- a/arctic_inference/semi_persistence/scripts/test_weights.py
+++ b/arctic_inference/semi_persistence/scripts/test_weights.py
@@ -1,0 +1,77 @@
+"""Save/restore with the weights kept outside the CRIU image.
+
+Contrast with ``test_image.py``, which leaves the staged weights inside
+the image: here ``save_weights()`` writes them to ``<model_dir>/weights``
+and ``detach()`` frees the pinned buffer before the dump, so the image
+stays small.  The restore side rebuilds the buffer with ``attach()`` and
+refills it with ``load_weights()``.
+
+Two models are driven concurrently to exercise parallel dump/restore.
+Run twice: the first run cold-starts and saves, the second restores.
+"""
+import os
+
+from arctic_inference.semi_persistence import Instance
+
+config_qwen_27b = {"model": "Qwen/Qwen3.8-27B", "gpu_memory_utilization": 0.7, "max_num_seqs": 512}
+config_qwen_35b = {"model": "Qwen/Qwen3.6-35B-A3B", "gpu_memory_utilization": 0.7}
+MODEL_DIR = "/data-fast/image-cache"
+
+conversation = ["Write an essay about the importance of higher education."]
+sampling_params = {"temperature": 0.0, "max_tokens": 800}
+
+
+def init(inst: Instance, gpu=0):
+    inst.init(gpu=gpu)
+    inst.generate(conversation, sampling_params)
+    inst.attach()
+    inst.stage()
+    inst.save_weights()
+    inst.detach()
+    inst.sleep()
+    inst.cuda_checkpoint()
+    inst.criu_dump()  # destroys the instance
+
+
+def load(inst: Instance, gpu=0):
+    inst.criu_restore()
+    inst.cuda_restore(gpu=gpu)
+    inst.attach()
+    inst.load_weights()
+    inst.wake_up_weights()
+    inst.repin()
+    # Force a small (4 GiB) weight-restore staging buffer.  This image was
+    # dumped before the empty_cache() fix, so its checkpointed
+    # restore_weights leaves the staging buffer in torch's caching allocator
+    # (not returned to the driver); a large chunk would then starve
+    # wake_up_kv_cache and OOM.  A small chunk stays negligible.
+    inst.plan_restore_weights(max_buffer_bytes=4 * 1024**3)
+    inst.restore_weights()
+    inst.wake_up_kv_cache()
+    inst.generate(conversation, sampling_params)
+
+
+def main():
+    inst1 = Instance(config_qwen_27b, os.path.join(MODEL_DIR, "qwen_27b"))
+    inst2 = Instance(config_qwen_35b, os.path.join(MODEL_DIR, "qwen_35b"))
+    cache_hit = (
+        os.path.isfile(os.path.join(MODEL_DIR, "qwen_27b", "image", "meta.json"))
+        and os.path.isfile(os.path.join(MODEL_DIR, "qwen_35b", "image", "meta.json"))
+    )
+
+    if cache_hit:
+        print("[test] cache HIT — loading from image")
+        load(inst1, 5)
+        load(inst2, 6)
+    else:
+        print("[test] cache MISS — cold-starting, saving image")
+        init(inst1, 2)
+        init(inst2, 3)
+        print("[test] image saved")
+
+    inst1.wait()
+    inst2.wait()
+
+
+if __name__ == "__main__":
+    main()

--- a/arctic_inference/semi_persistence/skills/CRIU_PLUMBING.md
+++ b/arctic_inference/semi_persistence/skills/CRIU_PLUMBING.md
@@ -295,8 +295,19 @@ CRIU from loading plugins (the CUDA plugin is loaded separately by the
 CRIU CUDA infrastructure).  If the directory does not exist, CRIU
 aborts at plugin initialization and the dump fails.
 
-**Fix:** Ensure `/usr/lib/criu/empty` exists (an empty directory).
-The CRIU PPA package does not create it automatically.
+```
+Error (criu/plugin.c:228): Unable to open directory /usr/lib/criu/empty: No such file or directory
+```
+
+**Fix:** `_worker_criu_save` creates the directory before every dump —
+`os.makedirs`, falling back to `sudo mkdir -p` when the worker is not
+root, since it lives under `/usr/lib`.  Neither the PPA package nor the
+source build creates it, and it is easier to make than to require of
+every node.  The `mkdir` in [`INSTALL.md`](INSTALL.md) is therefore
+optional now.
+
+Dump-only: no restore path passes `--libdir`, and nothing here is
+TP-dependent — the same argv serves TP=1 and TP>1.
 
 ---
 
@@ -660,7 +671,7 @@ leave `TIME_WAIT` behind.
 | stdout/stderr      | File size changes between dump/load | Redirect to /dev/null              | `--inherit-fd fd[1]/fd[2]`           |
 | Pipe FD            | sudo closes FDs >= 3                | —                                  | SCM_RIGHTS via Unix socket           |
 | CUDA context       | GPU state not in CRIU image         | CRIU CUDA plugin at dump           | Driver API or cuda-checkpoint        |
-| Plugin directory   | `--libdir` path missing             | Create `/usr/lib/criu/empty`       | —                                    |
+| Plugin directory   | `--libdir` path missing             | `_worker_criu_save` creates `/usr/lib/criu/empty` before each dump | —                    |
 | stdin / tty        | pts captured as `--shell-job`; can't reattach in a PID ns | fd 0 → `/dev/null` + `setsid()` at child start | drop `--shell-job` |
 | PID collisions     | Zombie from the destructive dump holds the recorded PID | — | Restore each tree in its own PID namespace (reaper + private /proc); retry loop as backstop |
 | Privileged-only CRIU | dump + restore need `CAP_SYS_ADMIN` (netns kerndat probe; restore PID namespace) | `--unprivileged` (`SEMIP_UNPRIVILEGED=1`) skips the netns probe; caps shed in the child before `import torch` | lowcap path: `criu restore -d --unprivileged` in the host PID ns (no `unshare`), tree-kill teardown |

--- a/arctic_inference/semi_persistence/skills/CRIU_PLUMBING.md
+++ b/arctic_inference/semi_persistence/skills/CRIU_PLUMBING.md
@@ -573,23 +573,49 @@ conda install under `$HOME` is not.
 `criu` itself is never implicated: it lives at `/usr/sbin/criu`
 (`-rwxr-xr-x`) and runs in the worker, which keeps its capabilities.
 
-**Only cold start is affected; restoring a pre-existing image is not.**
-This asymmetry is worth internalising, because it makes the bug look
-intermittent:
+**`criu_restore` itself is safe; what runs after it is not.**  The
+restore maps an already-initialised process back into memory, so the
+child resumes in-memory code, imports nothing, and performs no
+DAC-checked read.  The file reads the restore *does* need (reopening
+every file-backed mapping) are done by `criu` in the worker, which keeps
+its capabilities -- only the child ever drops.
 
-- `init` spawns a fresh interpreter, so the child runs Python's import
-  machinery -- which is exactly where the drop fires and exactly what
-  breaks next.
-- `criu_restore` maps an already-initialised process back into memory.
-  The restored child resumes in-memory code and imports nothing, so it
-  never performs a DAC-checked read and zero capabilities cost it
-  nothing.  The file reads the restore *does* need (reopening every
-  file-backed mapping) are done by `criu` in the worker, which keeps its
-  capabilities -- only the child ever drops.
+That makes `init` the obvious victim: it spawns a fresh interpreter, so
+the child runs Python's import machinery, which is exactly where the drop
+fires.  But **any post-restore primitive that spawns a process or imports
+a not-yet-loaded module hits the same wall**, and at TP>1 `reinit_nccl`
+does:
 
-So an image dumped before the precondition was met will keep restoring
-happily, and the failure only reappears the next time something
-cold-starts.
+```
+_reinit_nccl -> init_worker_distributed_environment
+             -> init_distributed_environment -> _node_count
+             -> in_the_same_node_as        (vllm/distributed/parallel_state.py)
+             -> shared_memory.SharedMemory(create=True)
+             -> multiprocessing.resource_tracker.ensure_running()   # spawns python
+```
+
+The tracker spawn cannot read its own stdlib, dies, and the write to its
+pipe fails with `BrokenPipeError: [Errno 32] Broken pipe`.
+
+**The symptom is a silent hang, not an error.**  vLLM wraps that block in
+`contextlib.suppress(OSError)`, and `BrokenPipeError` *is* an `OSError`,
+so nothing is logged at all -- not even the `Error ignored in
+is_in_the_same_node` line, which only fires for non-`OSError`.  The
+source rank skips its `broadcast_object_list` and proceeds to the
+`barrier()` a few lines below, while every other rank waits forever in
+the matching broadcast.  `py-spy dump` on the workers shows the two ranks
+stopped at *different* lines of `in_the_same_node_as`, which is the
+signature.  All you see in the log is `reinit_nccl` never returning and
+vLLM repeating:
+
+```
+No available shared memory broadcast block found in 60 seconds.
+```
+
+So the precondition is not cold-start-only: an image dumped before it was
+met keeps *restoring* fine and then deadlocks in `reinit_nccl`.  The fix
+is the same (`chmod o+x` the home, or a world-readable interpreter
+prefix) and needs no re-dump, since nothing about the image is wrong.
 
 ---
 

--- a/arctic_inference/semi_persistence/skills/CRIU_PLUMBING.md
+++ b/arctic_inference/semi_persistence/skills/CRIU_PLUMBING.md
@@ -81,7 +81,7 @@ target; everything else is `os.close()`'d:
 | `/dev/nvidia*`          | preserved — CUDA driver fds; restored by CRIU CUDA plugin  |
 | `/dev/shm/*`            | preserved — POSIX shm, including pinned host buffers       |
 | `anon_inode:*`          | preserved — eventfd, epoll, **and io_uring** (rings munmap'd separately) |
-| `socket:[…]`            | preserved — worker tags unix sockets `--external unix[ino]`; TCP gets `--tcp-close` |
+| `socket:[…]`            | preserved — worker tags unix sockets `--external unix[ino]`; TCP gets `--tcp-close` plus `SO_LINGER(1,0)` (Complication 12) |
 | `pipe:[…]`              | preserved                                                  |
 | Everything else         | closed (regular files, Triton `.so` opens, log files, etc.) |
 
@@ -125,6 +125,11 @@ blocked on network I/O.
 Then poll `/proc/<pid>/task/` until the store threads exit (up to 2.5s).
 The TCPStore thread sometimes lingers — the dump proceeds with a
 warning, and CRIU handles the remaining thread via `--tcp-close`.
+
+`--tcp-close` covers the *connections*, not the ports they occupied:
+CRIU rebinds each recorded local port before closing it, so the sockets
+that survive into the image also need `SO_LINGER(1,0)` at dump time.  See
+Complication 12.
 
 ---
 
@@ -208,6 +213,13 @@ Failed because the sudoers policy doesn't permit `-C`.
 2. A background thread accepts and sends the pipe FD via `SCM_RIGHTS`
 3. A Python helper script runs under `sudo`, connects to the socket,
    receives the FD, `dup2`s it into place, then `execvp`s `criu restore`
+
+`sudo` is skipped when the worker is already root (`_is_root`), which
+avoids leaving a long-lived `sudo` between the worker and the reaper —
+it holds the terminal for the life of the namespace and leaves the tty
+in a bad state when teardown SIGKILLs it.  The `SCM_RIGHTS` dance stays
+either way: `subprocess` closes FDs >= 3 in the child regardless of
+`sudo`.
 
 ---
 
@@ -570,11 +582,79 @@ cold-starts.
 
 ---
 
+## Complication 12: `TIME_WAIT` vs the Recorded Local Port
+
+**Problem:** CRIU records every inet socket's exact local port and
+**rebinds it** at restore, *before* `--tcp-close` gets to close it.  The
+dump is destructive, so every socket still open at dump time closes with
+a FIN when the tree is killed and leaves its tuple in `TIME_WAIT` on the
+host.  A restore that follows its own dump immediately then collides
+with those tuples:
+
+```
+Error (criu/sk-inet.c): Can't bind inet socket (id 0x…): Address already in use
+```
+
+The bind cannot step over the tuple because CRIU restores `SO_REUSEADDR`
+from the recorded value rather than forcing it on.  Decode an image to
+see which sockets are exposed:
+
+```bash
+sudo crit decode -i <image_dir>/files.img --pretty \
+  | jq -c '.entries[] | select(.type=="INETSK") | .isk
+           | {state, src_port, reuseaddr: .opts.reuseaddr}'
+```
+
+Listeners — and the sockets accepted from them, which inherit the option
+— carry `reuseaddr: true` and rebind fine.  The client-side connected
+sockets carry `reuseaddr: false`, and those are the ones that fail.
+
+**Deterministic at TP2+, a race at TP1.**  Every rank adds a TCPStore
+connection, so at TP>1 there is always a colliding tuple.  A TP1 image
+still contains such sockets (the store's self-connection, plus whatever
+HTTPS connections the child left open), so TP1 is exposed too — it just
+usually wins the race.
+
+**Fix (dump side): `SO_LINGER(1,0)` before the NCCL teardown.**
+`_mark_inet_sockets_rst` (`vllm_child.py`) walks the worker's
+`/proc/<pid>/fd` and, for every `AF_INET`/`AF_INET6` `SOCK_STREAM`
+socket, sets `SO_LINGER` with `l_onoff=1, l_linger=0` so the eventual
+close sends an **RST** instead of a FIN and the tuple never enters
+`TIME_WAIT`.  It runs at the top of `_destroy_nccl`, before anything is
+closed, and it marks through a `dup()` so the wrapper's `close()`
+releases only the duplicate: the live fd stays open for CRIU, and
+because the option lives on the shared socket the RST fires whenever
+teardown or CRIU's kill finally closes it.  `AF_UNIX` and non-stream
+sockets are left alone.
+
+**Time-bound, not image-bound — no re-dump needed.**  `TIME_WAIT` is
+`TCP_TIMEWAIT_LEN` (60s, hard-coded in the kernel; `tcp_fin_timeout` is
+a different timer), so the window closes a minute after the dump that
+opened it.  Unlike Complications 10 and 11, **images dumped before this
+change do not need re-dumping** — they restore fine once the window has
+drained, which is exactly why the failure looks like it needs a
+cooldown.
+
+What a fresh dump does buy: CRIU stores the option in the image
+(`SkOptsEntry.so_linger`) and replays it at restore, so a tree restored
+from a new image also RSTs on its own teardown.  That keeps back-to-back
+`criu_restore` → teardown → `criu_restore` cycles on one node clean,
+where an old image re-blocks its ports on every teardown.
+
+**Not covered (known, benign today):** the marking sits after the
+`tp_size <= 1` early return in `_destroy_nccl`, so TP1 is never marked;
+and `_destroy_nccl` is a `collective_rpc` target, so only the workers
+are walked — the child's own sockets (e.g. leftover HTTPS connections to
+the model hub, bound to the routable IP rather than loopback) still
+leave `TIME_WAIT` behind.
+
+---
+
 ## Summary Table
 
 | Resource           | Problem at dump time               | Dump-side fix                      | Restore-side fix                     |
 |--------------------|-------------------------------------|------------------------------------|--------------------------------------|
-| NCCL/TCPStore      | Background threads, TCP sockets     | `destroy_process_group()` + poll   | `--tcp-close`                        |
+| NCCL/TCPStore      | Background threads, TCP sockets; the tree-kill's FINs park the recorded local ports in `TIME_WAIT` | `destroy_process_group()` + poll; `SO_LINGER(1,0)` on every inet TCP socket so the kill RSTs instead | `--tcp-close` — but it closes only *after* the rebind, so it is not sufficient alone |
 | io_uring           | Non-serializable kernel state       | Munmap rings (FDs kept via keep-list) | —                                 |
 | POSIX semaphores   | `(deleted)` files → ghost/link remap| Delete sem files; captured as anon | —                                    |
 | stdout/stderr      | File size changes between dump/load | Redirect to /dev/null              | `--inherit-fd fd[1]/fd[2]`           |

--- a/arctic_inference/semi_persistence/skills/CRIU_PLUMBING.md
+++ b/arctic_inference/semi_persistence/skills/CRIU_PLUMBING.md
@@ -536,8 +536,19 @@ namei -l "$(python -c 'import sys; print(sys.base_prefix)')"
 and fix by granting traversal (`chmod o+x /home/<user>`, which permits
 path traversal without allowing directory listing) or by using an
 interpreter under a world-readable prefix such as `/usr/lib/python3.12`.
-Internal does not hit this because it runs the system python from
-`/usr/local/lib/python3.12`.
+
+The operative variable is *where the interpreter lives*, not how it was
+installed.  A pre-baked pod image that ships vLLM, CRIU and Python
+system-wide satisfies this for free -- `/usr/lib/python3.12` and
+`/usr/local/lib/python3.12/dist-packages` are `drwxr-xr-x`, so dropping
+capabilities changes nothing that process could already read.  That is
+why the mode appears to "just work" on such an image and then fails on a
+development pod where the same code runs from a venv on a private home.
+A venv built on `/usr/bin/python3` is equally fine; a venv built on a
+conda install under `$HOME` is not.
+
+`criu` itself is never implicated: it lives at `/usr/sbin/criu`
+(`-rwxr-xr-x`) and runs in the worker, which keeps its capabilities.
 
 **Only cold start is affected; restoring a pre-existing image is not.**
 This asymmetry is worth internalising, because it makes the bug look

--- a/arctic_inference/semi_persistence/skills/CRIU_PLUMBING.md
+++ b/arctic_inference/semi_persistence/skills/CRIU_PLUMBING.md
@@ -424,6 +424,80 @@ PID-namespace restore. **Images captured before this change (with a tty /
 
 ---
 
+## Complication 11: Unprivileged Dump + Restore (`SEMIP_UNPRIVILEGED`)
+
+**Problem:** the default dump and restore paths need `CAP_SYS_ADMIN` in
+two places, so they only run on privileged pods:
+
+1. CRIU's kerndat init builds a throwaway *network* namespace to probe
+   kernel features; creating a netns needs `CAP_SYS_ADMIN`. Without it
+   criu aborts with "Could not initialize kernel features detection" --
+   on **both** dump and restore.
+2. The restore path additionally wraps criu in a private PID namespace
+   (Complication 10): `unshare(CLONE_NEWPID|CLONE_NEWNS)` + a private
+   `/proc` mount, which also needs `CAP_SYS_ADMIN`.
+
+Production pods are non-privileged: they grant only
+`CAP_CHECKPOINT_RESTORE + CAP_SYS_PTRACE`, never `CAP_SYS_ADMIN`.
+
+**Fix: `SEMIP_UNPRIVILEGED=1` -- one flag for both sides.**
+
+- **Dump** (`_worker_criu_save`): append `--unprivileged`, which makes
+  CRIU skip the netns kerndat probe. The dump has no namespace machinery
+  of its own, so this one flag is the only change it needs; seizing the
+  target still uses `CAP_SYS_PTRACE`.
+- **Restore**: take `_worker_criu_load_lowcap` instead of
+  `_worker_criu_load`. It runs `criu restore -d --unprivileged`
+  **directly in the host PID namespace** -- no `unshare`, no reaper, no
+  private `/proc`. The recorded PID is therefore the host PID, so
+  `--pidfile` is authoritative (with a pipe-scan fallback), and teardown
+  SIGKILLs the restored tree directly (holder
+  `{"kind": "tree", "pid": host_pid}`) rather than collapsing a namespace.
+
+Why the asymmetry (a flag on dump, a whole function on restore): the dump
+had only dependency (1); the restore had (1) **and** (2), and (2) lives
+in the sudo'd wrapper *around* criu, so it cannot be undone by a criu
+flag -- it needs a different, wrapper-free restore procedure.
+
+Because `-d` makes criu exit with the restore rc, the sudo process's exit
+code *is* criu's rc, so this path needs none of the `reaper.pid` /
+`restore.rc` side-channel files the namespace path uses. Its stdout and
+stderr must go to `/dev/null` rather than pipes: with `-d` the restored
+process inherits fd 1/2 and holds them open after criu exits, so a pipe
+would never EOF and draining it would deadlock.
+
+**Capability floor:** `CAP_CHECKPOINT_RESTORE + CAP_SYS_PTRACE`, no
+`CAP_SYS_ADMIN`. `clone3(set_tid)` at the recorded PIDs in the host PID
+namespace is authorized by `CAP_CHECKPOINT_RESTORE`, so it does not need
+to write the read-only `ns_last_pid` sysctl. Validate a node with
+`sudo criu check --unprivileged` (a residual read-only `ns_last_pid`
+complaint from the checker is expected and does not block restore).
+
+**Trade-off (accepted):** without the private PID namespace the recorded
+PIDs must be free on the host -- at most **one live restore per node**.
+Fine for a one-job-per-pod layout. A collision surfaces as CRIU
+"File exists" in `restore.log`, which the existing retry loop recognizes.
+Note this makes `scripts/test_weights.py`, which restores two models
+concurrently, incompatible with this mode.
+
+**Restorable image requires shed capabilities.** CRIU's `restore_creds()`
+calls `capset()` to reinstate each task's recorded caps; if the image
+recorded caps the low-cap node can't grant, restore fails at
+`criu/pie/restorer.c` ("Unable to restore capabilities"). So in
+unprivileged mode the vLLM child zeroes its caps *before* `import torch`
+-- torch and vLLM spawn many background threads and CRIU records
+credentials **per thread**, so dropping first is what makes every task
+record an empty cap set. This is **implied by `SEMIP_UNPRIVILEGED=1`**,
+not a separate flag: the worker sets an internal
+`_SEMIP_CHILD_DROP_CAPS` signal only across the child's spawn, because
+the worker itself must keep its caps to run `sudo criu`.
+
+Consequently **image portability is decided at dump time**: an image
+dumped without the flag records real caps and cannot be restored on a
+low-cap node without re-dumping.
+
+---
+
 ## Summary Table
 
 | Resource           | Problem at dump time               | Dump-side fix                      | Restore-side fix                     |
@@ -437,6 +511,7 @@ PID-namespace restore. **Images captured before this change (with a tty /
 | Plugin directory   | `--libdir` path missing             | Create `/usr/lib/criu/empty`       | —                                    |
 | stdin / tty        | pts captured as `--shell-job`; can't reattach in a PID ns | fd 0 → `/dev/null` + `setsid()` at child start | drop `--shell-job` |
 | PID collisions     | Zombie from the destructive dump holds the recorded PID | — | Restore each tree in its own PID namespace (reaper + private /proc); retry loop as backstop |
+| Privileged-only CRIU | dump + restore need `CAP_SYS_ADMIN` (netns kerndat probe; restore PID namespace) | `--unprivileged` (`SEMIP_UNPRIVILEGED=1`) skips the netns probe; caps shed in the child before `import torch` | lowcap path: `criu restore -d --unprivileged` in the host PID ns (no `unshare`), tree-kill teardown |
 | Ghost remap race   | `(deleted)` .so → ghost race        | Destructive dump + sem deletion    | `--link-remap`                       |
 
 ---

--- a/arctic_inference/semi_persistence/skills/CRIU_PLUMBING.md
+++ b/arctic_inference/semi_persistence/skills/CRIU_PLUMBING.md
@@ -496,6 +496,67 @@ Consequently **image portability is decided at dump time**: an image
 dumped without the flag records real caps and cannot be restored on a
 low-cap node without re-dumping.
 
+### Precondition: everything the child reads must be world-accessible
+
+The worker tree runs as root, and root bypasses file permission checks
+via `CAP_DAC_OVERRIDE`.  Zeroing the capabilities takes that away while
+leaving uid 0 in place, so from that instant the child can only read what
+is reachable by *other* -- every directory on the path needs `o+x`, and
+the files need `o+r`.
+
+If the interpreter itself lives behind a private directory, the child
+dies immediately after the drop, and the symptom does not look like a
+permission problem.  `multiprocessing` spawn runs `spawn_main` ->
+`_main` -> unpickle, and unpickling imports the target's module
+(`vllm_child`), which is where the drop fires.  The next stdlib import
+needed to finish that same unpickle then fails:
+
+```
+[semip] dropped capabilities for portable image (capset rc=0)
+Traceback (most recent call last):
+  File ".../multiprocessing/spawn.py", line 132, in _main
+ModuleNotFoundError: No module named 'multiprocessing.popen_spawn_posix'
+```
+
+followed by `init FAILED (child pipe broken, ... state=Z (zombie),
+exited_code=1)`.  A `ModuleNotFoundError` for a stdlib module right after
+the cap-drop line always means this.
+
+Observed with a conda interpreter under a `drwxr-x---` home directory.
+Note a venv does not help by itself: it shares its base interpreter's
+stdlib, so `/data-fast/myenv/bin/python` built on
+`/home/user/miniconda3/envs/dev` still reads its stdlib from under the
+private home -- switching between several such venvs changes nothing.
+Check the base, not the venv:
+
+```bash
+namei -l "$(python -c 'import sys; print(sys.base_prefix)')"
+```
+
+and fix by granting traversal (`chmod o+x /home/<user>`, which permits
+path traversal without allowing directory listing) or by using an
+interpreter under a world-readable prefix such as `/usr/lib/python3.12`.
+Internal does not hit this because it runs the system python from
+`/usr/local/lib/python3.12`.
+
+**Only cold start is affected; restoring a pre-existing image is not.**
+This asymmetry is worth internalising, because it makes the bug look
+intermittent:
+
+- `init` spawns a fresh interpreter, so the child runs Python's import
+  machinery -- which is exactly where the drop fires and exactly what
+  breaks next.
+- `criu_restore` maps an already-initialised process back into memory.
+  The restored child resumes in-memory code and imports nothing, so it
+  never performs a DAC-checked read and zero capabilities cost it
+  nothing.  The file reads the restore *does* need (reopening every
+  file-backed mapping) are done by `criu` in the worker, which keeps its
+  capabilities -- only the child ever drops.
+
+So an image dumped before the precondition was met will keep restoring
+happily, and the failure only reappears the next time something
+cold-starts.
+
 ---
 
 ## Summary Table

--- a/arctic_inference/semi_persistence/skills/CRIU_PLUMBING.md
+++ b/arctic_inference/semi_persistence/skills/CRIU_PLUMBING.md
@@ -46,18 +46,23 @@ covered there.
   8. Audit /proc/<pid>/task for non-"python" threads (informational)
 
   (back in worker)
-  9. Scan child fds for socket:[ino] → --external unix[ino]
+  9. Scan child AND descendant fds for socket:[ino] → --external unix[ino]
+     (TP>1 worker subprocesses hold the multiproc-executor IPC sockets)
  10. Scan child fds for /dev/nvidia*   → record into meta.json
  11. → criu dump (destructive): image written, child killed
 
 [Every use after dump — load from image]
 
   1. Pass pipe FD via Unix socket (SCM_RIGHTS) into sudo'd helper
-  2. helper dup2's the pipe fd into place, execvp's criu restore
+  2. helper dup2's the pipe fd into place, then unshares a fresh PID
+     namespace and forks: PID 1 is a reaper that unshares a mount ns with
+     a private /proc and execs criu restore *inside* the new namespace
+     (see Complication 10 — this frees the image's recorded PIDs)
   3. criu restore --inherit-fd fd[N]:pipe_resource
                   --inherit-fd fd[1]:stdout, fd[2]:stderr
-                  --link-remap --tcp-close --shell-job
-  4. cuda-checkpoint restore / driver API restores GPU context
+                  --link-remap --tcp-close        (no --shell-job)
+  4. worker finds the restored root's *host* PID via the inherited pipe
+  5. cuda-checkpoint restore / driver API restores GPU context
 ```
 
 ---
@@ -245,14 +250,21 @@ that occurred when remapping deleted shared-memory files.
 
 `save()` writes a `meta.json` file alongside the CRIU image containing:
 
-- **CRIU plumbing**: `child_pid`, `pipe_fd`, `pipe_resource`, `nvidia_fds`, `rank`
+- **CRIU plumbing**: `child_pid`, `pipe_fd`, `pipe_resource`, `nvidia_fds`
+- **Placement and hardware identity**: `rank`, `gpus` (the physical GPU
+  list; single-element at TP=1), and `gpu_uuids` — the *capture* node's
+  GPU UUIDs, which the restore device map needs as its "old" side so the
+  image can be restored on a different node
 - **Instance metadata**: `vllm_config` (which may include the reserved
-  `_env` mapping of per-model env vars), `total_gpu_bytes`,
-  `pinned_cpu_bytes`
+  `_env` mapping of per-model env vars), `model_dir`, `total_gpu_bytes`,
+  `pinned_cpu_bytes`, `n_gpus`, `max_pinned_bytes_per_worker`
 
-On `load()`, the instance validates that the image's `vllm_config`
-matches the instance's config.  A mismatch raises `RuntimeError`
-immediately, before any worker is spawned or CRIU restore attempted.
+On `criu_restore()`, the instance validates that the image's
+`vllm_config` and `model_dir` both match.  A mismatch raises
+`RuntimeError` immediately, before any worker is spawned or CRIU restore
+attempted.  The `model_dir` check matters because the image bakes
+absolute compile-cache paths (see
+[semi-p_DESIGN.md](semi-p_DESIGN.md)).
 
 The child's `os.environ` is itself captured inside the CRIU dump and
 restored verbatim by `load()`, so env vars set during cold start
@@ -278,19 +290,31 @@ The CRIU PPA package does not create it automatically.
 
 ## Complication 8: PID Collisions at Restore
 
-**Problem:** CRIU restores the process tree with the same PIDs recorded
-in the image.  When multiple models restore concurrently, the target PID
-may already be in use by an unrelated process on the host:
+**Problem:** CRIU restores every task at its *recorded* PID (via
+`clone3(set_tid)`), so the restore fails if that PID is already taken:
 
 ```
 Can't fork for 47619: File exists
 ```
 
-**Fix (worker):** `worker_loop` wraps `_worker_criu_load` in a retry
-loop (up to 5 attempts with 0.5s backoff).  If the error message
-contains `"File exists"`, the attempt is retried with fresh pipe
-descriptors.  The conflicting PID is typically short-lived, so a brief
-delay is sufficient.
+Three ways it gets taken:
+
+1. **A zombie from the dump.** The destructive dump kills the child, but
+   its still-live worker never reaps it, and a zombie holds its PID.
+   This one is guaranteed, not incidental — the image's own `child_pid`
+   is the PID that is occupied.
+2. **Concurrent restores.** Two images captured on the same node with
+   their child trees alive simultaneously carry adjacent/interleaved
+   PIDs, so the second restore collides with the first.
+3. **An unrelated host process** happening to hold the recorded PID.
+
+**Partial fix (retry loop):** `worker_loop` retries `_worker_criu_load`
+up to 5 times with 0.5s backoff on `"File exists"`.  This only helps for
+case 3, and only when the holder is short-lived.  A zombie under a live
+parent never goes away, so cases 1 and 2 defeat it entirely.
+
+**Real fix:** restore each tree into its own PID namespace, where the
+recorded PIDs are always free.  See Complication 10.
 
 ---
 
@@ -346,6 +370,60 @@ which are `MAP_PRIVATE`, unlike semaphores which are `MAP_SHARED`).
 
 ---
 
+## Complication 10: Per-Restore PID Namespace (and the tty it forced out)
+
+**Problem:** See Complication 8 — the recorded PIDs are frequently
+occupied, and CRIU 4.2 explicitly rejects `--join-ns pid:`, so we cannot
+ask it to place the tree into a pre-made namespace.
+
+**Fix: run criu inside a fresh PID namespace held open by a reaper.**
+The sudo'd restore helper (`_worker_criu_load` in `worker.py`):
+
+1. Receives the inherited pipe fd (SCM_RIGHTS, as in Complication 5),
+   then `unshare(CLONE_NEWPID)` and `fork()`.
+2. The host-namespace parent publishes **PID 1's host PID** to
+   `reaper.pid` (in the image dir) and blocks — this keeps the namespace,
+   and the `sudo` handle, alive.
+3. **PID 1** unshares a mount namespace, mounts a private `/proc` (so
+   criu sees the namespace's PID view), then forks `criu restore -d`
+   into the namespace, records criu's exit code to `restore.rc`, and
+   reaps forever. A live PID 1 is required both for the namespace to
+   persist and for `clone3(set_tid)` of any non-1 PID to be permitted.
+4. After criu detaches, the restored tree reparents onto PID 1. The
+   worker discovers the restored root's **host** PID via the inherited
+   pipe and drives the rest of the lifecycle with it (CUDA
+   checkpoint/restore, `/proc` walks, and signals all use host PIDs,
+   which are unaffected by the nesting) — `--pidfile` now holds the
+   meaningless in-namespace PID.
+
+Teardown SIGKILLs PID 1, which makes the kernel tear down the whole
+namespace and the restored tree in one shot. An `atexit` fallback in
+`worker_loop` catches Ctrl-C and unhandled exceptions, and a stale-reaper
+sweep (reads a leftover `reaper.pid` and kills it) covers `SIGKILL`
+deaths that cannot run cleanup.
+
+**The tty this forced out.** A private PID namespace is incompatible
+with a `--shell-job` image. The child inherited the interactive shell's
+pts on fd 0, so it was captured as a shell job tied to an external
+terminal. On restore inside the new namespace the session and pgrp
+collapse to `1`, and CRIU's `TIOCSPGRP` on the host terminal fails:
+
+```
+tty: Restore inherited group 1
+Error (criu/tty.c:689): tty: Failed to set group 1 on 0: Inappropriate ioctl for device
+Error (criu/files.c:1221): Unable to open fd=0 id=0xec
+```
+
+**Fix (dump side):** the child sheds its controlling terminal at startup
+(`vllm_child_loop`): point fd 0 at `/dev/null` and `os.setsid()` so the
+captured tree owns its own session and holds no terminal. With no tty in
+the image, `--shell-job` is unnecessary and is dropped from both `criu
+dump` and `criu restore`. This matches the CRIU maintainers' guidance for
+PID-namespace restore. **Images captured before this change (with a tty /
+`--shell-job`) must be re-dumped.**
+
+---
+
 ## Summary Table
 
 | Resource           | Problem at dump time               | Dump-side fix                      | Restore-side fix                     |
@@ -357,7 +435,8 @@ which are `MAP_PRIVATE`, unlike semaphores which are `MAP_SHARED`).
 | Pipe FD            | sudo closes FDs >= 3                | —                                  | SCM_RIGHTS via Unix socket           |
 | CUDA context       | GPU state not in CRIU image         | CRIU CUDA plugin at dump           | Driver API or cuda-checkpoint        |
 | Plugin directory   | `--libdir` path missing             | Create `/usr/lib/criu/empty`       | —                                    |
-| PID collisions     | —                                   | —                                  | Retry loop (5 attempts, 0.5s delay)  |
+| stdin / tty        | pts captured as `--shell-job`; can't reattach in a PID ns | fd 0 → `/dev/null` + `setsid()` at child start | drop `--shell-job` |
+| PID collisions     | Zombie from the destructive dump holds the recorded PID | — | Restore each tree in its own PID namespace (reaper + private /proc); retry loop as backstop |
 | Ghost remap race   | `(deleted)` .so → ghost race        | Destructive dump + sem deletion    | `--link-remap`                       |
 
 ---

--- a/arctic_inference/semi_persistence/skills/INSTALL.md
+++ b/arctic_inference/semi_persistence/skills/INSTALL.md
@@ -49,15 +49,17 @@ checker and does **not** block restore: `clone3(set_tid)` at the recorded PIDs
 is authorized by `CAP_CHECKPOINT_RESTORE`.  See Complication 11 in
 [`CRIU_PLUMBING.md`](CRIU_PLUMBING.md).
 
-After installing, create the empty plugin directory that the dump
-command references via `--libdir`:
+The dump also needs the empty plugin directory it passes to `--libdir`,
+which no CRIU package creates.  `_worker_criu_save` now creates it (via
+`sudo` when the worker is not root), so this is only needed if you want
+it in place ahead of the first dump:
 
 ```bash
 sudo mkdir -p /usr/lib/criu/empty
 ```
 
-Without this directory the dump aborts at plugin initialization
-(see *Complication 7* in [`CRIU_PLUMBING.md`](./CRIU_PLUMBING.md)).
+See *Complication 7* in [`CRIU_PLUMBING.md`](./CRIU_PLUMBING.md) for why
+the directory exists at all.
 
 ### Alternative: build from source (when apt mirrors are unreachable)
 

--- a/arctic_inference/semi_persistence/skills/INSTALL.md
+++ b/arctic_inference/semi_persistence/skills/INSTALL.md
@@ -49,6 +49,47 @@ checker and does **not** block restore: `clone3(set_tid)` at the recorded PIDs
 is authorized by `CAP_CHECKPOINT_RESTORE`.  See Complication 11 in
 [`CRIU_PLUMBING.md`](CRIU_PLUMBING.md).
 
+### Also qualify the interpreter for `SEMIP_UNPRIVILEGED=1`
+
+`criu check` says nothing about the *other* precondition of unprivileged
+mode: the child zeroes its capabilities, losing `CAP_DAC_OVERRIDE`, so
+from then on uid 0 can only read what `other` can.  Every directory on
+the path to the interpreter needs `o+x` and its files `o+r`.  Check the
+**base** prefix, since a venv shares its base interpreter's stdlib:
+
+```bash
+namei -l "$(python -c 'import sys; print(sys.base_prefix)')"
+```
+
+Any component without `o+x` (a `750` home is the usual culprit) fails the
+precondition.  A system-wide Python (`/usr/lib/python3.12`,
+`/usr/local/lib/python3.12/dist-packages`) satisfies it for free, which is
+why pre-baked pod images never hit this.
+
+The functional version of the same check — worth running once per node,
+because it exercises the exact call that breaks — drops capabilities and
+then does what vLLM's `in_the_same_node_as` does during `reinit_nccl`:
+
+```bash
+sudo python3 -c '
+import ctypes
+from multiprocessing import shared_memory, resource_tracker  # pre-import
+libc = ctypes.CDLL("libc.so.6", use_errno=True)
+for c in range(64): libc.prctl(24, c, 0, 0, 0)   # PR_CAPBSET_DROP
+libc.prctl(47, 4, 0, 0, 0)                       # PR_CAP_AMBIENT_CLEAR_ALL
+class H(ctypes.Structure): _fields_=[("version",ctypes.c_uint32),("pid",ctypes.c_int)]
+class D(ctypes.Structure): _fields_=[("effective",ctypes.c_uint32),("permitted",ctypes.c_uint32),("inheritable",ctypes.c_uint32)]
+libc.capset(ctypes.byref(H(0x20080522,0)), ctypes.byref((D*2)()))
+s = shared_memory.SharedMemory(create=True, size=128); print("OK", s.name)
+s.close(); s.unlink()'
+```
+
+Run it with the interpreter you will actually serve with.  `OK` means the
+node is fit; a `BrokenPipeError` means the precondition is violated and a
+TP>1 restore will **hang silently** in `reinit_nccl` (Complication 11).
+Fix it before dumping: images are otherwise fine, but you will not find
+out until a later restore.
+
 The dump also needs the empty plugin directory it passes to `--libdir`,
 which no CRIU package creates.  `_worker_criu_save` now creates it (via
 `sudo` when the worker is not root), so this is only needed if you want

--- a/arctic_inference/semi_persistence/skills/INSTALL.md
+++ b/arctic_inference/semi_persistence/skills/INSTALL.md
@@ -35,6 +35,20 @@ ls /usr/lib/criu/cuda_plugin.so    # shipped by the PPA package
 sudo criu check                    # "Looks good."
 ```
 
+On a **non-privileged** node (only `CAP_CHECKPOINT_RESTORE + CAP_SYS_PTRACE`,
+no `CAP_SYS_ADMIN`), plain `criu check` aborts at kernel-feature detection
+because it tries to create a throwaway network namespace.  Check such a node
+with the flag that the `SEMIP_UNPRIVILEGED=1` paths use:
+
+```bash
+sudo criu check --unprivileged      # must get past kerndat
+```
+
+A residual complaint about a read-only `ns_last_pid` is expected from the
+checker and does **not** block restore: `clone3(set_tid)` at the recorded PIDs
+is authorized by `CAP_CHECKPOINT_RESTORE`.  See Complication 11 in
+[`CRIU_PLUMBING.md`](CRIU_PLUMBING.md).
+
 After installing, create the empty plugin directory that the dump
 command references via `--libdir`:
 

--- a/arctic_inference/semi_persistence/skills/INSTALL.md
+++ b/arctic_inference/semi_persistence/skills/INSTALL.md
@@ -15,6 +15,11 @@ CRIU is not in the default Ubuntu repos at a recent-enough version.
 Install from the official CRIU PPA:
 
 ```bash
+# 0. Refresh the package lists first.  On a container whose lists are
+#    stale, step 1 fails with 404s on every package because the mirrors
+#    have already rotated out the versions the old lists point at.
+sudo apt-get update
+
 # 1. Add the CRIU PPA
 sudo apt-get install -y software-properties-common
 sudo add-apt-repository -y ppa:criu/ppa
@@ -24,8 +29,10 @@ sudo apt-get update
 sudo apt-get install -y criu
 
 # 3. Verify
-criu --version          # should print 4.x
-which crit              # /usr/sbin/crit  (CRIU image tool)
+criu --version                     # should print 4.x (4.2.1 from the PPA)
+which crit                         # /usr/bin/crit  (CRIU image tool)
+ls /usr/lib/criu/cuda_plugin.so    # shipped by the PPA package
+sudo criu check                    # "Looks good."
 ```
 
 After installing, create the empty plugin directory that the dump
@@ -103,17 +110,19 @@ Verify:
 
 ```bash
 criu --version          # Version: 4.2,  GitID: v4.2
-which crit              # /usr/local/bin/crit  (note: not /usr/sbin/crit)
+which crit              # /usr/local/bin/crit  (note: not /usr/bin/crit)
 ls -d /usr/lib/criu/empty
 ```
 
 Notes:
 
-- `crit` lands in `/usr/local/bin/` on the source build (vs `/usr/sbin/`
+- `crit` lands in `/usr/local/bin/` on the source build (vs `/usr/bin/`
   from the PPA), because it ships as a Python wheel installed by
   `install-crit`.
 - The from-source path also produces `cuda_plugin.so` in the CRIU build
-  tree — the CRIU CUDA infrastructure picks it up at dump time.
+  tree — the CRIU CUDA infrastructure picks it up at dump time.  The PPA
+  package already ships it as `/usr/lib/criu/cuda_plugin.so`, so the CUDA
+  plugin is not on its own a reason to prefer the source build.
 - More detailed build notes (and conditional fix-ups for systems missing
   even more headers) live in `instance_DESIGN.md` under
   *"CRIU Installation (v4.2, from source)"*.

--- a/arctic_inference/semi_persistence/skills/SKILL.md
+++ b/arctic_inference/semi_persistence/skills/SKILL.md
@@ -153,9 +153,16 @@ a CRIU image on disk and needs neither.
   venv that differs in one compiled extension kills a cross-node restore from
   inside CRIU, with no up-front check. Run `scripts/imgdiff.py <image_dir>`
   before restoring an image captured elsewhere.
+- **An image's capability level is fixed at dump time.** Restoring on a pod
+  without `CAP_SYS_ADMIN` needs `SEMIP_UNPRIVILEGED=1` set *when the image was
+  dumped*, so the child sheds its capabilities and `restore_creds` can reinstate
+  them. An image dumped without it cannot be restored there at all. The same
+  flag costs concurrent restore (one live restore per node), which makes
+  `scripts/test_weights.py` incompatible with it. See Complication 11.
 - **Reserved env keys** (`CUDA_VISIBLE_DEVICES`,
-  `VLLM_ENABLE_V1_MULTIPROCESSING`, `USE_LIBUV`) are silently dropped from
-  `vllm_config["_env"]` at apply time, but retained on disk in `meta.json`.
+  `VLLM_ENABLE_V1_MULTIPROCESSING`, `USE_LIBUV`, the loopback trio and the
+  compile-cache roots) are silently dropped from `vllm_config["_env"]` at apply
+  time, but retained on disk in `meta.json`.
 - **`criu_restore` does not re-apply `_env`** — the child's environment is baked
   into the CRIU image and restored verbatim.
 - **Staging buffers must be freed via `storage().resize_(0)`**, not
@@ -171,7 +178,7 @@ a CRIU image on disk and needs neither.
 | [`pipeline_DESIGN.md`](pipeline_DESIGN.md) | Op model, interrupts, cross-model eviction, regression plan |
 | [`slots_DESIGN.md`](slots_DESIGN.md) | Buddy allocator algorithms, invariants, worked example |
 | [`client_DESIGN.md`](client_DESIGN.md) | Job/model two-layer split, calling shapes, session persistence |
-| [`CRIU_PLUMBING.md`](CRIU_PLUMBING.md) | The ten CRIU complications and the FD keep-list |
+| [`CRIU_PLUMBING.md`](CRIU_PLUMBING.md) | The eleven CRIU complications and the FD keep-list |
 | [`tp_DESIGN.md`](tp_DESIGN.md) | Tensor parallelism: the four TP primitives, NCCL teardown/rebuild, graph reuse |
 | [`semi-p_DESIGN.md`](semi-p_DESIGN.md) | The `model_dir` layout, what a re-dump touches, what binds an image |
 | [`async_generate_DETAILS.md`](async_generate_DETAILS.md) | Async generate, IPC protocol, drain points |

--- a/arctic_inference/semi_persistence/skills/SKILL.md
+++ b/arctic_inference/semi_persistence/skills/SKILL.md
@@ -153,8 +153,8 @@ a CRIU image on disk and needs neither.
   socket … Address already in use`. Dumps now mark the workers' TCP sockets
   `SO_LINGER(1,0)` so the kill RSTs instead; images from before that change
   need the 60s to drain, not a re-dump. See Complication 12.
-- **`/usr/lib/criu/empty` must exist** or dump aborts at plugin init. See
-  [`INSTALL.md`](INSTALL.md).
+- **`/usr/lib/criu/empty` is created by the dump**, not by any CRIU package;
+  without it criu aborts at plugin init. See Complication 7.
 - **An image binds to its node's shared libraries byte-for-byte.** CRIU
   re-validates the recorded size of every file-backed mapping at restore, so a
   venv that differs in one compiled extension kills a cross-node restore from

--- a/arctic_inference/semi_persistence/skills/SKILL.md
+++ b/arctic_inference/semi_persistence/skills/SKILL.md
@@ -125,6 +125,7 @@ semi_persistence/
   *.py           library code (orchestrator, instance, worker, client, dashboard, ...)
   tests/         pytest: CPU-only, hermetic, ~2.5s, no GPU
   scripts/       imperative repros: need real GPUs and real vLLM
+                 (except imgdiff.py, which only needs crit + root)
   skills/        this skill (SKILL.md + reference.md) and every design doc
 ```
 
@@ -138,7 +139,8 @@ python dashboard.py               # needs a running orchestrator on :8157
 ```
 
 `tests/` is the only part runnable in CI. Everything in `scripts/` allocates
-real GPUs and loads real weights.
+real GPUs and loads real weights, except `scripts/imgdiff.py`, which inspects
+a CRIU image on disk and needs neither.
 
 ## Gotchas that bite
 
@@ -146,6 +148,11 @@ real GPUs and loads real weights.
   so after `criu_dump` the model is always `saved` with no live process.
 - **`/usr/lib/criu/empty` must exist** or dump aborts at plugin init. See
   [`INSTALL.md`](INSTALL.md).
+- **An image binds to its node's shared libraries byte-for-byte.** CRIU
+  re-validates the recorded size of every file-backed mapping at restore, so a
+  venv that differs in one compiled extension kills a cross-node restore from
+  inside CRIU, with no up-front check. Run `scripts/imgdiff.py <image_dir>`
+  before restoring an image captured elsewhere.
 - **Reserved env keys** (`CUDA_VISIBLE_DEVICES`,
   `VLLM_ENABLE_V1_MULTIPROCESSING`, `USE_LIBUV`) are silently dropped from
   `vllm_config["_env"]` at apply time, but retained on disk in `meta.json`.

--- a/arctic_inference/semi_persistence/skills/SKILL.md
+++ b/arctic_inference/semi_persistence/skills/SKILL.md
@@ -159,6 +159,13 @@ a CRIU image on disk and needs neither.
   them. An image dumped without it cannot be restored there at all. The same
   flag costs concurrent restore (one live restore per node), which makes
   `scripts/test_weights.py` incompatible with it. See Complication 11.
+- **`SEMIP_UNPRIVILEGED=1` needs a world-readable interpreter.** The child
+  drops *all* capabilities, so a uid-0 process loses `CAP_DAC_OVERRIDE` and can
+  only read what `other` can. An interpreter behind a private home (`chmod 750`)
+  then breaks cold start with a bogus-looking `ModuleNotFoundError` for a stdlib
+  module right after the `[semip] dropped capabilities` line. A venv inherits
+  its base interpreter's stdlib, so check `sys.base_prefix`, not the venv.
+  Restoring an existing image is unaffected -- it imports nothing.
 - **Reserved env keys** (`CUDA_VISIBLE_DEVICES`,
   `VLLM_ENABLE_V1_MULTIPROCESSING`, `USE_LIBUV`, the loopback trio and the
   compile-cache roots) are silently dropped from `vllm_config["_env"]` at apply

--- a/arctic_inference/semi_persistence/skills/SKILL.md
+++ b/arctic_inference/semi_persistence/skills/SKILL.md
@@ -143,13 +143,13 @@ real GPUs and loads real weights.
 ## Gotchas that bite
 
 - **CRIU dump is destructive.** The child is killed once the image is written,
-  so after `save_image` the model is always `saved` with no live process.
+  so after `criu_dump` the model is always `saved` with no live process.
 - **`/usr/lib/criu/empty` must exist** or dump aborts at plugin init. See
   [`INSTALL.md`](INSTALL.md).
 - **Reserved env keys** (`CUDA_VISIBLE_DEVICES`,
   `VLLM_ENABLE_V1_MULTIPROCESSING`, `USE_LIBUV`) are silently dropped from
   `vllm_config["_env"]` at apply time, but retained on disk in `meta.json`.
-- **`load_image` does not re-apply `_env`** — the child's environment is baked
+- **`criu_restore` does not re-apply `_env`** — the child's environment is baked
   into the CRIU image and restored verbatim.
 - **Staging buffers must be freed via `storage().resize_(0)`**, not
   `caching_allocator_delete`, because vLLM's cumem allocator intercepts

--- a/arctic_inference/semi_persistence/skills/SKILL.md
+++ b/arctic_inference/semi_persistence/skills/SKILL.md
@@ -172,7 +172,10 @@ a CRIU image on disk and needs neither.
   then breaks cold start with a bogus-looking `ModuleNotFoundError` for a stdlib
   module right after the `[semip] dropped capabilities` line. A venv inherits
   its base interpreter's stdlib, so check `sys.base_prefix`, not the venv.
-  Restoring an existing image is unaffected -- it imports nothing.
+  `criu_restore` itself is unaffected (it imports nothing), but what runs after
+  it is: at TP>1 `reinit_nccl` spawns a process underneath vLLM's
+  `in_the_same_node_as`, and the failure is a *silent* deadlock because vLLM
+  suppresses the resulting `OSError`. No re-dump needed -- fix the permissions.
 - **Reserved env keys** (`CUDA_VISIBLE_DEVICES`,
   `VLLM_ENABLE_V1_MULTIPROCESSING`, `USE_LIBUV`, the loopback trio and the
   compile-cache roots) are silently dropped from `vllm_config["_env"]` at apply

--- a/arctic_inference/semi_persistence/skills/SKILL.md
+++ b/arctic_inference/semi_persistence/skills/SKILL.md
@@ -164,7 +164,9 @@ real GPUs and loads real weights.
 | [`pipeline_DESIGN.md`](pipeline_DESIGN.md) | Op model, interrupts, cross-model eviction, regression plan |
 | [`slots_DESIGN.md`](slots_DESIGN.md) | Buddy allocator algorithms, invariants, worked example |
 | [`client_DESIGN.md`](client_DESIGN.md) | Job/model two-layer split, calling shapes, session persistence |
-| [`CRIU_PLUMBING.md`](CRIU_PLUMBING.md) | The nine CRIU complications and the FD keep-list |
+| [`CRIU_PLUMBING.md`](CRIU_PLUMBING.md) | The ten CRIU complications and the FD keep-list |
+| [`tp_DESIGN.md`](tp_DESIGN.md) | Tensor parallelism: the four TP primitives, NCCL teardown/rebuild, graph reuse |
+| [`semi-p_DESIGN.md`](semi-p_DESIGN.md) | The `model_dir` layout, what a re-dump touches, what binds an image |
 | [`async_generate_DETAILS.md`](async_generate_DETAILS.md) | Async generate, IPC protocol, drain points |
 | [`INSTALL.md`](INSTALL.md) | CRIU install (PPA and from-source), draft model sync |
 

--- a/arctic_inference/semi_persistence/skills/SKILL.md
+++ b/arctic_inference/semi_persistence/skills/SKILL.md
@@ -126,6 +126,7 @@ semi_persistence/
   tests/         pytest: CPU-only, hermetic, ~2.5s, no GPU
   scripts/       imperative repros: need real GPUs and real vLLM
                  (except imgdiff.py, which only needs crit + root)
+  reproduce/     example_full.py: the saved -> up sweep across TP1/2/4/8
   skills/        this skill (SKILL.md + reference.md) and every design doc
 ```
 
@@ -146,6 +147,12 @@ a CRIU image on disk and needs neither.
 
 - **CRIU dump is destructive.** The child is killed once the image is written,
   so after `criu_dump` the model is always `saved` with no live process.
+- **A restore right after its own dump can hit `TIME_WAIT`.** CRIU rebinds
+  every local port it recorded, and the destructive dump's own FIN closes park
+  those ports for 60s, so the restore dies inside CRIU with `Can't bind inet
+  socket … Address already in use`. Dumps now mark the workers' TCP sockets
+  `SO_LINGER(1,0)` so the kill RSTs instead; images from before that change
+  need the 60s to drain, not a re-dump. See Complication 12.
 - **`/usr/lib/criu/empty` must exist** or dump aborts at plugin init. See
   [`INSTALL.md`](INSTALL.md).
 - **An image binds to its node's shared libraries byte-for-byte.** CRIU
@@ -185,7 +192,7 @@ a CRIU image on disk and needs neither.
 | [`pipeline_DESIGN.md`](pipeline_DESIGN.md) | Op model, interrupts, cross-model eviction, regression plan |
 | [`slots_DESIGN.md`](slots_DESIGN.md) | Buddy allocator algorithms, invariants, worked example |
 | [`client_DESIGN.md`](client_DESIGN.md) | Job/model two-layer split, calling shapes, session persistence |
-| [`CRIU_PLUMBING.md`](CRIU_PLUMBING.md) | The eleven CRIU complications and the FD keep-list |
+| [`CRIU_PLUMBING.md`](CRIU_PLUMBING.md) | The twelve CRIU complications and the FD keep-list |
 | [`tp_DESIGN.md`](tp_DESIGN.md) | Tensor parallelism: the four TP primitives, NCCL teardown/rebuild, graph reuse |
 | [`semi-p_DESIGN.md`](semi-p_DESIGN.md) | The `model_dir` layout, what a re-dump touches, what binds an image |
 | [`async_generate_DETAILS.md`](async_generate_DETAILS.md) | Async generate, IPC protocol, drain points |

--- a/arctic_inference/semi_persistence/skills/async_generate_DETAILS.md
+++ b/arctic_inference/semi_persistence/skills/async_generate_DETAILS.md
@@ -345,7 +345,7 @@ A paused model has at least one in-flight `generate` whose
 `generate_done` is parked in the child until `resume`.  That generate
 counts toward `inst._pending_count`.  Any pool-worker
 `inst.wait()` issued by `_step_up` / `_step_down` (e.g. for `sleep`,
-`checkpoint_cuda`, `restore_cuda`, `wake_up_kv_cache`, ...) would loop
+`cuda_checkpoint`, `cuda_restore`, `wake_up_kv_cache`, ...) would loop
 forever waiting for `_pending_count` to drain to 0 -- which won't
 happen until resume.
 
@@ -392,8 +392,8 @@ without self-deadlock.
 | Caller | Path | Mechanism | Notes |
 |--------|------|-----------|-------|
 | `_register_sync` | child boot / image restore | `inst.wait()` | Cold start; no listeners installed yet. The condvar wait is independent of listener state. |
-| `_step_up(saved -> checkpoint)` | `inst.load_image().plan_restore_weights().wait()` | `inst.wait()` | First time the model is reanimated; listeners are installed on the new Instance just before this chain so subsequent steps can use `_send_cmd_with_ack`. |
-| `_step_up`, `_step_down` (every cmd: `sleep`, `unpin`, `checkpoint_cuda`, `restore_cuda`, `repin`, `wake_up_weights`, `restore_weights`, `wake_up_kv_cache`) | move ladder, possibly under a paused model | `_send_cmd_with_ack` | Always synchronises only on its own cmd's ack, so it works whether or not generates are deferred. |
+| `_step_up(saved -> checkpoint)` | `inst.criu_restore().plan_restore_weights().wait()` | `inst.wait()` | First time the model is reanimated; listeners are installed on the new Instance just before this chain so subsequent steps can use `_send_cmd_with_ack`. |
+| `_step_up`, `_step_down` (every cmd: `sleep`, `unpin`, `cuda_checkpoint`, `cuda_restore`, `repin`, `wake_up_weights`, `restore_weights`, `wake_up_kv_cache`) | move ladder, possibly under a paused model | `_send_cmd_with_ack` | Always synchronises only on its own cmd's ack, so it works whether or not generates are deferred. |
 | `_step_down(checkpoint -> saved)` | `inst.teardown().wait().remove()` | `inst.wait()` | Demuxer applies the teardown ack (calls `_reset()`) before notifying the wait; the wait then returns and the inst is GC'd. |
 | `_pause_sync`, `_resume_sync` | pause/resume a generating model | `_send_cmd_with_ack` | Issued mid-generate by definition; deferred generate keeps `_pending_count` non-zero so only the FIFO ack path works. |
 | `_generate_sync` | submit a new generate | per-request `Event` (not `inst.wait()`) | The orchestrator's permanent generate listener resolves the matching `req_id`. |
@@ -730,7 +730,7 @@ wake_up_kv_cache       <- last Phase 1 cmd (engine ready)
 sleep                  <- move's first cmd (cumem freed)
 generate               <- Phase 2's enqueue (request added
                           to a sleeping engine)
-unpin / checkpoint_cuda  <- rest of move's ladder-down
+unpin / cuda_checkpoint  <- rest of move's ladder-down
 ```
 
 The engine hangs trying to schedule a request against freed
@@ -972,7 +972,7 @@ ladder state at which pause itself is allowed -- `up`, `sleep`,
 underlying vLLM engine, however, is only safe to call into
 while it is at `up`: `llm.sleep(level=2)` discards the cumem
 allocator's GPU blocks and tears the executor context down,
-and a subsequent `checkpoint_cuda` (via `cuda-checkpoint`)
+and a subsequent `cuda_checkpoint` (via `cuda-checkpoint`)
 freezes the entire CUDA context.  Either state makes the engine
 APIs hazardous -- `engine.add_request` enqueues into a
 scheduler that can no longer `step()`, and `engine.abort_request`
@@ -1014,7 +1014,7 @@ whose per-eid state never saw a step are restored.
 **Why this is order-independent.**  Because the route is keyed
 on `_paused` (set by `pause`, cleared by `resume`) and not on
 any engine-state predicate, any pipe interleaving of
-`pause`, `sleep`, `unpin`, `checkpoint_cuda`, `restore_cuda`,
+`pause`, `sleep`, `unpin`, `cuda_checkpoint`, `cuda_restore`,
 `repin`, `wake_up_weights`, `restore_weights`, and `generate`
 that the "Walking down past `up` while paused" rule permits is
 handled by the same line of code.  Earlier designs needed a

--- a/arctic_inference/semi_persistence/skills/instance_DESIGN.md
+++ b/arctic_inference/semi_persistence/skills/instance_DESIGN.md
@@ -845,7 +845,8 @@ sudo PIP_BREAK_SYSTEM_PACKAGES=1 make install-criu PREFIX=/usr
 sudo PIP_BREAK_SYSTEM_PACKAGES=1 make install-lib PREFIX=/usr
 sudo PIP_BREAK_SYSTEM_PACKAGES=1 make install-crit PREFIX=/usr
 
-# Empty plugin directory (required by --libdir during dump)
+# Empty plugin directory (used by --libdir during dump; the dump creates
+# it if missing, so this is optional)
 sudo mkdir -p /usr/lib/criu/empty
 ```
 

--- a/arctic_inference/semi_persistence/skills/instance_DESIGN.md
+++ b/arctic_inference/semi_persistence/skills/instance_DESIGN.md
@@ -126,8 +126,12 @@ Main process
   |           |-- [checkpoint/restore via cuCheckpointProcess ctypes]
   |           |
   |           `-- vLLM child process  (spawned)
-  |                 |-- owns CPU buffer (allocated on attach, pinned via repin)
   |                 |-- EngineCore (in-process, holds GPU memory)
+  |                 |     `-- each vLLM worker owns a CPU staging buffer
+  |                 |         (allocated on attach, pinned via repin).  At
+  |                 |         TP=1 the worker is this same process; at TP>1
+  |                 |         there is one worker subprocess (and one buffer)
+  |                 |         per rank.
   |                 `-- resource_tracker  (no GPU, skipped during checkpoint)
   |
   |-- Instance 2  (handle, main-process side)
@@ -165,15 +169,16 @@ primitives must be:
 | `criu_dump(filename)`        | CRIU-dump the child process tree to disk (destructive).  The child is killed after the image is written.  Writes `meta.json` with `vllm_config` (including `_env` if set) and CRIU metadata. | Worker (child thread) |
 | `criu_restore(filename)`        | Restore a process from a CRIU image on disk.  Validates that the image's `vllm_config` matches this instance.  Spawns a new worker and CRIU-restores the child.  Does *not* re-apply `_env` -- the child's `os.environ` is captured inside the CRIU image and restored verbatim. | Worker |
 | `cuda_restore(gpu)`          | Restore checkpointed CUDA state onto the specified GPU.  `gpu` is required. | Worker (ctypes) |
-| `attach()`              | Allocate unpinned CPU memory sized to the union of `main.named_parameters()` and (if present) `drafter.model.named_parameters()`.  Speculative-decoding drafters that expose a `.model` (Eagle / Medusa / DraftModel / ArcticProposer) contribute extra entries; non-model drafters (Ngram / Suffix) are skipped, in which case the layout collapses to main params only. | Child |
-| `attach_pinned()`       | Allocate CPU memory pinned for its entire lifetime (via torch `pin_memory=True`).  Skips the per-cycle `repin()`/`unpin()` pattern at the cost of ~34 ms/GiB extra inside `cuda_checkpoint`/`cuda_restore`.  Calling `repin()`/`unpin()` on a buffer created via `attach_pinned()` raises. | Child |
-| `detach()`              | Free CPU memory buffer.                                      | Child                                      |
-| `repin()`               | `cudaHostRegister` the buffer for DMA transfers.             | Child                                      |
-| `unpin()`               | `cudaHostUnregister` the buffer (data stays, CUDA registration removed). | Child                           |
-| `stage()`               | Snapshot main and drafter params (GPU -> pinned CPU) in vLLM's internal format. | Child                          |
-| `plan_restore_weights()` | Self-compute `max_buffer_bytes = min(pinned_cpu_bytes, allotment - pinned_cpu_bytes)` from instance state and walk `index` once to build a chunk plan (each chunk packs whole params under the budget).  Cache the plan in the child for the next `restore_weights()`. | Instance + Child |
-| `restore_weights()`      | Pure execution against the cached chunk plan: per chunk, copy a slice of the pinned buffer to a single reused GPU staging buffer, then scatter into `main.named_parameters()` and (if present) `drafter.model.named_parameters()` in place using the namespaced index.  Falls back to a single chunk if no plan was cached.  Frees the staging buffer before returning. | Child |
-| `wake_up_weights()`     | Re-allocate weight tensors on GPU (main + drafter).  The arctic patch's disk reload of the main model is suppressed via `_skip_main_reload_on_wake`; both main and drafter parameters are populated by the subsequent `restore_weights()` from the pinned buffer.  Drafter `named_buffers()` are restored here from the per-sleep CPU snapshot. | Child |
+| `attach()`              | Allocate unpinned CPU memory *per worker*, sized to the union of that rank's `main.named_parameters()` and (if present) `drafter.model.named_parameters()`.  Speculative-decoding drafters that expose a `.model` (Eagle / Medusa / DraftModel / ArcticProposer) contribute extra entries; non-model drafters (Ngram / Suffix) are skipped, in which case the layout collapses to main params only.  Reports `max_pinned_bytes_per_worker`. | Worker |
+| `attach_pinned()`       | **Unsupported; raises.**  Use `attach()` -> `repin()` instead.  (It allocated a permanently-pinned buffer via torch `pin_memory=True` before staging moved onto the workers.) | Worker |
+| `detach()`              | Free the CPU buffer on every worker.                         | Worker                                     |
+| `repin()`               | `cudaHostRegister` each worker's buffer for DMA transfers.  Idempotent. | Worker                           |
+| `unpin()`               | `cudaHostUnregister` each worker's buffer (data stays, CUDA registration removed).  Idempotent. | Worker          |
+| `stage()`               | Snapshot main and drafter params (GPU -> that worker's CPU buffer) in vLLM's internal format. | Worker           |
+| `plan_restore_weights(max_buffer_bytes=None)` | Self-compute the budget from `max_pinned_bytes_per_worker` (the per-GPU shard, not the TP-aggregate) and walk each worker's `index` once to build a chunk plan (each chunk packs whole params under the budget).  Cache the plan on the worker for the next `restore_weights()`.  An explicit `max_buffer_bytes` overrides the computation. | Instance + Worker |
+| `restore_weights()`      | Pure execution against the cached chunk plan: per chunk, copy a slice of that worker's buffer to a single reused GPU staging buffer, then scatter into `main.named_parameters()` and (if present) `drafter.model.named_parameters()` in place using the namespaced index.  Falls back to a single chunk if no plan was cached.  Frees the staging buffer and calls `empty_cache()` before returning. | Worker |
+| `save_weights()` / `load_weights()` | Write / read each worker's buffer as shards plus a `weights_meta.json` manifest.  Flat `weights/` at TP=1, per-rank `weights/rank{R}/` at TP>1. | Worker |
+| `wake_up_weights()`     | Re-allocate weight tensors on GPU (main + drafter).  The arctic patch's disk reload of the main model is suppressed via `_skip_main_reload_on_wake`; both main and drafter parameters are populated by the subsequent `restore_weights()` from the worker's buffer.  Drafter `named_buffers()` are restored here from the per-sleep CPU snapshot. | Child |
 | `wake_up_kv_cache()`    | Re-allocate KV cache on GPU.                                 | Child                                      |
 | `generate(prompts, sp)` | Submit inference to the engine.  Assigns a unique `req_id`; result stored in `generate_results[req_id]` and `last_generate_result`. | Child (async engine loop) |
 | `pause()`               | Freeze the engine and snapshot in-flight requests.  Sets `_paused`, captures every active sub-request's `(prompt_token_ids, output_token_ids_so_far, sampling_params)` into a child-local list, then `engine.abort_request(eids)` so subsequent `unpin`/`sleep`/`cuda_checkpoint` are safe.  Pending `generate_done` messages are deferred until `resume`. | Child |
@@ -185,25 +190,51 @@ primitives must be:
 
 ## CPU Buffer and Pin Management
 
-`attach()` allocates a regular (unpinned) CPU buffer via
+### The buffer lives on the worker, not in the child process
+
+All of the staging state -- the buffer, the param index, and the chunk
+plan -- lives on each vLLM worker as `worker._semip_*`, and every step
+runs there through `collective_rpc` (`_semip_attach`, `_semip_stage`,
+`_semip_repin`, `_semip_unpin`, `_semip_restore_weights`,
+`_semip_detach`, and the two weight-file primitives).
+
+This is not incidental.  At TP>1 `collective_rpc` cloudpickles the
+callable into every worker subprocess, so a buffer allocated in the
+vllm_child process and captured by a closure would be copied by value
+per worker and its writes discarded -- silently, with no error.  Each
+rank also owns a *different shard* of the parameters, so one buffer in
+the child would be the wrong size regardless.  At TP=1 the single
+worker is this same process, so the identical code path just works.
+
+The child aggregates the per-worker results: `attach` and
+`plan_restore_weights` report `max_pinned_bytes_per_worker`, which is
+what `Instance.plan_restore_weights` sizes the chunk budget from (the
+TP-aggregate `pinned_cpu_bytes` would overstate the per-GPU figure).
+
+### What each step does
+
+`attach()` allocates a regular (unpinned) CPU buffer per worker via
 `torch.empty(total_size, dtype=torch.uint8)`.  The buffer is sized to
 the total bytes of `main.named_parameters()` plus, when speculative
 decoding is configured with a model-bearing drafter,
-`drafter.model.named_parameters()`.  The layout is computed once after
-init via `collective_rpc` (not `apply_model`, which would only expose
-the main model).  An `index` dict maps each *namespaced* parameter
-name -- `"main:p:<name>"` or `"drafter:p:<name>"` -- to its
-`(offset, nbytes, dtype, shape)` in the buffer.  Non-model drafters
-(Ngram / Suffix) contribute no entries; the index then collapses to
-main params only and behavior matches the pre-drafter pipeline byte
-for byte.
+`drafter.model.named_parameters()`.  An `index` dict maps each
+*namespaced* parameter name -- `"main:p:<name>"` or
+`"drafter:p:<name>"` -- to its `(offset, nbytes, dtype, shape)` in the
+buffer.  Non-model drafters (Ngram / Suffix) contribute no entries; the
+index then collapses to main params only and behavior matches the
+pre-drafter pipeline byte for byte.
 
 Pinning is a separate step: `repin()` calls `cudaHostRegister` (via
 ctypes on `libcudart.so`) to register the buffer for DMA transfers.
 `unpin()` calls `cudaHostUnregister` to remove the registration while
-keeping the memory allocated and data intact.
+keeping the memory allocated and data intact.  Both are idempotent --
+the attach buffer starts unpinned, and a double register or an
+unregister of an unregistered buffer would hard-error.
 
 `detach()` frees the CPU buffer entirely.
+
+`attach_pinned()` is **not supported** on this path and raises; use
+`attach()` followed by `repin()`.
 
 ### Why separate attach / repin / unpin
 
@@ -245,17 +276,17 @@ the first `restore_weights()`, the instance calls `plan_restore_weights()` to
 build and cache a chunk plan in the worker.  `restore_weights()` then
 executes the cached plan as pure I/O.
 
-### stage (GPU main + drafter params -> pinned CPU)
+### stage (GPU main + drafter params -> worker CPU buffer)
 
-`stage()` uses `collective_rpc` (so the callback can reach
-`worker.model_runner.drafter` -- `apply_model` only passes the main
-`nn.Module`) to build a unified
+`stage()` runs `_semip_stage` on every worker via `collective_rpc` (so
+it can reach `worker.model_runner.drafter` -- `apply_model` only passes
+the main `nn.Module`).  Each worker builds a unified
 `name -> tensor.data` source table covering
 `main.named_parameters()` keyed `"main:p:<name>"` plus, if
 `drafter.model` exists, `drafter.model.named_parameters()` keyed
-`"drafter:p:<name>"`.  It then walks `index` and copies each entry's
-`.data` (contiguous, viewed as uint8) into the pinned buffer at the
-recorded offset.  This captures weights in vLLM's post-processed
+`"drafter:p:<name>"`.  It then walks its own `index` and copies each
+entry's `.data` (contiguous, viewed as uint8) into its own buffer at
+the recorded offset.  This captures weights in vLLM's post-processed
 internal format (e.g. Marlin-packed for GPTQ, cutlass layout for FP8,
 plain tensors for BF16) for both models in a single sweep.
 
@@ -294,24 +325,26 @@ on the worker until `detach()` resets it.
 
 ### restore_weights (cached plan -> GPU staging -> model params)
 
-For each chunk in the cached plan:
+`_semip_restore_weights` runs entirely on each worker, so both the host
+buffer and the GPU staging buffer are local to the rank that owns those
+parameters.  It allocates one
+`gpu_buf = torch.empty(chunk_size, dtype=torch.uint8, device=worker.device)`
+before the loop, then for each chunk in the cached plan:
 
-1. **Pinned CPU -> GPU staging buffer.**  Allocates one
-   `buf_gpu = torch.empty(chunk_size, dtype=torch.uint8, device="cuda:0")`
-   before the loop.  Per chunk, `buf_gpu[:n].copy_(pinned_buf[lo:hi],
-   non_blocking=True)` followed by `torch.cuda.synchronize()`.
-2. **GPU staging buffer -> main + drafter params (in place).**
-   `collective_rpc` rebuilds the namespaced
-   `name -> tensor.data` target table on the worker (mirror image of
-   `stage`'s source table) and scatters this chunk's members; each src
-   view is
-   `buf_gpu[(off - lo):(off - lo) + nbytes].view(dtype).reshape(shape)`,
+1. **Worker CPU buffer -> GPU staging buffer.**
+   `gpu_buf[:n].copy_(buf[lo:hi], non_blocking=True)` followed by
+   `torch.cuda.synchronize()`.
+2. **GPU staging buffer -> main + drafter params (in place).**  The
+   worker rebuilds the namespaced `name -> tensor.data` target table
+   (mirror image of `stage`'s source table) and scatters this chunk's
+   members; each src view is
+   `gpu_buf[(off - lo):(off - lo) + nbytes].view(dtype).reshape(shape)`,
    copied into the corresponding `"main:p:<name>"` or
    `"drafter:p:<name>"` parameter via `target.copy_(src)`.  No
    `model.load_weights()` or `process_weights_after_loading()` is
    needed because the staged data is already in vLLM's internal format.
 
-After the loop, `buf_gpu` is freed via `buf_gpu.storage().resize_(0)`
+After the loop, `gpu_buf` is freed via `gpu_buf.storage().resize_(0)`
 followed by `torch.cuda.empty_cache()`.  This releases memory through
 PyTorch's normal caching allocator path, keeping allocator metadata
 consistent for CRIU checkpoint/restore (see *Known Issues* below).
@@ -334,8 +367,8 @@ on every worker via `collective_rpc`:
 
 | Flag                            | Effect                                                                                                                                  |
 | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `_skip_main_reload_on_wake`     | `WorkerPatch.wake_up` does not call `GPUModelRunnerPatch._orig_reload_weights(self.model_runner)` -- main params come from the pinned buffer instead. |
-| `_skip_drafter_param_snapshot`  | `WorkerPatch._save_module_state(drafter.model, skip_params=True)` skips `named_parameters()` -- drafter params come from the pinned buffer instead. |
+| `_skip_main_reload_on_wake`     | `WorkerPatch.wake_up` does not call `GPUModelRunnerPatch._orig_reload_weights(self.model_runner)` -- main params come from the worker's staging buffer instead. |
+| `_skip_drafter_param_snapshot`  | `WorkerPatch._save_module_state(drafter.model, skip_params=True)` skips `named_parameters()` -- drafter params come from the worker's staging buffer instead. |
 
 Drafter `named_buffers()` are still snapshotted unconditionally and
 restored inside `WorkerPatch.wake_up`; they are sub-MB and may carry
@@ -529,7 +562,7 @@ instance_2.wait()
 
 ### Restore and generate (hot path)
 
-After cold-start, weights are already staged in pinned CPU memory
+After cold-start, weights are already staged in each worker's CPU buffer
 (unpinned from CUDA).  Restore re-pins and moves them CPU→GPU:
 
 ```python

--- a/arctic_inference/semi_persistence/skills/instance_DESIGN.md
+++ b/arctic_inference/semi_persistence/skills/instance_DESIGN.md
@@ -61,6 +61,32 @@ instance_1.init(gpu=0)
 instance_2.init(gpu=1)
 ```
 
+### Optional `model_dir`
+
+`Instance(vllm_config, model_dir=None)` accepts a per-model directory
+holding `{compilation, image, weights}`.  With it, `criu_dump()` and
+`criu_restore()` need no path, the weight shards land in
+`<model_dir>/weights`, and the JIT/compile caches move under
+`<model_dir>/compilation` so the whole directory travels between nodes as
+one unit.  Without it the primitives take explicit paths and the caches
+keep their node-local defaults, which is what the orchestrator uses.
+See [semi-p_DESIGN.md](semi-p_DESIGN.md).
+
+### Tensor parallelism
+
+TP size comes from `vllm_config["tensor_parallel_size"]`.  `init` and
+`cuda_restore` then take a `gpus` list that is placement only and must
+have exactly that many entries:
+
+```python
+inst = Instance({"model": "...", "tensor_parallel_size": 2}, model_dir)
+inst.init(gpus=[2, 3])
+```
+
+Four additional primitives (`destroy_nccl`, `reinit_nccl`, `cleargraph`,
+`recapture_graphs`) bracket the checkpoint and restore; all are no-ops at
+TP=1.  See [tp_DESIGN.md](tp_DESIGN.md).
+
 ## Process Hierarchy
 
 Each Instance owns one **worker process**, created when `init(gpu)` or

--- a/arctic_inference/semi_persistence/skills/instance_DESIGN.md
+++ b/arctic_inference/semi_persistence/skills/instance_DESIGN.md
@@ -64,7 +64,7 @@ instance_2.init(gpu=1)
 ## Process Hierarchy
 
 Each Instance owns one **worker process**, created when `init(gpu)` or
-`load_image(filename)` is called.  Both the worker and the vLLM child are **spawned** via
+`criu_restore(filename)` is called.  Both the worker and the vLLM child are **spawned** via
 `mp.get_context("spawn")`.  Spawning is safe to call from any thread
 (e.g. from a `ThreadPoolExecutor` in the orchestrator), unlike fork
 which can deadlock on glibc mutexes held by other threads.
@@ -135,12 +135,12 @@ primitives must be:
 | `init(gpu)`             | Cold start a model with real weights on the given GPU.  Spawns the worker process and vLLM child.  Applies `vllm_config["_env"]` (if present) to `os.environ` before importing vLLM. | Worker + Child                 |
 | `wait()`                | Block the main process until all pending commands complete.  | Main process                               |
 | `sleep()`               | `llm.sleep(level=2)` -- frees GPU memory for both main and drafter weights.  Main and drafter `named_buffers()` ride the stock vLLM / arctic CPU snapshot path; main and drafter `named_parameters()` come back via the pinned-buffer `stage` / `restore_weights` pair, so the per-sleep CPU snapshot of drafter parameters is suppressed (see *Arctic patch interaction*). | Child |
-| `checkpoint_cuda()`          | Save CUDA state to CPU via `cuCheckpointProcess`*.  Instance becomes stateless (`gpu=None`). | Worker (ctypes) |
-| `save_image(filename)`        | CRIU-dump the child process tree to disk (destructive).  The child is killed after the image is written.  Writes `meta.json` with `vllm_config` (including `_env` if set) and CRIU metadata. | Worker (child thread) |
-| `load_image(filename)`        | Restore a process from a CRIU image on disk.  Validates that the image's `vllm_config` matches this instance.  Spawns a new worker and CRIU-restores the child.  Does *not* re-apply `_env` -- the child's `os.environ` is captured inside the CRIU image and restored verbatim. | Worker |
-| `restore_cuda(gpu)`          | Restore checkpointed CUDA state onto the specified GPU.  `gpu` is required. | Worker (ctypes) |
+| `cuda_checkpoint()`          | Save CUDA state to CPU via `cuCheckpointProcess`*.  Instance becomes stateless (`gpu=None`). | Worker (ctypes) |
+| `criu_dump(filename)`        | CRIU-dump the child process tree to disk (destructive).  The child is killed after the image is written.  Writes `meta.json` with `vllm_config` (including `_env` if set) and CRIU metadata. | Worker (child thread) |
+| `criu_restore(filename)`        | Restore a process from a CRIU image on disk.  Validates that the image's `vllm_config` matches this instance.  Spawns a new worker and CRIU-restores the child.  Does *not* re-apply `_env` -- the child's `os.environ` is captured inside the CRIU image and restored verbatim. | Worker |
+| `cuda_restore(gpu)`          | Restore checkpointed CUDA state onto the specified GPU.  `gpu` is required. | Worker (ctypes) |
 | `attach()`              | Allocate unpinned CPU memory sized to the union of `main.named_parameters()` and (if present) `drafter.model.named_parameters()`.  Speculative-decoding drafters that expose a `.model` (Eagle / Medusa / DraftModel / ArcticProposer) contribute extra entries; non-model drafters (Ngram / Suffix) are skipped, in which case the layout collapses to main params only. | Child |
-| `attach_pinned()`       | Allocate CPU memory pinned for its entire lifetime (via torch `pin_memory=True`).  Skips the per-cycle `repin()`/`unpin()` pattern at the cost of ~34 ms/GiB extra inside `checkpoint_cuda`/`restore_cuda`.  Calling `repin()`/`unpin()` on a buffer created via `attach_pinned()` raises. | Child |
+| `attach_pinned()`       | Allocate CPU memory pinned for its entire lifetime (via torch `pin_memory=True`).  Skips the per-cycle `repin()`/`unpin()` pattern at the cost of ~34 ms/GiB extra inside `cuda_checkpoint`/`cuda_restore`.  Calling `repin()`/`unpin()` on a buffer created via `attach_pinned()` raises. | Child |
 | `detach()`              | Free CPU memory buffer.                                      | Child                                      |
 | `repin()`               | `cudaHostRegister` the buffer for DMA transfers.             | Child                                      |
 | `unpin()`               | `cudaHostUnregister` the buffer (data stays, CUDA registration removed). | Child                           |
@@ -150,7 +150,7 @@ primitives must be:
 | `wake_up_weights()`     | Re-allocate weight tensors on GPU (main + drafter).  The arctic patch's disk reload of the main model is suppressed via `_skip_main_reload_on_wake`; both main and drafter parameters are populated by the subsequent `restore_weights()` from the pinned buffer.  Drafter `named_buffers()` are restored here from the per-sleep CPU snapshot. | Child |
 | `wake_up_kv_cache()`    | Re-allocate KV cache on GPU.                                 | Child                                      |
 | `generate(prompts, sp)` | Submit inference to the engine.  Assigns a unique `req_id`; result stored in `generate_results[req_id]` and `last_generate_result`. | Child (async engine loop) |
-| `pause()`               | Freeze the engine and snapshot in-flight requests.  Sets `_paused`, captures every active sub-request's `(prompt_token_ids, output_token_ids_so_far, sampling_params)` into a child-local list, then `engine.abort_request(eids)` so subsequent `unpin`/`sleep`/`checkpoint_cuda` are safe.  Pending `generate_done` messages are deferred until `resume`. | Child |
+| `pause()`               | Freeze the engine and snapshot in-flight requests.  Sets `_paused`, captures every active sub-request's `(prompt_token_ids, output_token_ids_so_far, sampling_params)` into a child-local list, then `engine.abort_request(eids)` so subsequent `unpin`/`sleep`/`cuda_checkpoint` are safe.  Pending `generate_done` messages are deferred until `resume`. | Child |
 | `resume()`              | Re-add saved requests via prefill and unfreeze the engine.  For each saved record, calls `engine.add_request(new_eid, TokensPrompt(prompt + output_so_far), SamplingParams(max_tokens=remaining, ...))`, repopulates `_active_reqs`, then clears `_paused`.  Original `req_id` continues seamlessly; eventual completion folds pre-pause `output_text` and token counts into the reported view. | Child |
 | `teardown()`            | Tear down the instance, worker, and child.  Resets to created state, ready for `init(gpu)` again. | Worker + Child |
 | `remove()`              | Deregister from the class-level registry (`Instance._all`).  Non-blocking and non-destructive; does not touch the worker process or pending commands.  Returns the `Instance` class so a chained `status()` resolves to the classmethod view. | Main process |
@@ -195,26 +195,26 @@ works on memory registered via `cudaHostRegister`.
 
 ### Standard sequences
 
-- **Registration**: `attach() -> repin() -> stage() -> unpin() -> sleep() -> checkpoint_cuda()`
-- **Save to disk**: `... -> checkpoint_cuda() -> save_image(filename)`
-- **Load from disk**: `load_image(filename) -> plan_restore_weights() -> restore_cuda(gpu) -> ...`
-- **Generate restore**: `restore_cuda(gpu) -> wake_up_weights() -> repin() -> restore_weights() -> wake_up_kv_cache() -> ...`
-- **Generate checkpoint**: `... -> unpin() -> sleep() -> checkpoint_cuda()`
-- **Pause checkpoint**: `pause() -> unpin() -> sleep() -> checkpoint_cuda()`
-- **Pause restore**: `restore_cuda(gpu) -> repin() -> wake_up_weights() -> restore_weights() -> wake_up_kv_cache() -> resume()`
+- **Registration**: `attach() -> repin() -> stage() -> unpin() -> sleep() -> cuda_checkpoint()`
+- **Save to disk**: `... -> cuda_checkpoint() -> criu_dump(filename)`
+- **Load from disk**: `criu_restore(filename) -> plan_restore_weights() -> cuda_restore(gpu) -> ...`
+- **Generate restore**: `cuda_restore(gpu) -> wake_up_weights() -> repin() -> restore_weights() -> wake_up_kv_cache() -> ...`
+- **Generate checkpoint**: `... -> unpin() -> sleep() -> cuda_checkpoint()`
+- **Pause checkpoint**: `pause() -> unpin() -> sleep() -> cuda_checkpoint()`
+- **Pause restore**: `cuda_restore(gpu) -> repin() -> wake_up_weights() -> restore_weights() -> wake_up_kv_cache() -> resume()`
 
-`plan_restore_weights()` is chained right after `load_image(filename)` because that
+`plan_restore_weights()` is chained right after `criu_restore(filename)` because that
 is when the instance has hydrated `total_gpu_bytes` and `pinned_cpu_bytes`
 from `meta.json`.  The plan caches in the worker, survives `up <-> sleep`
-cycles, and is rebuilt on each fresh `load_image(filename)`.  Cold start does not
+cycles, and is rebuilt on each fresh `criu_restore(filename)`.  Cold start does not
 need it (cold start never calls `restore_weights()`), and in-memory
-checkpoint+restore paths that skip `save_image`/`load_image` rely on the single-chunk
+checkpoint+restore paths that skip `criu_dump`/`criu_restore` rely on the single-chunk
 fallback inside `restore_weights()`.
 
 ## stage / plan_restore_weights / restore_weights Pipeline
 
 `stage()` (host capture) and `restore_weights()` (device populate) are an
-inverse pair around the pinned CPU buffer.  Between `load_image(filename)` and
+inverse pair around the pinned CPU buffer.  Between `criu_restore(filename)` and
 the first `restore_weights()`, the instance calls `plan_restore_weights()` to
 build and cache a chunk plan in the worker.  `restore_weights()` then
 executes the cached plan as pure I/O.
@@ -292,7 +292,7 @@ consistent for CRIU checkpoint/restore (see *Known Issues* below).
 
 When `chunk_plan` is `None` (paths that never called
 `plan_restore_weights`, such as in-memory checkpoint+restore tests that
-skip `save_image`/`load_image`), the handler falls back to a single-chunk plan
+skip `criu_dump`/`criu_restore`), the handler falls back to a single-chunk plan
 covering the entire `index`, which is byte-identical to the
 pre-chunking behavior.
 
@@ -333,9 +333,9 @@ precise `param X exceeds chunk_size` message rather than via a
 separate threshold.
 
 `total_gpu_bytes` (NVML `.total` at `init`) and `pinned_cpu_bytes` are
-written into `meta.json` at `save_image` time in the order
+written into `meta.json` at `criu_dump` time in the order
 `{vllm_config, total_gpu_bytes, pinned_cpu_bytes}`.  Old images that
-predate `total_gpu_bytes` are still loadable: `Instance.load_image` falls
+predate `total_gpu_bytes` are still loadable: `Instance.criu_restore` falls
 back to the legacy `pinned_bytes` key for `pinned_cpu_bytes`, and a
 missing `total_gpu_bytes` causes `plan_restore_weights` to send
 `max_buffer_bytes=None`, which yields the single-chunk fallback in
@@ -366,9 +366,9 @@ are non-blocking, chainable, and idempotent.
 
 After `pause`, the engine has no in-flight requests and no KV
 blocks held on its behalf, so subsequent `unpin` / `sleep` /
-`checkpoint_cuda` are safe.  The captured state lives as a plain
+`cuda_checkpoint` are safe.  The captured state lives as a plain
 Python list, which CRIU dumps and restores for free across
-`checkpoint_cuda` / `restore_cuda`, so no extra plumbing is needed.
+`cuda_checkpoint` / `cuda_restore`, so no extra plumbing is needed.
 
 The captured fields per sub-request `eid` come from the child's
 own bookkeeping (populated incrementally in `_process_step_outputs`):
@@ -424,7 +424,7 @@ blocks (not implemented here).
 
 After `pause`, the child no longer produces `generate_done` messages,
 so the worker would deadlock on `_drain_pipe_generates` -- which
-synchronous commands like `sleep` / `checkpoint_cuda` call before
+synchronous commands like `sleep` / `cuda_checkpoint` call before
 forwarding.  The worker mirrors `_paused` in `_worker_paused` (set on
 a successful `pause` ack, cleared on `resume`) and turns the drain
 into a no-op while paused.  `_pending_generates` itself is unchanged
@@ -441,8 +441,8 @@ set on the default forwarding path.
 instance_1 = Instance(vllm_config_1)
 instance_2 = Instance(vllm_config_2)
 
-instance_1.init(gpu=0).attach().repin().stage().unpin().sleep().checkpoint_cuda()
-instance_2.init(gpu=1).attach().repin().stage().unpin().sleep().checkpoint_cuda()
+instance_1.init(gpu=0).attach().repin().stage().unpin().sleep().cuda_checkpoint()
+instance_2.init(gpu=1).attach().repin().stage().unpin().sleep().cuda_checkpoint()
 ```
 
 `init()` loads real weights via `load_format=auto`, so vLLM runs
@@ -450,39 +450,39 @@ instance_2.init(gpu=1).attach().repin().stage().unpin().sleep().checkpoint_cuda(
 `attach()` allocates an unpinned CPU buffer sized to the model's
 parameters.  `repin()` registers it with CUDA for DMA.  `stage()`
 snapshots the post-processed GPU parameters into the buffer.  `unpin()`
-removes the CUDA registration so that `checkpoint_cuda()` is fast (the CUDA
+removes the CUDA registration so that `cuda_checkpoint()` is fast (the CUDA
 driver does not need to re-map pinned pages on restore).  The buffer
-data survives `unpin()`, `sleep()`, and `checkpoint_cuda()` since it is CPU
+data survives `unpin()`, `sleep()`, and `cuda_checkpoint()` since it is CPU
 memory.
 
 ### Save to disk
 
-After checkpoint, `save_image()` writes a CRIU image to disk.  The dump is
+After checkpoint, `criu_dump()` writes a CRIU image to disk.  The dump is
 destructive — the child process is killed after the image is written.
 The worker exits and the instance returns to a clean state:
 
 ```python
 inst = Instance(vllm_config)
-inst.init(gpu=0).attach().repin().stage().unpin().sleep().checkpoint_cuda()
-inst.save_image("/data-fast/image-cache/my_model").wait()
+inst.init(gpu=0).attach().repin().stage().unpin().sleep().cuda_checkpoint()
+inst.criu_dump("/data-fast/image-cache/my_model").wait()
 # child is dead, worker exits
 ```
 
 ### Load from disk
 
-Every use after save goes through `load_image()`, which restores a fresh
+Every use after save goes through `criu_restore()`, which restores a fresh
 process from the on-disk image.  The instance's `vllm_config` must
 match the saved image's config (validated automatically):
 
 ```python
 inst = Instance(vllm_config)
-inst.load_image("/data-fast/image-cache/my_model").plan_restore_weights().wait()
+inst.criu_restore("/data-fast/image-cache/my_model").plan_restore_weights().wait()
 
-inst.restore_cuda(gpu=0).wake_up_weights().repin().restore_weights().wake_up_kv_cache()
+inst.cuda_restore(gpu=0).wake_up_weights().repin().restore_weights().wake_up_kv_cache()
 inst.generate(prompts, sampling_params).wait()
 ```
 
-`plan_restore_weights()` is chained right after `load_image()` because that is
+`plan_restore_weights()` is chained right after `criu_restore()` because that is
 when the instance has hydrated `total_gpu_bytes` and `pinned_cpu_bytes`
 from `meta.json`.
 
@@ -495,7 +495,7 @@ initializing instance 3 on the same GPU.
 instance_1.wait()
 
 instance_3 = Instance(vllm_config_3)
-instance_3.init(gpu=0).attach().repin().stage().unpin().sleep().checkpoint_cuda()
+instance_3.init(gpu=0).attach().repin().stage().unpin().sleep().cuda_checkpoint()
 
 instance_3.wait()
 instance_2.wait()
@@ -507,7 +507,7 @@ After cold-start, weights are already staged in pinned CPU memory
 (unpinned from CUDA).  Restore re-pins and moves them CPU→GPU:
 
 ```python
-instance_1.restore_cuda(gpu=0)
+instance_1.cuda_restore(gpu=0)
 instance_1.repin()
 instance_1.wake_up_weights()
 instance_1.restore_weights()
@@ -520,15 +520,15 @@ result = instance_1.last_generate_result
 To re-checkpoint after generate:
 
 ```python
-instance_1.unpin().sleep().checkpoint_cuda().wait()
+instance_1.unpin().sleep().cuda_checkpoint().wait()
 ```
 
 ### Swap active model on a GPU
 
 ```python
-instance_1.unpin().sleep().checkpoint_cuda().wait()
+instance_1.unpin().sleep().cuda_checkpoint().wait()
 
-instance_3.restore_cuda(gpu=0).repin()
+instance_3.cuda_restore(gpu=0).repin()
 instance_3.wake_up_weights()
 instance_3.restore_weights()
 instance_3.wake_up_kv_cache()
@@ -544,15 +544,15 @@ vllm_config_5 = {"model": "Qwen/Qwen3-1.7B", "gpu_memory_utilization": 0.4}
 instance_4 = Instance(vllm_config_4)
 instance_5 = Instance(vllm_config_5)
 
-instance_2.sleep().detach().checkpoint_cuda().wait()
+instance_2.sleep().detach().cuda_checkpoint().wait()
 
 instance_4.init(gpu=1)
 instance_4.wait()
 instance_5.init(gpu=1)
 instance_4.attach().repin().stage()
 instance_5.attach().repin().stage()
-instance_4.unpin().sleep().checkpoint_cuda()
-instance_5.unpin().sleep().checkpoint_cuda()
+instance_4.unpin().sleep().cuda_checkpoint()
+instance_5.unpin().sleep().cuda_checkpoint()
 instance_4.wait()
 instance_5.wait()
 ```
@@ -562,8 +562,8 @@ Reload both on the same GPU at the same time:
 ```python
 # In-memory checkpoint+restore (no save/load), so plan_restore_weights
 # is not chained: restore_weights falls back to a single-chunk plan.
-instance_4.restore_cuda(gpu=1).repin().wake_up_weights().restore_weights().wake_up_kv_cache()
-instance_5.restore_cuda(gpu=1).repin().wake_up_weights().restore_weights().wake_up_kv_cache()
+instance_4.cuda_restore(gpu=1).repin().wake_up_weights().restore_weights().wake_up_kv_cache()
+instance_5.cuda_restore(gpu=1).repin().wake_up_weights().restore_weights().wake_up_kv_cache()
 
 instance_4.wait()
 instance_5.wait()
@@ -574,17 +574,17 @@ responsibility to serialize (e.g. by calling `wait()` between inits).
 
 ### Cross-GPU migration
 
-Once checkpointed, an instance is stateless (`gpu=None`).  `restore_cuda(gpu)`
+Once checkpointed, an instance is stateless (`gpu=None`).  `cuda_restore(gpu)`
 specifies which GPU to restore onto -- it can be the same or a different
 GPU.
 
 ```python
 instance = Instance(vllm_config)
-instance.init(gpu=0).attach().repin().stage().unpin().sleep().checkpoint_cuda().wait()
+instance.init(gpu=0).attach().repin().stage().unpin().sleep().cuda_checkpoint().wait()
 # instance.gpu is now None
 
 # Restore on GPU 1
-instance.restore_cuda(gpu=1).repin()
+instance.cuda_restore(gpu=1).repin()
 instance.wake_up_weights().restore_weights().wake_up_kv_cache()
 instance.wait()
 # instance.gpu is now 1
@@ -601,12 +601,12 @@ counts folded as if the pause never happened.
 instance.generate(prompts, sampling_params)  # long-running
 
 # ... some time later, after partial decode ...
-instance.pause().unpin().sleep().checkpoint_cuda().wait()
+instance.pause().unpin().sleep().cuda_checkpoint().wait()
 # instance.gpu is now None; KV blocks freed; only token-id state lives in CPU.
 
 # ... model is swapped out, another instance runs on the GPU ...
 
-instance.restore_cuda(gpu=0).repin().wake_up_weights().restore_weights() \
+instance.cuda_restore(gpu=0).repin().wake_up_weights().restore_weights() \
         .wake_up_kv_cache().resume().wait()
 result = instance.last_generate_result   # original req_id, full output
 ```
@@ -633,7 +633,7 @@ inst.sleep() -----> cmd_queue
                      completed_counter += 1
                      result_queue.put()
 
-inst.checkpoint_cuda()--> cmd_queue
+inst.cuda_checkpoint()--> cmd_queue
                      _worker_checkpoint(pid)
                        enumerate descendants via psutil
                        checkpoint EngineCore (leaf first)
@@ -651,7 +651,7 @@ inst.wait() <-------- demuxer.wait_idle()  (condvar on _pending_count)
 Each Instance owns a single per-instance `Demuxer` thread (see
 [`demuxer.py`](../demuxer.py)) that is the **sole consumer** of
 `_result_queue`.  The demuxer is created lazily by `_ensure_queues`
-(at `init` / `load_image`) and torn down by `_close_queues` (at
+(at `init` / `criu_restore`) and torn down by `_close_queues` (at
 `teardown` / `_reset`).  For every result it:
 
 1. Calls `_apply_result` (with prompts pre-injected for generate
@@ -678,7 +678,7 @@ both racing for `_result_queue.get()`.
 `wait()` once, including from many threads at once:
 
 ```python
-instance.unpin().sleep().checkpoint_cuda().wait()
+instance.unpin().sleep().cuda_checkpoint().wait()
 ```
 
 If any cmd in this batch failed at the worker, the first error is
@@ -700,7 +700,7 @@ same set.
 
 ### Cross-GPU Restore
 
-`restore_cuda(gpu)` supports restoring onto a different GPU using the CUDA
+`cuda_restore(gpu)` supports restoring onto a different GPU using the CUDA
 driver's `CUcheckpointRestoreArgs` with `CUcheckpointGpuPair` UUID
 mapping (requires driver 580+).  The GPU pair mapping must be a valid
 permutation: old_gpu swaps with new_gpu, all others map to themselves.

--- a/arctic_inference/semi_persistence/skills/orchestrator_DESIGN.md
+++ b/arctic_inference/semi_persistence/skills/orchestrator_DESIGN.md
@@ -501,12 +501,12 @@ of the same model with different `_env` correctly resolve to two
 distinct backing models.
 
 `_env` is persisted into `meta.json` alongside the rest of
-`vllm_config` (via `save_image`'s `meta_extra`), so it survives orch
+`vllm_config` (via `criu_dump`'s `meta_extra`), so it survives orch
 reboots: on the next `Orchestrator.init`, the saved model is
 rediscovered with `_env` intact and dedup remains honest.
 
 CRIU restore captures the child's `os.environ` directly into the
-image, so `load_image` paths inherit the dump-time env without
+image, so `criu_restore` paths inherit the dump-time env without
 re-applying `_env` from `meta.json`.  `_env` is therefore consulted
 only on cold-start paths (`register` itself).
 
@@ -721,7 +721,7 @@ same code path -- both flavours converge on
 Allowed at every ladder state at which pause itself is allowed
 (`up`, `sleep`, `checkpoint` -- see "Walking down past `up` while
 paused"); the policy is order-independent w.r.t. any
-interleaving of `pause`, `sleep`, `checkpoint_cuda`, and
+interleaving of `pause`, `sleep`, `cuda_checkpoint`, and
 `generate` on the pipe, because none of those interleavings can
 expose the engine to a scheduler mutation while paused.  See
 "Generate-while-paused stash" in
@@ -912,7 +912,7 @@ system is live without restarting the orchestrator or any vLLM child.
 Synchronous, fast (pure bookkeeping).  Validates that `gpu` is visible
 to NVML (`nvmlDeviceGetCount`); if not, raises `ValueError` rather than
 admitting a non-existent device — the slot allocator would eventually
-hand it out and `restore_cuda(gpu=N)` would crash inside
+hand it out and `cuda_restore(gpu=N)` would crash inside
 `_build_restore_args` on the out-of-range UUID lookup, deadlocking the
 dependent `repin` already pipelined into the vLLM child.
 
@@ -1586,7 +1586,7 @@ breakdown and the `_move_sync` poll-loop pattern.
 `generate(mid, ...)` on the same model could hang the vLLM
 child.  Symptom: the worker queue accumulated
 `wake_up_kv_cache -> sleep -> generate -> unpin ->
-checkpoint_cuda` back-to-back; the engine tried to schedule
+cuda_checkpoint` back-to-back; the engine tried to schedule
 the request against cumem memory that `sleep` had just
 freed, and stuck.
 

--- a/arctic_inference/semi_persistence/skills/reference.md
+++ b/arctic_inference/semi_persistence/skills/reference.md
@@ -252,7 +252,7 @@ comes back via `cuda-checkpoint restore`.
 | 4 | stdout/stderr | `dup2 /dev/null`, restore with `--inherit-fd` |
 | 5 | Pipe FD through `sudo` | Pass via `SCM_RIGHTS`, helper `dup2`s then `execvp`s |
 | 6 | CUDA context | Driver API rather than the CLI |
-| 7 | CRIU plugin directory | `/usr/lib/criu/empty` must exist (`--libdir`) |
+| 7 | CRIU plugin directory | `--libdir` needs `/usr/lib/criu/empty`; the dump creates it |
 | 8 | PID collisions at restore | Restore into a private PID namespace; retry loop as backstop |
 | 9 | Ghost remap race (CRIU 4.2) | `--link-remap` handling |
 | 10 | Per-restore PID namespace, and the tty it forced out | Reaper + private `/proc`; child `setsid`, `--shell-job` dropped |

--- a/arctic_inference/semi_persistence/skills/reference.md
+++ b/arctic_inference/semi_persistence/skills/reference.md
@@ -14,8 +14,8 @@ stay optimal, and **chainable** — they all return `self`.
 
 ```python
 inst = Instance({"model": "Qwen/Qwen3-8B-FP8", "enforce_eager": True})
-inst.init(gpu=0).attach().repin().stage().unpin().sleep().checkpoint_cuda()
-inst.save_image("/data-fast/image-cache/foo").wait()
+inst.init(gpu=0).attach().repin().stage().unpin().sleep().cuda_checkpoint()
+inst.criu_dump("/data-fast/image-cache/foo").wait()
 ```
 
 ### Lifecycle
@@ -23,8 +23,8 @@ inst.save_image("/data-fast/image-cache/foo").wait()
 | Primitive | Effect | Runs in |
 |---|---|---|
 | `init(gpu)` | Cold start with real weights; spawns worker + child; applies `_env` | Worker + child |
-| `load_image(path)` | CRIU-restore from disk; validates the image's `vllm_config` matches | Worker |
-| `save_image(path)` | CRIU-dump the child tree (**destructive**); writes `meta.json` | Worker |
+| `criu_restore(path)` | CRIU-restore from disk; validates the image's `vllm_config` matches | Worker |
+| `criu_dump(path)` | CRIU-dump the child tree (**destructive**); writes `meta.json` | Worker |
 | `teardown()` | Tear down instance, worker, child; resets to created state | Worker + child |
 | `remove()` | Deregister from `Instance._all`; non-blocking, non-destructive | Main |
 | `wait()` | Block until pending commands complete | Main |
@@ -34,8 +34,8 @@ inst.save_image("/data-fast/image-cache/foo").wait()
 | Primitive | Effect |
 |---|---|
 | `sleep()` | `llm.sleep(level=2)` — frees GPU memory for main and drafter weights |
-| `checkpoint_cuda()` | Save CUDA state to CPU via `cuCheckpointProcess`; `gpu` becomes `None` |
-| `restore_cuda(gpu)` | Restore CUDA state onto a specific GPU (`gpu` is required) |
+| `cuda_checkpoint()` | Save CUDA state to CPU via `cuCheckpointProcess`; `gpu` becomes `None` |
+| `cuda_restore(gpu)` | Restore CUDA state onto a specific GPU (`gpu` is required) |
 | `wake_up_weights()` | Re-allocate weight tensors on GPU (main + drafter) |
 | `wake_up_kv_cache()` | Re-allocate the KV cache on GPU |
 
@@ -66,7 +66,7 @@ skipped, collapsing the layout to main params only.
 
 `pause` captures each active sub-request's `(prompt_token_ids,
 output_token_ids_so_far, sampling_params)` so that `unpin` / `sleep` /
-`checkpoint_cuda` are safe afterwards. `resume` replays them under a fresh
+`cuda_checkpoint` are safe afterwards. `resume` replays them under a fresh
 engine id while the caller's original `req_id` continues seamlessly; the final
 result folds pre-pause text and token counts back in.
 
@@ -226,7 +226,7 @@ for the pipe plus stdout/stderr, `--link-remap`, `--tcp-close`, and
 
 `meta.json` alongside the image holds the `vllm_config` (including `_env`) and
 the CRIU metadata, which is what lets the orchestrator rediscover saved models
-on reboot and lets `load_image` validate the image against the instance.
+on reboot and lets `criu_restore` validate the image against the instance.
 
 ---
 
@@ -291,7 +291,7 @@ source, which the security scanner flags as arbitrary code execution.
 - **`_env` reserved trio** (`CUDA_VISIBLE_DEVICES`,
   `VLLM_ENABLE_V1_MULTIPROCESSING`, `USE_LIBUV`) is hard-set at the top of the
   child loop and silently dropped from `_env`, but stays in the on-disk copy.
-- **`load_image` does not re-apply `_env`** — the environment is captured inside
+- **`criu_restore` does not re-apply `_env`** — the environment is captured inside
   the CRIU image and restored verbatim.
 - **NVML, not torch,** for GPU memory queries in the main process, to avoid
   initializing CUDA there.

--- a/arctic_inference/semi_persistence/skills/reference.md
+++ b/arctic_inference/semi_persistence/skills/reference.md
@@ -51,7 +51,7 @@ placement only and must have exactly that many entries. See
 
 | Primitive | Effect |
 |---|---|
-| `destroy_nccl(graph_mode="reuse")` | Tear down NCCL and CustomAllreduce IPC before a checkpoint |
+| `destroy_nccl(graph_mode="reuse")` | Tear down NCCL and CustomAllreduce IPC before a checkpoint. Also marks the worker's inet TCP sockets `SO_LINGER(1,0)` so their ports skip `TIME_WAIT` when the dump kills the tree (Complication 12) |
 | `reinit_nccl()` | Rebuild NCCL on a fresh port. Must run after `cuda_restore` and before the model runs or a captured graph replays; `attach`/`load_weights` are CPU-only and unconstrained by it |
 | `cleargraph(graph_mode="reuse")` | Drop CUDA-graph exec handles; `reuse` preserves them |
 | `recapture_graphs(graph_mode="reuse")` | Rebind (`reuse`) or recapture (`full`) decode graphs, after `wake_up_kv_cache` |
@@ -235,13 +235,14 @@ run the destructive `criu dump`.
 
 ### Restore sequence
 
-Pass the pipe FD through a Unix socket via `SCM_RIGHTS` into a `sudo`'d helper,
-which `dup2`s it into place, unshares a private PID namespace, and runs `criu
-restore` inside it with `--inherit-fd` for the pipe plus stdout/stderr,
-`--link-remap` and `--tcp-close` (no `--shell-job` — the child holds no tty).
-The CUDA context comes back via `cuda-checkpoint restore`.
+Pass the pipe FD through a Unix socket via `SCM_RIGHTS` into a helper (under
+`sudo` only when the worker is not already root), which `dup2`s it into place,
+unshares a private PID namespace, and runs `criu restore` inside it with
+`--inherit-fd` for the pipe plus stdout/stderr, `--link-remap` and
+`--tcp-close` (no `--shell-job` — the child holds no tty).  The CUDA context
+comes back via `cuda-checkpoint restore`.
 
-### The eleven complications
+### The twelve complications
 
 | # | Complication | Shape of the fix |
 |---|---|---|
@@ -256,6 +257,7 @@ The CUDA context comes back via `cuda-checkpoint restore`.
 | 9 | Ghost remap race (CRIU 4.2) | `--link-remap` handling |
 | 10 | Per-restore PID namespace, and the tty it forced out | Reaper + private `/proc`; child `setsid`, `--shell-job` dropped |
 | 11 | Unprivileged dump + restore | `SEMIP_UNPRIVILEGED=1`: `--unprivileged` on both sides, no-namespace restore, caps shed in the child |
+| 12 | `TIME_WAIT` on the recorded local port | `SO_LINGER(1,0)` on the workers' inet TCP sockets, so the dump's kill RSTs instead of FINs |
 
 `meta.json` alongside the image holds the `vllm_config` (including `_env`) and
 the CRIU metadata, which is what lets the orchestrator rediscover saved models

--- a/arctic_inference/semi_persistence/skills/reference.md
+++ b/arctic_inference/semi_persistence/skills/reference.md
@@ -22,22 +22,39 @@ inst.criu_dump("/data-fast/image-cache/foo").wait()
 
 | Primitive | Effect | Runs in |
 |---|---|---|
-| `init(gpu)` | Cold start with real weights; spawns worker + child; applies `_env` | Worker + child |
-| `criu_restore(path)` | CRIU-restore from disk; validates the image's `vllm_config` matches | Worker |
-| `criu_dump(path)` | CRIU-dump the child tree (**destructive**); writes `meta.json` | Worker |
+| `init(gpus=[...])` | Cold start with real weights; spawns worker + child; applies `_env`. A scalar `gpu=` still works at TP=1 | Worker + child |
+| `criu_restore(path=None)` | CRIU-restore from disk; validates the image's `vllm_config` and `model_dir` match. Defaults to `<model_dir>/image` | Worker |
+| `criu_dump(path=None)` | CRIU-dump the child tree (**destructive**); writes `meta.json`. Defaults to `<model_dir>/image` | Worker |
 | `teardown()` | Tear down instance, worker, child; resets to created state | Worker + child |
 | `remove()` | Deregister from `Instance._all`; non-blocking, non-destructive | Main |
 | `wait()` | Block until pending commands complete | Main |
+
+`Instance(vllm_config, model_dir=None)`. With a `model_dir`, the dump and
+restore paths default to `<model_dir>/image` and the compile cache moves
+under `<model_dir>/compilation`; see [semi-p_DESIGN.md](semi-p_DESIGN.md).
 
 ### GPU residency
 
 | Primitive | Effect |
 |---|---|
 | `sleep()` | `llm.sleep(level=2)` — frees GPU memory for main and drafter weights |
-| `cuda_checkpoint()` | Save CUDA state to CPU via `cuCheckpointProcess`; `gpu` becomes `None` |
-| `cuda_restore(gpu)` | Restore CUDA state onto a specific GPU (`gpu` is required) |
+| `cuda_checkpoint()` | Save CUDA state to CPU via `cuCheckpointProcess`; `gpu` becomes `None`. At TP>1 also inserts `cleargraph` + `destroy_nccl` first |
+| `cuda_restore(gpus=[...])` | Restore CUDA state onto specific GPU(s). Defaults to the placement recorded in the image; a scalar `gpu=` still works at TP=1 |
 | `wake_up_weights()` | Re-allocate weight tensors on GPU (main + drafter) |
 | `wake_up_kv_cache()` | Re-allocate the KV cache on GPU |
+
+### Tensor parallel (no-ops at TP=1)
+
+TP size comes from `vllm_config["tensor_parallel_size"]`; `gpus` is
+placement only and must have exactly that many entries. See
+[tp_DESIGN.md](tp_DESIGN.md).
+
+| Primitive | Effect |
+|---|---|
+| `destroy_nccl(graph_mode="reuse")` | Tear down NCCL and CustomAllreduce IPC before a checkpoint |
+| `reinit_nccl()` | Rebuild NCCL on a fresh port. Must run immediately after `cuda_restore`, before any collective |
+| `cleargraph(graph_mode="reuse")` | Drop CUDA-graph exec handles; `reuse` preserves them |
+| `recapture_graphs(graph_mode="reuse")` | Rebind (`reuse`) or recapture (`full`) decode graphs, after `wake_up_kv_cache` |
 
 ### CPU buffer and weight transfer
 
@@ -48,8 +65,14 @@ inst.criu_dump("/data-fast/image-cache/foo").wait()
 | `detach()` | Free the CPU buffer |
 | `repin()` / `unpin()` | `cudaHostRegister` / `cudaHostUnregister` the buffer |
 | `stage()` | Snapshot main + drafter params GPU -> pinned CPU |
-| `plan_restore_weights()` | Build and cache a chunk plan under a computed byte budget |
+| `save_weights()` | Write the staged buffer to `<model_dir>/weights` as shards + `weights_meta.json`. Call after `stage()`, before `detach()`, so the image stays small |
+| `load_weights()` | Read those shards back into the buffer. Requires a prior `attach()` on the restore side |
+| `plan_restore_weights(max_buffer_bytes=None)` | Build and cache a chunk plan under a computed byte budget; pass an explicit cap for older images |
 | `restore_weights()` | Execute the cached plan: buffer -> one reused GPU staging buffer -> scatter |
+
+`save_weights` / `load_weights` are optional: without them the staged
+weights stay inside the CRIU image, which is what the orchestrator does.
+At TP>1 the shards fan out to `weights/rank{R}/`.
 
 The drafter contributes extra parameter entries only when it exposes a `.model`
 (Eagle / Medusa / DraftModel / ArcticProposer). Ngram and Suffix drafters are

--- a/arctic_inference/semi_persistence/skills/reference.md
+++ b/arctic_inference/semi_persistence/skills/reference.md
@@ -236,11 +236,12 @@ run the destructive `criu dump`.
 ### Restore sequence
 
 Pass the pipe FD through a Unix socket via `SCM_RIGHTS` into a `sudo`'d helper,
-which `dup2`s it into place and `execvp`s `criu restore` with `--inherit-fd`
-for the pipe plus stdout/stderr, `--link-remap`, `--tcp-close`, and
-`--shell-job`. The CUDA context comes back via `cuda-checkpoint restore`.
+which `dup2`s it into place, unshares a private PID namespace, and runs `criu
+restore` inside it with `--inherit-fd` for the pipe plus stdout/stderr,
+`--link-remap` and `--tcp-close` (no `--shell-job` — the child holds no tty).
+The CUDA context comes back via `cuda-checkpoint restore`.
 
-### The nine complications
+### The eleven complications
 
 | # | Complication | Shape of the fix |
 |---|---|---|
@@ -251,12 +252,21 @@ for the pipe plus stdout/stderr, `--link-remap`, `--tcp-close`, and
 | 5 | Pipe FD through `sudo` | Pass via `SCM_RIGHTS`, helper `dup2`s then `execvp`s |
 | 6 | CUDA context | Driver API rather than the CLI |
 | 7 | CRIU plugin directory | `/usr/lib/criu/empty` must exist (`--libdir`) |
-| 8 | PID collisions at restore | Detect and retry |
+| 8 | PID collisions at restore | Restore into a private PID namespace; retry loop as backstop |
 | 9 | Ghost remap race (CRIU 4.2) | `--link-remap` handling |
+| 10 | Per-restore PID namespace, and the tty it forced out | Reaper + private `/proc`; child `setsid`, `--shell-job` dropped |
+| 11 | Unprivileged dump + restore | `SEMIP_UNPRIVILEGED=1`: `--unprivileged` on both sides, no-namespace restore, caps shed in the child |
 
 `meta.json` alongside the image holds the `vllm_config` (including `_env`) and
 the CRIU metadata, which is what lets the orchestrator rediscover saved models
 on reboot and lets `criu_restore` validate the image against the instance.
+
+### Environment switches
+
+| Variable | Effect |
+|---|---|
+| `SEMIP_UNPRIVILEGED=1` | Run dump and restore on a pod granting only `CAP_CHECKPOINT_RESTORE + CAP_SYS_PTRACE`. Adds `--unprivileged` to both, takes the no-namespace restore path, and sheds the child's capabilities so the image is portable to a low-cap node. Costs concurrent restore (one live restore per node). See Complication 11 |
+| `_SEMIP_CHILD_DROP_CAPS=1` | Internal only, set by the worker across the child's spawn. Not a user flag |
 
 ---
 

--- a/arctic_inference/semi_persistence/skills/reference.md
+++ b/arctic_inference/semi_persistence/skills/reference.md
@@ -60,12 +60,12 @@ placement only and must have exactly that many entries. See
 
 | Primitive | Effect |
 |---|---|
-| `attach()` | Allocate unpinned CPU memory sized to main + drafter `named_parameters()` |
-| `attach_pinned()` | Allocate permanently-pinned memory; skips repin/unpin at ~34 ms/GiB cost |
-| `detach()` | Free the CPU buffer |
-| `repin()` / `unpin()` | `cudaHostRegister` / `cudaHostUnregister` the buffer |
-| `stage()` | Snapshot main + drafter params GPU -> pinned CPU |
-| `save_weights()` | Write the staged buffer to `<model_dir>/weights` as shards + `weights_meta.json`. Call after `stage()`, before `detach()`, so the image stays small |
+| `attach()` | Allocate unpinned CPU memory *per worker*, sized to that rank's main + drafter `named_parameters()` |
+| `attach_pinned()` | **Unsupported; raises.** Use `attach()` -> `repin()` |
+| `detach()` | Free each worker's CPU buffer |
+| `repin()` / `unpin()` | `cudaHostRegister` / `cudaHostUnregister` each worker's buffer. Idempotent |
+| `stage()` | Snapshot main + drafter params GPU -> that worker's CPU buffer |
+| `save_weights()` | Write each worker's buffer to `<model_dir>/weights` as shards + `weights_meta.json`. Call after `stage()`, before `detach()`, so the image stays small |
 | `load_weights()` | Read those shards back into the buffer. Requires a prior `attach()` on the restore side |
 | `plan_restore_weights(max_buffer_bytes=None)` | Build and cache a chunk plan under a computed byte budget; pass an explicit cap for older images |
 | `restore_weights()` | Execute the cached plan: buffer -> one reused GPU staging buffer -> scatter |
@@ -73,6 +73,13 @@ placement only and must have exactly that many entries. See
 `save_weights` / `load_weights` are optional: without them the staged
 weights stay inside the CRIU image, which is what the orchestrator does.
 At TP>1 the shards fan out to `weights/rank{R}/`.
+
+All of this state (buffer, param index, chunk plan) lives on the vLLM
+workers as `worker._semip_*` and runs there via `collective_rpc`, not in
+the child process. At TP>1 a buffer held in the child would be
+cloudpickled by value into each worker subprocess and its writes lost;
+each rank also owns a different shard. One code path serves both TP
+sizes. See [instance_DESIGN.md](instance_DESIGN.md).
 
 The drafter contributes extra parameter entries only when it exposes a `.model`
 (Eagle / Medusa / DraftModel / ArcticProposer). Ngram and Suffix drafters are

--- a/arctic_inference/semi_persistence/skills/reference.md
+++ b/arctic_inference/semi_persistence/skills/reference.md
@@ -52,7 +52,7 @@ placement only and must have exactly that many entries. See
 | Primitive | Effect |
 |---|---|
 | `destroy_nccl(graph_mode="reuse")` | Tear down NCCL and CustomAllreduce IPC before a checkpoint |
-| `reinit_nccl()` | Rebuild NCCL on a fresh port. Must run immediately after `cuda_restore`, before any collective |
+| `reinit_nccl()` | Rebuild NCCL on a fresh port. Must run after `cuda_restore` and before the model runs or a captured graph replays; `attach`/`load_weights` are CPU-only and unconstrained by it |
 | `cleargraph(graph_mode="reuse")` | Drop CUDA-graph exec handles; `reuse` preserves them |
 | `recapture_graphs(graph_mode="reuse")` | Rebind (`reuse`) or recapture (`full`) decode graphs, after `wake_up_kv_cache` |
 

--- a/arctic_inference/semi_persistence/skills/semi-p_DESIGN.md
+++ b/arctic_inference/semi_persistence/skills/semi-p_DESIGN.md
@@ -165,6 +165,26 @@ sibling restore or with a zombie left by a destructive dump.  See
 Complications 8 and 10 in [CRIU_PLUMBING.md](CRIU_PLUMBING.md).  Images
 captured before that change carry a tty and must be re-dumped.
 
+**`SEMIP_UNPRIVILEGED=1` trades that concurrency for a lower capability
+floor.** It is the single switch for running on pods that grant only
+`CAP_CHECKPOINT_RESTORE + CAP_SYS_PTRACE` (no `CAP_SYS_ADMIN`): the dump
+gains `--unprivileged`, the restore takes a path with no private PID
+namespace, and the child sheds its capabilities so the image is
+restorable where `capset()` cannot grant real ones.  Two consequences
+worth planning around:
+
+- **At most one live restore per node**, since the recorded PIDs must be
+  free.  `scripts/test_weights.py` restores two models concurrently and
+  is therefore incompatible with this mode.
+- **Portability is decided at dump time.**  An image dumped *without* the
+  flag records real capabilities and cannot be restored on a low-cap node
+  at all; you have to re-dump with the flag set.  Setting it on a
+  privileged pod is fine and is the normal way to produce a portable
+  image -- `--unprivileged` only skips a probe you do not need.
+
+See Complication 11 in [CRIU_PLUMBING.md](CRIU_PLUMBING.md), and validate
+a target node with `sudo criu check --unprivileged`.
+
 ---
 
 ## 5. Known gaps

--- a/arctic_inference/semi_persistence/skills/semi-p_DESIGN.md
+++ b/arctic_inference/semi_persistence/skills/semi-p_DESIGN.md
@@ -1,0 +1,148 @@
+# Model directory and image semantics
+
+How a saved model is laid out on disk, what each part means, and the
+rules an image binds itself to.  Read this before wiring semi-persistence
+into a serving stack, or when debugging a restore that fails on paths,
+config, or stale code.
+
+For the primitive-by-primitive API see [reference.md](reference.md) and
+[instance_DESIGN.md](instance_DESIGN.md); for CRIU internals see
+[CRIU_PLUMBING.md](CRIU_PLUMBING.md); for tensor parallelism see
+[tp_DESIGN.md](tp_DESIGN.md).
+
+---
+
+## 1. The `model_dir` contract
+
+An `Instance` may be constructed with a per-model directory:
+
+```python
+inst = Instance(vllm_config, "/data-fast/image-cache/qwen_35b")
+```
+
+It holds everything a saved model needs, so `criu_dump()` and
+`criu_restore()` take no path:
+
+```
+<model_dir>/
+  compilation/   # per-model JIT/compile cache: Triton, torch inductor,
+                 # vLLM torch.compile, FlashInfer
+  image/         # CRIU image + meta.json
+  weights/       # detachable weight shards: shard_NNNN.bin + weights_meta.json
+                 # (per-rank subdirs weights/rank{R}/ at TP>1)
+```
+
+`model_dir` is optional.  Without it the primitives take explicit paths
+(`criu_dump("/path/to/image")`), the weights directory defaults to a
+`weights` sibling of the image path, and the compile caches keep their
+node-local defaults.  That mode is correct for same-node restore and is
+what the orchestrator uses.
+
+`model_dir` threads `init(gpu)` -> `worker_loop` -> `vllm_child_loop`,
+where the child points its compile-cache environment variables at
+`<model_dir>/compilation` *before* importing vLLM.
+
+**Suggested convention** when you do use it: derive the directory from
+the model path, e.g. `f"{resolve_model_path(model_name)}_image"`.  It is
+deterministic, colocated with the weights, human-readable, needs no
+hashing, and gives CRIU a stable absolute path for the recorded JIT
+mappings.
+
+**One image and one weights set per `model_dir`.** There are no
+per-config subdirectories and no path encoding of TP size, dtype, or
+`max_model_len`.  Binding an image to a specific `vllm_config` in the
+path is not attempted; the config check below does that job instead.
+
+---
+
+## 2. What a re-dump does to each directory
+
+Verified behavior, and the three parts differ:
+
+| Directory | On re-dump |
+|---|---|
+| `image/` | `rm -rf`'d and recreated. CRIU will not reliably overwrite a differing file set, so a stale image could otherwise corrupt the new one. |
+| `weights/` | Fully overwritten (cleared and rewritten). Shard counts vary with model size, so a partial overwrite would leave a mix the manifest cannot detect. |
+| `compilation/` | **Reused, never cleared.** It is a content-keyed cache, so re-dumping into the same directory skips recompilation. |
+
+The `rm -rf` paths fall back to `sudo rm -rf` because an aborted run can
+leave root-owned files behind.
+
+---
+
+## 3. What binds an image
+
+An image is not portable across arbitrary configurations.  `criu_restore`
+checks two things before spawning anything, and both raise immediately
+rather than failing later inside CRIU.
+
+**`vllm_config` must match exactly.**  The comparison is a full dict
+`!=`, so the config passed to `Instance` must be exactly the baked dict,
+with no extra keys.  Because `tensor_parallel_size` lives in the user's
+`vllm_config`, it participates in this check — a TP=2 image cannot be
+mistaken for a TP=1 one.
+
+**`model_dir` must match.**  CRIU records the compile-cache `.so` and
+cubin mappings by absolute path, so an image is bound to the directory it
+was dumped under.  `criu_dump` records `model_dir` in `meta.json` and a
+mismatch is rejected by name.
+
+`meta.json` also carries the CRIU plumbing (`child_pid`, `pipe_fd`,
+`pipe_resource`, `nvidia_fds`), the placement and hardware identity
+(`rank`, `gpus`, `gpu_uuids`), and the budget inputs (`total_gpu_bytes`,
+`pinned_cpu_bytes`, `n_gpus`, `max_pinned_bytes_per_worker`).
+
+---
+
+## 4. Constraints worth knowing before you debug
+
+**Cross-node restore needs the same absolute path.** Copy the whole
+`model_dir` to the target node at the identical path.  The compile cache
+is the reason: its `dlopen`'d artifacts are recorded by absolute path and
+must exist at restore.  The other two cross-node requirements are handled
+automatically — `meta.json` carries the capture node's GPU UUIDs so the
+CUDA restore device map can pair them against the local node's, and the
+child pins vLLM's rendezvous and the NCCL/gloo bootstrap sockets to
+loopback so CRIU does not bake a routable IP into the image.
+
+**A restored child runs the code frozen in the image.** Editing
+`vllm_child.py` has no effect on an existing image: the child resumes
+in-memory code and re-imports nothing from disk.  New behavior only
+appears after an offline re-dump with the updated code.  Keep dump-time
+code and runtime code the same checkout.  This is a common source of
+"my fix did nothing" confusion.
+
+**Root is required.** CUDA checkpoint/restore uses the libcuda driver API
+when `geteuid() == 0` and otherwise falls back to `sudo
+cuda-checkpoint`; CRIU dump and restore always shell out via `sudo`.
+`Instance` spawns its worker and vLLM child with `mp.spawn`, which
+inherits the uid, so the whole process tree must run as root.
+
+**Modules import their siblings by bare name.** `import semip_logging`,
+`from instance import Instance`, and so on, so the package directory must
+be on `sys.path`.  The lazy `__getattr__` in `__init__.py` installs that
+entry on first attribute access, which is what makes
+`from arctic_inference.semi_persistence import Instance` work while still
+letting the spawned worker and child import flat.
+
+**Concurrent restores are supported, deliberately.** Each restore runs
+inside its own PID namespace, so the recorded PIDs cannot collide with a
+sibling restore or with a zombie left by a destructive dump.  See
+Complications 8 and 10 in [CRIU_PLUMBING.md](CRIU_PLUMBING.md).  Images
+captured before that change carry a tty and must be re-dumped.
+
+---
+
+## 5. Known gaps
+
+- **Weight sync is not implemented.** The RL weight-update path is
+  deliberately deferred.
+- **Multiplexing more than one job per GPU with semi-persistence is
+  unvalidated.**
+- **Config compatibility is exact, not semantic.** The flat dict equality
+  above is strict: it rejects configs that differ only in engine-internal
+  or harmless keys. A richer model — bake the full effective engine
+  config at dump time and validate a meaningful subset — is the eventual
+  fix.
+- **`logprobs` are surfaced by the child** but not plumbed through every
+  adapter path.

--- a/arctic_inference/semi_persistence/skills/semi-p_DESIGN.md
+++ b/arctic_inference/semi_persistence/skills/semi-p_DESIGN.md
@@ -99,11 +99,45 @@ mismatch is rejected by name.
 **Cross-node restore needs the same absolute path.** Copy the whole
 `model_dir` to the target node at the identical path.  The compile cache
 is the reason: its `dlopen`'d artifacts are recorded by absolute path and
-must exist at restore.  The other two cross-node requirements are handled
-automatically — `meta.json` carries the capture node's GPU UUIDs so the
-CUDA restore device map can pair them against the local node's, and the
-child pins vLLM's rendezvous and the NCCL/gloo bootstrap sockets to
-loopback so CRIU does not bake a routable IP into the image.
+must exist at restore.  Two of the other cross-node requirements are
+handled automatically — `meta.json` carries the capture node's GPU UUIDs
+so the CUDA restore device map can pair them against the local node's
+(zero overlap between the two UUID sets is the normal case, not an
+error), and the child pins vLLM's rendezvous and the NCCL/gloo bootstrap
+sockets to loopback so CRIU does not bake a routable IP into the image.
+
+**Cross-node restore also needs a byte-identical environment, and this
+one is not checked up front.**  CRIU records every file-backed mapping by
+absolute path *and* size, then re-validates the size when it reopens the
+file at restore.  One mapped file of a different length aborts the entire
+restore:
+
+```
+Error (criu/files-reg.c:2175): File <path> has bad size <local> (expect <image>)
+Error (criu/mem.c:1467): `- Can't open vma
+Error (criu/cr-restore.c:2331): Restoring FAILED.
+```
+
+The venv is where this bites in practice: two nodes that installed the
+same requirements at different times end up with different builds of some
+compiled extension, and CRIU aborts on the first one it hits rather than
+reporting them all.  Unlike the `vllm_config` and `model_dir` checks
+above, there is no early raise — the failure surfaces from inside CRIU.
+Reinstalling from the same requirements is *not* sufficient, because
+identical version specs routinely yield different bytes; copy the tree
+itself (`rsync -a`, or a tarball — never `tar -h`, which dereferences the
+venv's symlinks and changes sizes) to the identical absolute path.
+
+**Check an image against the node before spending a restore attempt.**
+`scripts/imgdiff.py <image_dir>` decodes the image's `files.img` and
+reports every recorded mapping whose local size differs or whose file is
+missing, so a cross-node environment mismatch takes seconds to diagnose
+instead of a failed restore.  It also compares the ELF build-IDs CRIU
+recorded, which catches a same-size-but-different-build library that
+would pass CRIU's size check and then map the wrong text pages.  The one
+entry it always lists and that is never a problem is the `/dev/shm/sem.*`
+ghost file: unlinked at dump time, carried inside the image, recreated by
+CRIU at restore.
 
 **A restored child runs the code frozen in the image.** Editing
 `vllm_child.py` has no effect on an existing image: the child resumes

--- a/arctic_inference/semi_persistence/skills/tp_DESIGN.md
+++ b/arctic_inference/semi_persistence/skills/tp_DESIGN.md
@@ -1,0 +1,293 @@
+# Tensor Parallelism (TP>1) — Design
+
+How the semi-persistence stack supports tensor-parallel instances, on top
+of the single-GPU (TP=1) baseline, including dense TP and TP+EP (expert
+parallel) MoE.
+
+The guiding principle is **strict superset**: TP>1 is a set of extra
+primitives and a few widened signatures, and every TP-specific step is a
+**no-op at TP=1**.  The proven single-GPU path is left untouched, so
+running with one GPU reproduces the original behavior exactly.
+
+Scope: dense TP and TP+EP MoE. Ulysses / shift sequence-parallel is out
+of scope (`vllm_child._is_arctic_parallel_worker` returns `False`).
+
+---
+
+## 1. Why TP>1 is not free
+
+CRIU cannot snapshot a live distributed engine as-is, and CUDA graphs
+bake absolute device addresses that move across a checkpoint/restore.
+Three things break at TP>1 that simply do not exist at TP=1:
+
+1. **NCCL communicators / TCPStore.** There is no communicator at TP=1.
+   At TP>1, live NCCL comms and the torch `ProcessGroupNCCL` /
+   `CustomAllreduce` IPC handles cannot survive a CRIU dump, so they must
+   be torn down before checkpoint and rebuilt after restore.
+2. **CUDA-graph baked addresses.** At TP=1 the captured decode graphs
+   have no cross-rank IPC pointers.  At TP>1 (especially with
+   CustomAllreduce) the graphs bake peer buffer addresses that go stale
+   after `destroy_nccl` -> `reinit_nccl` reallocates them, so the graphs
+   must be rebound (reuse) or recaptured (full).  See `ca_graph_rebind.py`.
+3. **Physical GPU placement.** A TP group must span an arbitrary set of
+   physical GPUs while keeping all of them visible (the cuda-checkpoint
+   physical-GPU addressing requires it), rather than pinning one GPU via
+   `CUDA_VISIBLE_DEVICES`.
+
+These map to the four new primitives (`destroy_nccl`, `reinit_nccl`,
+`cleargraph`, `recapture_graphs`), the `SemipGPUWorker` + `SEMIP_GPU_MAP`
+placement mechanism, and a per-worker memory-budget correction.
+
+---
+
+## 2. Lifecycle chains, TP=1 vs TP>1
+
+**TP is selected by the vLLM config**, not by the GPU count: set
+`tensor_parallel_size=N` in `Instance(vllm_config)` (default 1 -> TP=1).
+The `gpus=[...]` passed to `init` / `cuda_restore` is *physical placement
+only* and must have exactly `tensor_parallel_size` entries (validated,
+raises otherwise).  `n_gpus == tensor_parallel_size` is fixed at
+construction.
+
+The core pipeline is one shared sequence.  TP>1 interleaves NCCL and
+graph steps; TP=1 omits them (they would be no-ops anyway).
+
+```
+                 TP=1                               TP>1 (tensor_parallel_size=N)
+  save:          init(gpu)                          init(gpus=[...])  # len == N
+                 generate                            generate
+                 attach                              attach
+                 [stage] save_weights                [stage] save_weights
+                 detach                              detach
+                 sleep                               sleep
+                 cuda_checkpoint  ─────────────────  cuda_checkpoint
+                                                       ├─ cleargraph(reuse)   ┐ auto-inserted
+                                                       ├─ destroy_nccl(reuse) ┘ when n_gpus>1
+                                                       └─ cuda_checkpoint
+                 criu_dump                           criu_dump
+
+  restore:       criu_restore                        criu_restore
+                 cuda_restore(gpu)                   cuda_restore(gpus=[...])
+                                                     reinit_nccl          <- NEW
+                 wake_up_weights                     attach
+                 attach                              load_weights
+                 repin                               wake_up_weights
+                 load_weights                        repin
+                 plan_restore_weights                plan_restore_weights
+                 restore_weights                     restore_weights
+                 wake_up_kv_cache                    wake_up_kv_cache
+                                                     recapture_graphs(reuse)  <- NEW
+                 generate                            generate
+```
+
+`cleargraph`/`destroy_nccl` before the checkpoint and
+`reinit_nccl`/`recapture_graphs` after the restore are the only
+TP-specific caller-visible steps.  `cuda_checkpoint` inserts the first
+pair itself; the caller must invoke `reinit_nccl` and `recapture_graphs`
+on the restore side (see `scripts/test_tp2.py`).
+
+---
+
+## 3. What TP adds to `instance.py`
+
+Every item below is additive or a widened signature; nothing was removed
+from the TP=1 path.
+
+### 3.1 Per-instance TP state
+
+`gpus` is the physical GPU list; `n_gpus == tensor_parallel_size`.
+Because TP is wired from the config, `n_gpus` is derived from
+`vllm_config["tensor_parallel_size"]` at construction (authoritative) and
+`gpus` is validated against it — never the other way around.
+`max_pinned_bytes_per_worker` is the largest **per-worker** staging shard,
+needed because at TP>1 the aggregate `pinned_cpu_bytes` overstates the
+per-GPU budget ~N-fold.
+
+### 3.2 `init(gpus=...)`: validate placement, don't infer TP
+
+`init(gpus=None, gpu=None)` is back-compatible: a scalar `gpu=` or
+positional `init(0)` still works for TP=1.  TP size is read from the
+config, and the supplied GPU list is validated to match; `init` never
+infers TP from `len(gpus)` nor injects `tensor_parallel_size` into the
+config (the user already set it).  It does inject the internal
+`worker_cls` for TP>1.
+
+`total_gpu_bytes` is snapshotted from `gpus[0]` — every GPU in a TP group
+has the same capacity, so it stays representative of the per-GPU
+`gpu_memory_utilization` budget.
+
+### 3.3 `cuda_checkpoint()`: graph-preserving NCCL teardown prologue
+
+Before the checkpoint, TP>1 preserves the captured graphs
+(`cleargraph(reuse)` is a no-op on the graphs themselves in reuse mode)
+and unilaterally aborts NCCL (`destroy_nccl(reuse)`).  TP=1 keeps the
+single `cuda_checkpoint` send.
+
+### 3.4 Four new primitives
+
+All four short-circuit to a no-op in the child when
+`_semip_tp_size(worker) <= 1`, so they are safe to call unconditionally.
+
+| Primitive | When | Child-side |
+|---|---|---|
+| `destroy_nccl(mode)` | inside `cuda_checkpoint` (TP>1) | `_destroy_nccl` — unilateral `ncclCommAbort` (reuse/EP) or collective destroy; closes CustomAllreduce IPC handles |
+| `reinit_nccl()` | after `cuda_restore` | `_reinit_nccl` — fresh TCP port, `init_worker_distributed_environment`, rebind `tp:0`/`world:0` (+ `ep:0`/`dp:0` for MoE) group slots the graphs look up |
+| `cleargraph(mode)` | inside `cuda_checkpoint` (TP>1); also `full` before recapture | `_semip_cleargraph` — no-op in `reuse`; in `full` drops exec handles, refreshes the shared graph pool, resets MoE aux stream / V2 graph manager |
+| `recapture_graphs(mode)` | after `wake_up_kv_cache` | `_semip_recapture_graphs` — `reuse` rebinds preserved graphs' baked addresses (`ca_graph_rebind`); `full` clears + `capture_model()` |
+
+`graph_mode` semantics: **`reuse`** preserves the cold-start captured
+graphs across the checkpoint and only rewrites their stale device
+addresses on restore (fast). **`full`** discards and recaptures via
+`capture_model()` (slow; the fallback when reuse rebind fails).
+
+### 3.5 `criu_dump()` / `criu_restore()`: TP shape in the image
+
+`criu_dump` persists `n_gpus` and `max_pinned_bytes_per_worker` into
+`meta.json` (alongside `gpus` and `gpu_uuids`, written worker-side).
+
+The restore side has no live `init(gpus)` call.  TP size is authoritative
+from this instance's `vllm_config["tensor_parallel_size"]` (already equal
+to the image's, per the config mismatch check), so `n_gpus` is derived
+from the config with `meta["n_gpus"]` kept only as a legacy fallback.
+`gpus` / `max_pinned_bytes_per_worker` are hydrated from `meta.json` (with
+a `rank` -> `[rank]` shim for legacy images), and the worker is spawned on
+the restored GPU list rather than a hardcoded GPU 0.
+
+### 3.6 `cuda_restore(gpus=...)`: place the group, validate against config
+
+`cuda_restore(gpu=None, gpus=None)`.  With neither argument it falls back
+to the `self.gpus` hydrated from `meta.json`, so a restore can re-place
+the group on a different physical GPU set.  The GPU count is validated
+against the config-derived `n_gpus` (TP size cannot change across a
+restore) rather than redefining it.
+
+### 3.7 `plan_restore_weights()`: per-GPU (not aggregate) chunk budget
+
+This is the one correctness-critical numeric change.  The restore chunk
+budget must be sized against the **per-GPU** staging shard.  Using the
+TP-aggregate `pinned_cpu_bytes` would overstate the per-worker pinned
+buffer ~N-fold, shrinking the chunk budget needlessly (or spuriously
+failing the `param exceeds chunk_size` check):
+
+```python
+pinned = self.max_pinned_bytes_per_worker or self.pinned_cpu_bytes
+mb = int(0.9 * min(pinned, allotment - pinned))
+```
+
+> **Why the budget matters (both TP=1 and TP>1).** `restore_weights`
+> without a cached plan allocates a GPU staging buffer as large as the
+> whole per-worker weight buffer, which torch's caching allocator keeps
+> resident even after `resize_(0)`. `wake_up_kv_cache` then allocates via
+> vLLM's `cumem` allocator straight from the driver and cannot reuse
+> torch's cached block -> CUDA OOM. `plan_restore_weights()` bounds the
+> staging buffer so enough free driver memory remains for the KV wake-up.
+> Always call `plan_restore_weights()` before `restore_weights()`.
+> Pass an explicit `max_buffer_bytes` for images dumped before the
+> `empty_cache()` fix.
+
+### 3.8 Result bookkeeping
+
+`attach` and `plan_restore_weights` surface `max_pinned_bytes_per_worker`;
+`criu_restore` / `cuda_restore` echo the resolved `gpus` back into
+instance state; `detach` clears the per-worker figure.
+
+---
+
+## 4. Child-side counterparts
+
+The `instance.py` surface is only the orchestration; the mechanism lives
+in the child.  All of it degrades to a no-op at TP=1.
+
+- **`_semip_worker.SemipGPUWorker`** (`vllm_config["worker_cls"]`, TP>1
+  only). Two hooks:
+  - `init_device` remaps vLLM `local_rank` -> physical GPU via
+    `SEMIP_GPU_MAP` (set by the child before spawn), so the group spans
+    an arbitrary GPU set with all GPUs visible.
+  - `compile_or_warm_up_model` forces the cold-start CUDA-graph capture
+    onto the CustomAllreduce copy path with `keep_graph=True`, so the
+    preserved graph is reuse-friendly for `ca_graph_rebind`.  It returns
+    whatever the base class returns, so it is agnostic to that method's
+    return type across vLLM versions.
+- **GPU visibility fork** (`vllm_child.vllm_child_loop`): TP>1 clears
+  `CUDA_VISIBLE_DEVICES` and sets `SEMIP_GPU_MAP`; TP=1 pins the single
+  GPU as device 0 (unchanged).
+- **TP-only engine config** (`init`, `_tp >= 2`): disables fused
+  allreduce+RMS, NVLS, symmetric-memory allreduce and the MoE
+  shared-experts stream, all of which hold state CRIU cannot serialize
+  or complicate graph capture.
+- **`_destroy_nccl` / `_reinit_nccl`**: NCCL abort/rebuild; both
+  early-out when `_semip_tp_size(worker) <= 1`.
+- **`_prepare_worker_dump`**: per-worker CRIU dump prep (FD close,
+  io_uring/IB munmap, PSM shm unlink), invoked only when `len(gpus) > 1`
+  since at TP=1 the "worker" is the driver process itself.
+- **`ca_graph_rebind.py`**: the graph-address rebind engine that lets
+  preserved decode graphs replay after `destroy_nccl` -> `reinit_nccl`
+  without a full recapture (the reuse path). This is the heaviest and
+  most fragile piece of the TP work; it is entirely bypassed at TP=1.
+- **Per-rank weight shards**: `save_weights`/`load_weights` fan out to
+  `weights/rank{R}/` at TP>1; TP=1 keeps the flat `weights/` layout.
+
+### Worker-side (`worker.py`)
+
+- `worker_loop` and `_child_thread` take a `gpus` list (a bare int is
+  still accepted); `rank = gpus[0]`.
+- `_gpu_migration_permutation` generalises the old 2-GPU swap into a full
+  N-GPU bijection pinning `old_gpus[k] -> new_gpus[k]`, completing the
+  permutation over the remaining GPUs so `cuCheckpointProcessRestore`
+  gets a bijection over every visible device.
+- Two-pass restore: restore **all** pids, then unlock **all** pids.  With
+  a TP process tree an unlocked worker could otherwise touch a
+  still-locked sibling over NCCL/IPC and race.
+- The CRIU dump scans **descendant** PIDs (deduped by socket inode), not
+  just the child, so the multiproc-executor Unix sockets are declared
+  `--external`.
+
+---
+
+## 5. Invariants and gotchas
+
+- **TP is config-driven.** Set `tensor_parallel_size` in the vLLM config;
+  `init`/`cuda_restore` take `gpus` as placement only and require
+  `len(gpus) == tensor_parallel_size` (raise otherwise). `n_gpus` is
+  fixed at construction and never re-derived from a GPU count.
+- **Superset invariant.** Any TP>1 primitive is a no-op at TP=1, and the
+  TP=1 chain is exactly the original chain. Do not route TP=1 through
+  the NCCL/graph machinery.
+- **Caller drives NCCL/graph on restore.** `cuda_checkpoint` inserts
+  `cleargraph`+`destroy_nccl` itself, but `reinit_nccl` (right after
+  `cuda_restore`) and `recapture_graphs("reuse")` (right after
+  `wake_up_kv_cache`) are the caller's responsibility.
+- **`reinit_nccl` ordering.** It must run before any collective (attach,
+  weight restore, graph replay), i.e. immediately after `cuda_restore`.
+- **Per-worker budget, not aggregate.** Size the restore chunk plan from
+  `max_pinned_bytes_per_worker`; the aggregate `pinned_cpu_bytes` is
+  ~N times too large per GPU.
+- **`reuse` first, `full` as fallback.** Prefer `graph_mode="reuse"`
+  (rebind); fall back to `full` (recapture) only when rebind fails.
+- **Silent degradation.** `ca_graph_rebind` is written defensively with
+  many guarded imports and `getattr` fallbacks, so a mismatch against a
+  newer vLLM tends to *skip* a rebind path rather than raise. When
+  bringing up a new vLLM version, check the logs for skipped paths
+  instead of assuming success.
+- **Image portability.** `meta.json` carries `n_gpus`, `gpus`,
+  `gpu_uuids` and `max_pinned_bytes_per_worker`; legacy single-GPU images
+  fall back via the `rank` -> `[rank]` shim and `n_gpus=1`. Because
+  `tensor_parallel_size` lives in the user's `vllm_config`, it is
+  persisted in `meta.json` and participates in the `criu_restore`
+  mismatch check, so a TP=2 image is not mistaken for a TP=1 one.
+
+---
+
+## 6. Primitive delta summary
+
+```
+TP>1 = TP=1 baseline
+     + { destroy_nccl, reinit_nccl, cleargraph, recapture_graphs }   # 4 new primitives
+     + TP wired from vllm_config["tensor_parallel_size"]             # config-driven, not GPU-count
+     + init(gpus=[...]) / cuda_restore(gpus=[...]) placement + check  # len(gpus) == tp validated
+     + cuda_checkpoint auto-inserts cleargraph+destroy_nccl @ TP>1    # behavior change
+     + plan_restore_weights uses per-worker pinned budget             # per-GPU correctness
+     + meta.json carries n_gpus / gpus / max_pinned_bytes_per_worker  # image portability
+```
+
+Nothing is removed from the TP=1 path; TP>1 is a strict superset.

--- a/arctic_inference/semi_persistence/skills/tp_DESIGN.md
+++ b/arctic_inference/semi_persistence/skills/tp_DESIGN.md
@@ -274,6 +274,15 @@ in the child.  All of it degrades to a no-op at TP=1.
   `cleargraph`+`destroy_nccl` itself, but `reinit_nccl` (right after
   `cuda_restore`) and `recapture_graphs("reuse")` (right after
   `wake_up_kv_cache`) are the caller's responsibility.
+- **`destroy_nccl` frees the ports too, not just the comms.** Before
+  tearing the process groups down it marks every inet TCP socket in each
+  worker `SO_LINGER(1,0)`, so the destructive dump's kill RSTs them and
+  their local ports skip `TIME_WAIT`.  Without that, a restore inside 60s
+  of its own dump fails in CRIU with `Address already in use`, because
+  CRIU rebinds each recorded local port.  Every rank contributes a
+  TCPStore connection, which is why the collision is deterministic at
+  TP>1 and only a race at TP=1.  See Complication 12 in
+  [`CRIU_PLUMBING.md`](CRIU_PLUMBING.md).
 - **`reinit_nccl` ordering.** It must run after `cuda_restore`, and before
   anything that runs the model or replays a captured graph — in practice
   before `recapture_graphs` and `generate`.  `attach` and `load_weights`

--- a/arctic_inference/semi_persistence/skills/tp_DESIGN.md
+++ b/arctic_inference/semi_persistence/skills/tp_DESIGN.md
@@ -33,10 +33,19 @@ Three things break at TP>1 that simply do not exist at TP=1:
    physical GPUs while keeping all of them visible (the cuda-checkpoint
    physical-GPU addressing requires it), rather than pinning one GPU via
    `CUDA_VISIBLE_DEVICES`.
+4. **Where the weight-staging buffer lives.** At TP=1 vLLM uses the
+   "uni" executor and the worker *is* the vllm_child process, so a
+   buffer allocated there and captured by a `collective_rpc` closure is
+   mutated in place.  At TP>1 the multiproc executor cloudpickles that
+   closure into N subprocesses: each gets a *copy* of the buffer, writes
+   into the copy, and the writes are discarded when the call returns --
+   silently.  Each rank also owns a different shard of the parameters,
+   so a single child-side buffer is the wrong size regardless.
 
 These map to the four new primitives (`destroy_nccl`, `reinit_nccl`,
 `cleargraph`, `recapture_graphs`), the `SemipGPUWorker` + `SEMIP_GPU_MAP`
-placement mechanism, and a per-worker memory-budget correction.
+placement mechanism, the worker-local staging primitives
+(`worker._semip_*`), and a per-worker memory-budget correction.
 
 ---
 
@@ -224,6 +233,14 @@ in the child.  All of it degrades to a no-op at TP=1.
   preserved decode graphs replay after `destroy_nccl` -> `reinit_nccl`
   without a full recapture (the reuse path). This is the heaviest and
   most fragile piece of the TP work; it is entirely bypassed at TP=1.
+- **Worker-local weight staging** (`_semip_attach`, `_semip_stage`,
+  `_semip_repin`, `_semip_unpin`, `_semip_plan_load_weights`,
+  `_semip_restore_weights`, `_semip_detach`, `_semip_save_weights`,
+  `_semip_load_weights`): the staging buffer, param index and chunk plan
+  live on the worker (`worker._semip_*`) for the reason in section 1.4.
+  Unlike the primitives above this is *not* a TP-only addition -- it is
+  the single path both TP sizes take, and the child only aggregates the
+  per-worker results. `attach_pinned` is unsupported on it.
 - **Per-rank weight shards**: `save_weights`/`load_weights` fan out to
   `weights/rank{R}/` at TP>1; TP=1 keeps the flat `weights/` layout.
 
@@ -288,6 +305,11 @@ TP>1 = TP=1 baseline
      + cuda_checkpoint auto-inserts cleargraph+destroy_nccl @ TP>1    # behavior change
      + plan_restore_weights uses per-worker pinned budget             # per-GPU correctness
      + meta.json carries n_gpus / gpus / max_pinned_bytes_per_worker  # image portability
+     + weights/rank{R}/ shard layout                                  # per-rank shards
 ```
+
+Plus one change that is shared rather than TP-gated: weight staging
+lives on the workers (`worker._semip_*`) for both TP sizes, because a
+child-side buffer cannot be written by workers at TP>1.
 
 Nothing is removed from the TP=1 path; TP>1 is a strict superset.

--- a/arctic_inference/semi_persistence/skills/tp_DESIGN.md
+++ b/arctic_inference/semi_persistence/skills/tp_DESIGN.md
@@ -274,8 +274,16 @@ in the child.  All of it degrades to a no-op at TP=1.
   `cleargraph`+`destroy_nccl` itself, but `reinit_nccl` (right after
   `cuda_restore`) and `recapture_graphs("reuse")` (right after
   `wake_up_kv_cache`) are the caller's responsibility.
-- **`reinit_nccl` ordering.** It must run before any collective (attach,
-  weight restore, graph replay), i.e. immediately after `cuda_restore`.
+- **`reinit_nccl` ordering.** It must run after `cuda_restore`, and before
+  anything that runs the model or replays a captured graph — in practice
+  before `recapture_graphs` and `generate`.  `attach` and `load_weights`
+  are *not* constrained by it: `collective_rpc` is the executor's
+  Unix-socket fan-out, not a device collective, and the work each rank
+  does is CPU-only (a host `torch.empty` for `_semip_attach`, then shard
+  reads from `<weights_dir>/rankN` for `_semip_load_weights`).
+  `test_tp2.py` runs both *before* `cuda_restore` for that reason.
+  `restore_weights` is in between: its H2D copies need the restored
+  context, but no NCCL.
 - **Per-worker budget, not aggregate.** Size the restore chunk plan from
   `max_pinned_bytes_per_worker`; the aggregate `pinned_cpu_bytes` is
   ~N times too large per GPU.

--- a/arctic_inference/semi_persistence/tests/test_pipeline.py
+++ b/arctic_inference/semi_persistence/tests/test_pipeline.py
@@ -700,7 +700,7 @@ def test_evict_for_peer_walks_paused_incumbent_down() -> None:
     ``_step_up`` ran ``remaining -= share`` unconditionally regardless
     of whether the EvictForPeerOp actually freed anything, so the
     acquirer believed Phase 2 had freed enough HBM.  It then called
-    ``wake_up_kv_cache`` and OOM'd inside ``restore_cuda`` with
+    ``wake_up_kv_cache`` and OOM'd inside ``cuda_restore`` with
     ``CUresult=2``.  Every L1 generate that raced any paused L2/L3
     peer on the same GPU hung indefinitely (q_rec stayed at
     ``state="waiting"`` -- that surface is patched in ``orchestrator.py``
@@ -817,7 +817,7 @@ def test_evict_for_peer_noops_on_stale_below_up_incumbent() -> None:
     sitting behind a queued ``MoveOp``), an unrelated op (a client
     ``move(checkpoint)``, a parallel eviction, ...) may have walked
     the incumbent past ``up`` and CRIU-frozen its CUDA context
-    (``checkpoint_cuda``).  Sending ``sleep`` to that worker drives
+    (``cuda_checkpoint``).  Sending ``sleep`` to that worker drives
     vLLM's sleep path into ``torch.cuda.synchronize`` ->
     ``cuCtxSynchronize`` -> SEGFAULT, killing vllm_child and
     permanently wedging the pipeline (every later

--- a/arctic_inference/semi_persistence/vllm_child.py
+++ b/arctic_inference/semi_persistence/vllm_child.py
@@ -23,7 +23,8 @@ slice of pinned CPU into a single reused GPU staging buffer and
 scatter into model parameters by name.  If no plan is cached,
 restore_weights falls back to a single-chunk path.
 """
-import ctypes, os, sys, time
+import ctypes, json, os, shutil, subprocess, sys, time
+from concurrent.futures import ThreadPoolExecutor
 
 import torch
 
@@ -42,6 +43,10 @@ def _truncate_for_display(value, limit=200):
         return out if isinstance(value, list) else tuple(out)
     return value
 
+
+# Shard size / parallelism for save_weights + load_weights disk I/O.
+_WEIGHTS_SHARD_BYTES = 2 * 2**30   # 2 GiB per shard
+_WEIGHTS_IO_WORKERS = 8            # thread pool size for shard I/O
 
 _cudart = ctypes.CDLL("libcudart.so")
 _cudart.cudaHostUnregister.argtypes = [ctypes.c_void_p]
@@ -1052,6 +1057,151 @@ def vllm_child_loop(pipe_conn, instance_id, rank):
                 log = semip_logging.child(new_id, rank)
                 info["instance_id"] = new_id
                 info["path"] = _child_log_path
+
+            elif cmd == "save_weights":
+                if pinned_buf is None or index is None:
+                    raise RuntimeError(
+                        "save_weights requires attach+stage first")
+
+                weights_dir = kwargs["weights_dir"]
+                shard_bytes = int(kwargs.get("shard_bytes")
+                                  or _WEIGHTS_SHARD_BYTES)
+                workers_req = int(kwargs.get("io_workers")
+                                  or _WEIGHTS_IO_WORKERS)
+                total = pinned_buf.numel()
+                mv = memoryview(pinned_buf.numpy())
+
+                # Recreate the dir clean so stale shards from a prior
+                # (possibly larger) model can't linger.  Aborted runs may
+                # leave root-owned files -> fall back to `sudo rm -rf`
+                # (mirrors the criu_dump dir-clear in worker.py).
+                if os.path.exists(weights_dir):
+                    try:
+                        shutil.rmtree(weights_dir)
+                    except PermissionError:
+                        subprocess.run(["sudo", "rm", "-rf", weights_dir],
+                                       check=True)
+                os.makedirs(weights_dir, exist_ok=True)
+
+                ranges = []
+                _lo = 0
+                _i = 0
+                while _lo < total:
+                    _hi = min(_lo + shard_bytes, total)
+                    ranges.append((_i, _lo, _hi))
+                    _lo = _hi
+                    _i += 1
+                workers = max(1, min(workers_req, len(ranges)))
+
+                def _write_shard(i, lo, hi):
+                    fd = os.open(
+                        os.path.join(weights_dir, f"shard_{i:04d}.bin"),
+                        os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+                    try:
+                        pos = lo
+                        while pos < hi:            # os.write may short-write
+                            pos += os.write(fd, mv[pos:hi])
+                        os.fsync(fd)
+                    finally:
+                        os.close(fd)
+                    return hi - lo
+
+                t0 = time.perf_counter()
+                with ThreadPoolExecutor(max_workers=workers) as ex:
+                    for fu in [ex.submit(_write_shard, *r) for r in ranges]:
+                        fu.result()               # re-raise worker errors
+                dt = time.perf_counter() - t0
+
+                model_name = getattr(
+                    getattr(engine, "model_config", None), "model", None)
+                manifest = {
+                    "total_bytes": total,
+                    "n_params": len(index),
+                    "model": model_name,
+                    "shard_bytes": shard_bytes,
+                    "shards": [{"name": f"shard_{i:04d}.bin",
+                                "offset": lo, "nbytes": hi - lo}
+                               for (i, lo, hi) in ranges],
+                    "layout": [[name, off, nbytes, str(dtype), list(shape)]
+                               for name, (off, nbytes, dtype, shape)
+                               in index.items()],
+                }
+                with open(os.path.join(weights_dir, "weights_meta.json"),
+                          "w") as f:
+                    json.dump(manifest, f)
+
+                info["weights_dir"] = weights_dir
+                info["bytes"] = total
+                info["n_shards"] = len(ranges)
+                log.info("  saved weights: %d shard(s), %.2f GiB in %.2fs "
+                         "(%.2f GiB/s)", len(ranges), total / 2**30, dt,
+                         (total / 2**30) / dt if dt > 0 else 0.0)
+
+            elif cmd == "load_weights":
+                if pinned_buf is None or index is None:
+                    raise RuntimeError("load_weights requires attach first")
+
+                weights_dir = kwargs["weights_dir"]
+                meta_path = os.path.join(weights_dir, "weights_meta.json")
+                if not os.path.isfile(meta_path):
+                    raise RuntimeError(
+                        f"no weights manifest at {meta_path}; "
+                        f"run save_weights first")
+                with open(meta_path) as f:
+                    manifest = json.load(f)
+
+                total = pinned_buf.numel()
+                if int(manifest["total_bytes"]) != total:
+                    raise RuntimeError(
+                        f"weights size mismatch: manifest "
+                        f"{manifest['total_bytes']}B but attached buffer "
+                        f"{total}B (config/model changed?)")
+
+                # Strict layout check against the freshly-attached index:
+                # (name, offset, nbytes) must line up exactly.
+                cur_layout = [[name, off, nbytes]
+                              for name, (off, nbytes, dtype, shape)
+                              in index.items()]
+                man_layout = [[row[0], row[1], row[2]]
+                              for row in manifest.get("layout", [])]
+                if man_layout and man_layout != cur_layout:
+                    raise RuntimeError(
+                        "weights layout mismatch between manifest and "
+                        "attached model (param order/sizes differ)")
+
+                mv = memoryview(pinned_buf.numpy())
+                shards = manifest["shards"]
+                workers = max(1, min(int(kwargs.get("io_workers")
+                                         or _WEIGHTS_IO_WORKERS), len(shards)))
+
+                def _read_shard(s):
+                    lo = int(s["offset"])
+                    n = int(s["nbytes"])
+                    dst = mv[lo:lo + n]
+                    got = 0
+                    with open(os.path.join(weights_dir, s["name"]),
+                              "rb", buffering=0) as f:
+                        while got < n:             # readinto may short-read
+                            r = f.readinto(dst[got:])
+                            if r == 0:
+                                break
+                            got += r
+                    if got != n:
+                        raise RuntimeError(
+                            f"{s['name']}: read {got} != {n}")
+                    return n
+
+                t0 = time.perf_counter()
+                with ThreadPoolExecutor(max_workers=workers) as ex:
+                    for fu in [ex.submit(_read_shard, s) for s in shards]:
+                        fu.result()               # re-raise worker errors
+                dt = time.perf_counter() - t0
+
+                info["bytes"] = total
+                info["n_shards"] = len(shards)
+                log.info("  loaded weights: %d shard(s), %.2f GiB in %.2fs "
+                         "(%.2f GiB/s)", len(shards), total / 2**30, dt,
+                         (total / 2**30) / dt if dt > 0 else 0.0)
 
             else:
                 error = f"unknown command: {cmd}"

--- a/arctic_inference/semi_persistence/vllm_child.py
+++ b/arctic_inference/semi_persistence/vllm_child.py
@@ -513,6 +513,67 @@ def _semip_destroy_fi_ar_workspace():
         pass
 
 
+def _mark_rst_on_close(fd_int):
+    """Set SO_LINGER(1,0) on an inet TCP socket so its eventual close sends RST
+    (skips TIME_WAIT) -> avoids restore-time EADDRINUSE on the rebind. AF_UNIX
+    and non-stream sockets are left untouched. Operates on a *dup* so we never
+    close the worker's live fd here -- the option lives on the shared socket, so
+    the original fd RSTs when it is finally closed by teardown/CRIU-kill."""
+    import socket, struct
+    try:
+        dup = os.dup(fd_int)
+    except OSError:
+        return None
+    try:
+        s = socket.socket(fileno=dup)   # Linux auto-detects family/type/proto
+    except OSError:
+        os.close(dup)
+        return None
+    try:
+        if (s.family in (socket.AF_INET, socket.AF_INET6)
+                and s.type == socket.SOCK_STREAM):
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER,
+                         struct.pack("ii", 1, 0))
+            try:
+                return (fd_int, s.family.name, s.getsockname())
+            except OSError:
+                return (fd_int, s.family.name, None)
+    finally:
+        s.close()   # closes the dup only; fd_int stays open for CRIU
+    return None
+
+
+def _mark_inet_sockets_rst(where):
+    """Scan this worker's fds and SO_LINGER(1,0) every inet TCP socket, so the
+    next close (distributed teardown / destructive CRIU dump) sends RST and the
+    tuple skips TIME_WAIT -> restore rebinds the rendezvous port immediately with
+    no cooldown. AF_UNIX / non-stream sockets are left alone. Returns marked
+    (fd, family, addr) tuples."""
+    pid = os.getpid()
+    marked = []
+    try:
+        fd_names = os.listdir(f"/proc/{pid}/fd")
+    except OSError:
+        return []
+    for fd_name in fd_names:
+        try:
+            fd_int = int(fd_name)
+            if fd_int <= 2:
+                continue
+            link = os.readlink(f"/proc/{pid}/fd/{fd_name}")
+        except (OSError, ValueError):
+            continue
+        if not link.startswith("socket:"):
+            continue
+        r = _mark_rst_on_close(fd_int)
+        if r is not None:
+            marked.append(r)
+    if marked:
+        print(f"[rst-on-dump] {where}: SO_LINGER(1,0) on {len(marked)} "
+              f"inet TCP socket(s): {marked}", flush=True)
+    return marked
+
+
 def _destroy_nccl(worker, graph_mode=None):
     """Tear down NCCL process groups before checkpoint.  No-op at TP1."""
     import torch.distributed as dist
@@ -546,6 +607,14 @@ def _destroy_nccl(worker, graph_mode=None):
     from vllm.distributed import parallel_state as ps
     from vllm.distributed.parallel_state import (
         destroy_model_parallel, destroy_distributed_environment)
+
+    # RST-on-close: mark the rendezvous inet TCP sockets now, while they are
+    # still open, so the teardown below closes them with RST (skips TIME_WAIT).
+    # Otherwise the destructive dump leaves the tuple in TIME_WAIT and the
+    # restore rebind fails with EADDRINUSE (sk-inet.c: Address already in use).
+    # Runs per-worker (this is a collective_rpc target), so it hits each rank's
+    # rendezvous socket.
+    _mark_inet_sockets_rst("destroy_nccl")
 
     # Free the FlashInfer AR+RMS multicast workspace before NCCL teardown (full
     # only; reuse preserves graphs and thus the workspace they reference).

--- a/arctic_inference/semi_persistence/vllm_child.py
+++ b/arctic_inference/semi_persistence/vllm_child.py
@@ -121,9 +121,9 @@ def vllm_child_loop(pipe_conn, instance_id, rank):
     # synthesises a never-stepped record), then drained on `resume`
     # via `engine.add_request` for each entry.  All of this lives
     # in plain Python state so CRIU dumps and restores it for free
-    # across checkpoint_cuda/restore_cuda cycles, and keeping the
+    # across cuda_checkpoint/cuda_restore cycles, and keeping the
     # engine untouched while paused makes the path robust to any
-    # pipe interleaving of pause / sleep / checkpoint_cuda /
+    # pipe interleaving of pause / sleep / cuda_checkpoint /
     # generate that the orchestrator's "Walking down past `up`
     # while paused" rule permits.
     #
@@ -195,7 +195,7 @@ def vllm_child_loop(pipe_conn, instance_id, rank):
             #
             # This keeps the engine untouched for the entire dormant
             # span -- `llm.sleep` discards cumem-allocated KV blocks
-            # and `cuda-checkpoint` (during `checkpoint_cuda`)
+            # and `cuda-checkpoint` (during `cuda_checkpoint`)
             # freezes the CUDA context, so any `engine.add_request`
             # / `engine.abort_request` call inside that window would
             # either enqueue into a scheduler that can never `step`
@@ -799,7 +799,7 @@ def vllm_child_loop(pipe_conn, instance_id, rank):
 
                 # Snapshot every active sub-request and abort it in
                 # the engine so the upcoming `unpin` / `sleep` /
-                # `checkpoint_cuda` runs against an empty scheduler.
+                # `cuda_checkpoint` runs against an empty scheduler.
                 # Pending `generate_done` messages are deferred until
                 # `resume` re-adds the requests via prefill.
                 saved_count, aborted_count = _snapshot_active_into_saved()

--- a/arctic_inference/semi_persistence/vllm_child.py
+++ b/arctic_inference/semi_persistence/vllm_child.py
@@ -30,6 +30,22 @@ import torch
 
 import semip_logging
 
+# Ensure this package dir is importable in the child + its TP worker
+# subprocesses (worker_cls="_semip_worker.SemipGPUWorker" and ca_graph_rebind
+# are resolved by bare module name).
+_semip_here = os.path.dirname(os.path.abspath(__file__))
+if _semip_here not in sys.path:
+    sys.path.insert(0, _semip_here)
+
+try:
+    import ca_graph_rebind  # dense-TP graph reuse support
+    _CA_REBIND_AVAILABLE = True
+except Exception as _ca_e:  # best-effort: reuse degrades to full recapture
+    _CA_REBIND_AVAILABLE = False
+    ca_graph_rebind = None
+    print(f"[semip-ca-rebind] unavailable: {_ca_e}", flush=True)
+
+
 def _truncate_for_display(value, limit=200):
     """Truncate strings (or strings inside a list/tuple) to ``limit`` chars,
     appending ``...(<n> chars)`` when the original exceeds ``limit``.
@@ -71,18 +87,686 @@ def _repin_buffer(buf):
         raise RuntimeError(f"cudaHostRegister failed with cudaError={ret}")
 
 
-def vllm_child_loop(pipe_conn, instance_id, rank, model_dir=None):
+# ---------------------------------------------------------------------------
+# TP>1 NCCL teardown / reinit around CRIU (worker-local, via collective_rpc).
+#
+# CRIU cannot restore live NCCL communicators or CustomAllreduce IPC handles,
+# so they are torn down before checkpoint and rebuilt after restore.  For
+# graph reuse the teardown must be graph-preserving (unilateral ncclCommAbort,
+# not the collective ncclCommDestroy that a live captured graph would deadlock);
+# for MoE/EP the abort must also be concurrent (see _nccl_abort_comms_concurrent).
+# ---------------------------------------------------------------------------
+GRAPH_MODE_REUSE = "reuse"
+GRAPH_MODE_FULL = "full"
+_MISSING = object()
+_LIBNCCL = None
+
+
+def _semip_config_value(config, key, default=None):
+    """Read ``key`` from a vllm config object or dict, falling back to its
+    nested ``parallel_config``."""
+    if config is None:
+        return default
+    if isinstance(config, dict):
+        if key in config:
+            return config[key]
+        pc = config.get("parallel_config")
+    else:
+        if hasattr(config, key):
+            return getattr(config, key)
+        pc = getattr(config, "parallel_config", None)
+    if pc is not None:
+        if isinstance(pc, dict):
+            if key in pc:
+                return pc[key]
+        elif hasattr(pc, key):
+            return getattr(pc, key)
+    return default
+
+
+def _semip_tp_size(worker):
+    return int(_semip_config_value(
+        getattr(worker, "vllm_config", None), "tensor_parallel_size", 1) or 1)
+
+
+def _semip_ep_enabled(config):
+    return bool(_semip_config_value(config, "enable_expert_parallel", False))
+
+
+def _is_arctic_parallel_worker(worker):
+    # Ulysses / shift SP is out of scope for this port (dense TP + EP only).
+    return False
+
+
+def _clear_fd_backed_nccl_env():
+    """Drop restored NCCL/OFI env that points at process-local fds (closed
+    before CRIU save), so the next NCCL init regenerates them."""
+    native_keys = (
+        "NCCL_TOPO_FILE", "NCCL_TUNER_PLUGIN", "NCCL_NETDEVS_POLICY",
+        "NCCL_NET_FORCE_FLUSH", "NCCL_NVLS_CHUNKSIZE",
+        "NCCL_NVLSTREE_MAX_CHUNKSIZE", "NCCL_P2P_NET_CHUNKSIZE",
+        "FI_EFA_FORK_SAFE",
+    )
+    for key in native_keys:
+        os.environ.pop(key, None)
+        os.unsetenv(key)
+    for key, value in list(os.environ.items()):
+        if key == "NCCL_TOPO_FILE" or (
+                key.startswith("NCCL_") and value.startswith("/proc/self/fd/")):
+            os.environ.pop(key, None)
+            os.unsetenv(key)
+
+
+def _nccl_abort_comm(comm):
+    """ncclCommAbort(comm) via ctypes -- UNILATERAL and non-blocking, unlike the
+    collective ncclCommDestroy which deadlocks when a live captured graph or an
+    overlapping MoE/EP topology pins the comm."""
+    global _LIBNCCL
+    if _LIBNCCL is None:
+        _LIBNCCL = ctypes.CDLL("libnccl.so.2")
+        _LIBNCCL.ncclCommAbort.restype = ctypes.c_int
+        _LIBNCCL.ncclCommAbort.argtypes = [ctypes.c_void_p]
+    cp = comm if isinstance(comm, ctypes.c_void_p) else ctypes.c_void_p(int(comm))
+    return _LIBNCCL.ncclCommAbort(cp)
+
+
+def _nccl_abort_comms_concurrent(targets, timeout=60.0, after_fire=None):
+    """Abort a set of pynccl comms CONCURRENTLY (one thread each).  Sequential
+    abort deadlocks on DeepSeek-style overlapping world/tp/dp/ep comms: the
+    shared per-rank proxy only drains once every comm's abort flag is set.  The
+    ``after_fire`` hook sets the torch ProcessGroupNCCL abort flags while the
+    pynccl aborts are in flight, so all flags are set together."""
+    import threading
+    import time as _t
+    results = {}
+
+    def _worker(nm, ptr):
+        try:
+            results[nm] = ("ok", _nccl_abort_comm(ptr))
+        except BaseException as e:  # noqa: BLE001
+            results[nm] = ("err", f"{type(e).__name__}: {e}")
+
+    threads = []
+    for nm, ptr in targets:
+        th = threading.Thread(target=_worker, args=(nm, ptr), daemon=True)
+        th.start()
+        threads.append(th)
+    if after_fire is not None:
+        try:
+            after_fire()
+        except BaseException:  # noqa: BLE001
+            pass
+    deadline = _t.monotonic() + timeout
+    for th in threads:
+        th.join(max(0.0, deadline - _t.monotonic()))
+    return results
+
+
+def _abort_torch_process_groups():
+    """Abort (non-blocking) every torch NCCL process group so the subsequent
+    clean destroy does not deadlock on a comm a live graph still pins."""
+    import torch
+    from torch.distributed import distributed_c10d as c
+    try:
+        world = getattr(c, "_world", None)
+        pg_map = dict(getattr(world, "pg_map", {}) or {})
+        for pg in list(pg_map.keys()):
+            try:
+                be = pg._get_backend(torch.device("cuda"))
+            except Exception:  # noqa: BLE001
+                be = None
+            fn = getattr(be, "abort", None) or getattr(pg, "abort", None)
+            if fn is not None:
+                fn()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _semip_destroy_fi_ar_workspace():
+    """Free the FlashInfer fused allreduce+RMSNorm workspace before checkpoint
+    (full mode only).  Defensive no-op when it was never created."""
+    try:
+        from vllm.distributed.device_communicators import (
+            flashinfer_all_reduce as _fiar)
+    except Exception:
+        return
+    try:
+        _fiar.destroy_fi_ar_workspace()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _destroy_nccl(worker, graph_mode=None):
+    """Tear down NCCL process groups before checkpoint.  No-op at TP1."""
+    import torch.distributed as dist
+
+    graph_mode = graph_mode or GRAPH_MODE_REUSE
+    if _semip_tp_size(worker) <= 1:
+        return None
+
+    preserve_graph = graph_mode == GRAPH_MODE_REUSE
+    # Abort (unilateral) rather than collective-destroy when a live graph pins
+    # the comm (reuse) or the MoE/EP topology would deadlock a collective destroy.
+    abort_nccl = preserve_graph or _semip_ep_enabled(
+        getattr(worker, "vllm_config", None))
+
+    def _close_custom_allreduce_ipc_handles(ca):
+        if ca is None or getattr(ca, "disabled", True):
+            return
+        rank = ca.rank
+        for pointers in (getattr(ca, "meta_ptrs", []),
+                         getattr(ca, "buffer_ptrs", [])):
+            for i, ptr in enumerate(pointers):
+                if i == rank or not ptr:
+                    continue
+                ret = _cudart.cudaIpcCloseMemHandle(ctypes.c_void_p(ptr))
+                if ret != 0:
+                    raise RuntimeError(
+                        f"cudaIpcCloseMemHandle failed with cudaError={ret}")
+
+    if not dist.is_initialized():
+        return {}
+    from vllm.distributed import parallel_state as ps
+    from vllm.distributed.parallel_state import (
+        destroy_model_parallel, destroy_distributed_environment)
+
+    # Free the FlashInfer AR+RMS multicast workspace before NCCL teardown (full
+    # only; reuse preserves graphs and thus the workspace they reference).
+    if not preserve_graph:
+        _semip_destroy_fi_ar_workspace()
+
+    seen_pynccl_ids = set()
+    seen_ca_ids = set()
+    abort_targets = []
+    abort_pynccls = []
+    # Every group, not just tp/world: MoE adds ep (and may add dp/dcp/pcp/eplb);
+    # leaving any undestroyed leaks NCCL/NVLS handles across the checkpoint.
+    for name, ref in list(getattr(ps, "_groups", {}).items()):
+        group = ref() if callable(ref) else ref
+        if group is None:
+            continue
+        comm = getattr(group, "device_communicator", None)
+        if comm is None:
+            continue
+        pynccl = getattr(comm, "pynccl_comm", None)
+        if pynccl is not None and getattr(pynccl, "comm", None) is not None:
+            if id(pynccl) not in seen_pynccl_ids:
+                seen_pynccl_ids.add(id(pynccl))
+                if abort_nccl:
+                    cp = pynccl.comm
+                    cp = (int(cp.value) if isinstance(cp, ctypes.c_void_p)
+                          else int(cp))
+                    abort_targets.append((name, cp))
+                    abort_pynccls.append(pynccl)
+                else:
+                    pynccl.nccl.ncclCommDestroy(pynccl.comm)
+                    pynccl.comm = None
+        ca = getattr(comm, "ca_comm", None)
+        if ca is not None and id(ca) not in seen_ca_ids:
+            seen_ca_ids.add(id(ca))
+            _close_custom_allreduce_ipc_handles(ca)
+            ca.close()
+            comm.ca_comm = None
+
+    _torch_abort_state = {"done": False}
+
+    def _do_torch_pg_abort():
+        _abort_torch_process_groups()
+        _torch_abort_state["done"] = True
+
+    if abort_targets:
+        _nccl_abort_comms_concurrent(
+            abort_targets,
+            after_fire=(_do_torch_pg_abort if not preserve_graph else None))
+        for pynccl in abort_pynccls:
+            pynccl.comm = None
+
+    if abort_nccl and not _torch_abort_state["done"]:
+        _do_torch_pg_abort()
+
+    try:
+        destroy_model_parallel()
+        destroy_distributed_environment()
+    except Exception:  # noqa: BLE001
+        # Aborted comms make the clean destroy raise; parallel_state is reset
+        # enough for reinit to rebuild.  Only re-raise on the clean path.
+        if not abort_nccl:
+            raise
+    _clear_fd_backed_nccl_env()
+    return {"graph_mode": graph_mode}
+
+
+def _force_dist_uninitialized_for_restore():
+    """Force torch.distributed + parallel_state to a clean uninitialized state so
+    the next init rebuilds a FRESH process group / TCP store / NCCL comms.  After
+    an abort-based teardown the CRIU image can carry is_initialized()==True with
+    dead PGs, which makes post-restore init skip init_process_group and deadlock."""
+    from vllm.distributed import parallel_state as ps
+    try:
+        import torch.distributed as dist  # noqa: F401
+        from torch.distributed import distributed_c10d as c10d
+        try:
+            c10d._update_default_pg(None)
+        except BaseException:  # noqa: BLE001
+            c10d.GroupMember.WORLD = None
+        w = getattr(c10d, "_world", None)
+        if w is not None:
+            for _attr in ("comms", "pg_map", "pg_names", "pg_group_ranks",
+                          "pg_backend_config", "pg_to_tag", "tags_to_pg",
+                          "pg_coalesce_state"):
+                try:
+                    getattr(w, _attr).clear()
+                except BaseException:  # noqa: BLE001
+                    pass
+            try:
+                w.group_count = 0
+            except BaseException:  # noqa: BLE001
+                pass
+        try:
+            c10d._unregister_all_process_groups()
+        except BaseException:  # noqa: BLE001
+            pass
+    except BaseException:  # noqa: BLE001
+        pass
+    for _g in ("_WORLD", "_INNER_DP_WORLD", "_NODE_COUNT", "_TP", "_PP", "_DP",
+               "_DCP", "_PCP", "_EP", "_EPLB", "_SP", "_SP_TP"):
+        try:
+            if hasattr(ps, _g):
+                setattr(ps, _g, None)
+        except BaseException:  # noqa: BLE001
+            pass
+
+
+def _reinit_nccl(worker, port):
+    """Re-initialize NCCL after restore on a fresh TCP port, then rebind the
+    canonical tp:0/world:0 (+ ep:0/dp:0 for MoE) group slots the captured graphs
+    look up."""
+    import traceback
+    import weakref
+    from vllm.config import set_current_vllm_config
+    from vllm.distributed import parallel_state as ps
+    from vllm.v1.worker.gpu_worker import init_worker_distributed_environment
+    try:
+        _clear_fd_backed_nccl_env()
+        _force_dist_uninitialized_for_restore()
+        # NVLS / SymmMem exchange fds that do not survive CRIU -> keep them off.
+        os.environ["NCCL_NVLS_ENABLE"] = "0"
+        os.environ["VLLM_ALLREDUCE_USE_SYMM_MEM"] = "0"
+        _rd_keep = getattr(worker, "_semip_rank_data_keep", None)
+        with set_current_vllm_config(worker.vllm_config):
+            # Reuse the preserved cold-start rank_data tensor (same VA) so the
+            # kept-graph CA _dp pointers stay valid.
+            _rd_patched = bool(
+                _CA_REBIND_AVAILABLE and ca_graph_rebind is not None
+                and _rd_keep is not None
+                and ca_graph_rebind.install_rank_data_reuse_patch(_rd_keep))
+            try:
+                init_worker_distributed_environment(
+                    worker.vllm_config,
+                    worker.rank,
+                    distributed_init_method=f"tcp://127.0.0.1:{port}",
+                    local_rank=worker.local_rank,
+                    backend="nccl",
+                )
+            finally:
+                if _rd_patched:
+                    ca_graph_rebind.restore_rank_data_reuse_patch()
+        new_tp = ps.get_tp_group()
+        new_world = ps.get_world_group()
+        if hasattr(ps, "_groups"):
+            ps._groups["tp:0"] = weakref.ref(new_tp)
+            ps._groups["world:0"] = weakref.ref(new_world)
+            if _semip_ep_enabled(getattr(worker, "vllm_config", None)):
+                for _grp_name, _getter in (("ep:0", "get_ep_group"),
+                                           ("dp:0", "get_dp_group")):
+                    try:
+                        _grp = getattr(ps, _getter)()
+                    except Exception:  # noqa: BLE001
+                        _grp = None
+                    if _grp is not None:
+                        ps._groups[_grp_name] = weakref.ref(_grp)
+        return {"ok": True, "rank": getattr(worker, "rank", "?")}
+    except BaseException as e:  # noqa: BLE001
+        return {"ok": False, "rank": getattr(worker, "rank", "?"),
+                "error": f"{type(e).__name__}: {e}",
+                "traceback": traceback.format_exc()}
+
+
+def _prepare_worker_dump(worker):
+    """Clean up per-worker FDs / io_uring / IB verbs mappings for CRIU dump.
+    Invoked from the parent's prepare_criu_dump handler via collective_rpc so
+    each TP worker subprocess sheds state CRIU cannot serialize."""
+    pid = os.getpid()
+    closed_fds = []
+    unmapped = []
+    devnull = os.open(os.devnull, os.O_RDWR)
+    for std_fd in (1, 2):
+        os.dup2(devnull, std_fd)
+    os.close(devnull)
+    close_anon = ("infinibandevent", "io_uring")
+    close_shm = ("/dev/shm/psm_",)
+    keep_prefixes = ("/dev/nvidia", "/dev/shm", "anon_inode:", "socket:", "pipe:")
+    for fd_name in sorted(os.listdir(f"/proc/{pid}/fd"), key=int):
+        try:
+            fd_int = int(fd_name)
+            if fd_int <= 2:
+                continue
+            link = os.readlink(f"/proc/{pid}/fd/{fd_name}")
+            if link.startswith("anon_inode:"):
+                if any(bad in link for bad in close_anon):
+                    os.close(fd_int)
+                    closed_fds.append(fd_int)
+                continue
+            if any(link.startswith(p) for p in close_shm):
+                os.close(fd_int)
+                closed_fds.append(fd_int)
+                continue
+            if any(link.startswith(p) for p in keep_prefixes):
+                continue
+            os.close(fd_int)
+            closed_fds.append(fd_int)
+        except (OSError, ValueError):
+            pass
+    libc = ctypes.CDLL("libc.so.6")
+    with open(f"/proc/{pid}/maps") as f:
+        for line in f:
+            if (("io_uring" in line) or ("/dev/infiniband/" in line)
+                    or ("uverbs" in line)):
+                start_s, end_s = line.split()[0].split("-")
+                start = int(start_s, 16)
+                length = int(end_s, 16) - start
+                libc.munmap(ctypes.c_void_p(start), ctypes.c_size_t(length))
+                unmapped.append(f"0x{start:x}")
+
+    # PSM (IB/EFA) shm: do NOT munmap -- the mapping may still be referenced by
+    # a live provider thread even after NCCL teardown, so munmap SIGSEGVs the
+    # worker.  Instead unlink the /dev/shm/psm_* file while keeping the mapping;
+    # the inode stays alive so the worker is unaffected, and CRIU then captures
+    # the mapping as anonymous memory (no file to reopen on restore).
+    import glob as _glob
+    removed_psm = []
+    for _pf in _glob.glob("/dev/shm/psm_*") + _glob.glob("/dev/shm/psm2_*"):
+        try:
+            os.remove(_pf)
+            removed_psm.append(_pf)
+        except OSError:
+            pass
+    return {"closed_fds": closed_fds, "unmapped": unmapped,
+            "removed_psm": removed_psm}
+
+
+# ---------------------------------------------------------------------------
+# CUDA graph handling around CRIU (worker-local, via collective_rpc).
+#
+# Default is graph REUSE: cold-start graphs are preserved in the CRIU image and
+# their stale CustomAllreduce addresses are rewritten after reinit by
+# ca_graph_rebind (fast).  graph_mode="full" is an explicit fallback that drops
+# the graphs (cleargraph) and rebuilds them with capture_model() (slow).
+# ---------------------------------------------------------------------------
+def _semip_prepare_graph_reuse_snapshot(worker):
+    """Cold-start hook: record the CA meta/buffer/rank_data snapshot the
+    post-reinit rebind rewrites against.  No-op at TP1 or without ca_graph_rebind.
+    The cold capture was already forced onto the CA copy path + keep_graph by
+    SemipGPUWorker.compile_or_warm_up_model, so this only records state."""
+    if _semip_tp_size(worker) <= 1:
+        return {"enabled": False, "reason": "tp1"}
+    if not _CA_REBIND_AVAILABLE or ca_graph_rebind is None:
+        return {"available": False}
+    try:
+        result = ca_graph_rebind.store_snapshot(worker, None, None)
+        result["graph_mode"] = GRAPH_MODE_REUSE
+        return result
+    except Exception as e:  # noqa: BLE001
+        return {"available": True, "ok": False, "error": f"{type(e).__name__}: {e}"}
+
+
+def _semip_cleargraph(worker, graph_mode=None):
+    """Drop captured cudagraphs so the next capture_model() runs fresh.  No-op in
+    reuse mode (graphs are preserved).  In full mode: destroy exec handles, call
+    each wrapper's clear_all_graphs(), refresh the shared graph pool (else
+    recapture mints private per-size pools and OOMs), reset the MoE aux stream,
+    and reset the V2 ModelCudaGraphManager."""
+    import gc
+    from vllm.compilation.monitor import set_cudagraph_capturing_enabled
+    from vllm.platforms import current_platform
+
+    graph_mode = graph_mode or GRAPH_MODE_REUSE
+    if graph_mode == GRAPH_MODE_REUSE:
+        return {"graph_mode": graph_mode, "skipped": "reuse_preserves_graph"}
+
+    set_cudagraph_capturing_enabled(False)
+    try:
+        mr = getattr(worker, "model_runner", None)
+        mgr = getattr(mr, "cudagraph_manager", None)
+        wrapper_classes = {}
+
+        def _consider(cls):
+            if cls is not None and hasattr(cls, "_all_instances") \
+                    and hasattr(cls, "clear_all_graphs"):
+                wrapper_classes[id(cls)] = cls
+
+        for _mod, _name in (
+                ("vllm.compilation.cuda_graph", "CUDAGraphWrapper"),
+                ("vllm.compilation.breakable_cudagraph", "BreakableCUDAGraphWrapper")):
+            try:
+                _m = __import__(_mod, fromlist=[_name])
+                _consider(getattr(_m, _name, None))
+            except Exception:  # noqa: BLE001
+                pass
+        _mdl = getattr(mr, "model", None)
+        _consider(type(_mdl) if _mdl is not None else None)
+        _inner = getattr(_mdl, "cudagraph_wrapper", None) if _mdl is not None else None
+        _consider(type(_inner) if _inner is not None else None)
+        _bcr = getattr(mgr, "breakable_cg_runner", None)
+        _consider(type(_bcr) if _bcr is not None else None)
+        if len(wrapper_classes) < 2:
+            for o in gc.get_objects():
+                t = type(o)
+                try:
+                    if hasattr(t, "_all_instances") and hasattr(t, "clear_all_graphs"):
+                        wrapper_classes[id(t)] = t
+                except Exception:  # noqa: BLE001
+                    pass
+
+        def _entries_of(inst):
+            for attr in ("concrete_cudagraph_entries", "entries", "cudagraphs"):
+                d = getattr(inst, attr, None)
+                if isinstance(d, dict):
+                    return d
+            return {}
+
+        def _reset_graph(obj):
+            if obj is not None and hasattr(obj, "reset"):
+                try:
+                    obj.reset()
+                except Exception:  # noqa: BLE001
+                    pass
+
+        for cls in wrapper_classes.values():
+            for i in list(getattr(cls, "_all_instances", []) or []):
+                for e in list(_entries_of(i).values()):
+                    _reset_graph(getattr(e, "cudagraph", None))
+                    cap = getattr(e, "capture", None)
+                    for seg in list(getattr(cap, "segments", []) or []):
+                        _reset_graph(getattr(seg, "__self__", None))
+
+        for cls in wrapper_classes.values():
+            try:
+                cls.clear_all_graphs()
+            except Exception:  # noqa: BLE001
+                for i in list(getattr(cls, "_all_instances", []) or []):
+                    try:
+                        i.clear_graphs()
+                    except Exception:  # noqa: BLE001
+                        try:
+                            _entries_of(i).clear()
+                        except Exception:  # noqa: BLE001
+                            pass
+
+        for cand in (_mdl, getattr(_mdl, "cudagraph_wrapper", None)
+                     if _mdl is not None else None):
+            if (cand is not None and not hasattr(type(cand), "_all_instances")
+                    and hasattr(cand, "cudagraphs") and hasattr(cand, "clear_graphs")):
+                try:
+                    cand.clear_graphs()
+                except Exception:  # noqa: BLE001
+                    pass
+
+        fresh_pool = None
+        try:
+            type(current_platform)._global_graph_pool = None
+            fresh_pool = current_platform.get_global_graph_pool()
+        except Exception:  # noqa: BLE001
+            pass
+        if fresh_pool is not None:
+            for cls in wrapper_classes.values():
+                for i in list(getattr(cls, "_all_instances", []) or []):
+                    if hasattr(i, "graph_pool"):
+                        try:
+                            i.graph_pool = fresh_pool
+                        except Exception:  # noqa: BLE001
+                            pass
+
+        try:
+            import vllm.utils.torch_utils as _vtu
+            if getattr(_vtu, "_aux_stream", None) is not None:
+                _vtu._aux_stream = None
+        except Exception:  # noqa: BLE001
+            pass
+
+        if mgr is not None:
+            try:
+                for _g in list(getattr(mgr, "graphs", {}).values()):
+                    _reset_graph(_g)
+                if hasattr(mgr, "graphs"):
+                    mgr.graphs.clear()
+                if hasattr(mgr, "_graphs_captured"):
+                    mgr._graphs_captured = False
+                if getattr(mgr, "pool", None) is not None and fresh_pool is not None:
+                    mgr.pool = fresh_pool
+            except Exception:  # noqa: BLE001
+                pass
+
+        gc.collect()
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+    finally:
+        set_cudagraph_capturing_enabled(True)
+    return {"graph_mode": graph_mode}
+
+
+def _semip_reuse_graphs(worker):
+    """Repair preserved CUDA graphs against the post-restore runtime by rewriting
+    the moved CustomAllreduce addresses (ca_graph_rebind).  No capture_model()."""
+    if _semip_tp_size(worker) <= 1:
+        torch.cuda.synchronize()
+        return {"ok": True, "recaptured": False, "graph_mode": GRAPH_MODE_REUSE,
+                "skipped": "tp1_graph_reuse"}
+    if not _CA_REBIND_AVAILABLE or ca_graph_rebind is None:
+        return {"ok": False, "graph_mode": GRAPH_MODE_REUSE,
+                "error": "ca_graph_rebind unavailable"}
+    ca_rebind = ca_graph_rebind.rebind_after_reinit(worker)
+    torch.cuda.synchronize()
+    return {"ok": bool(ca_rebind.get("ok")), "recaptured": False,
+            "graph_mode": GRAPH_MODE_REUSE, "ca_rebind": ca_rebind}
+
+
+def _semip_connect_ep_channels_before_capture(worker):
+    """Connect every MoE/EP NCCL channel on the default stream before a full
+    capture_model().  Without this the ep all_gather/reduce_scatter lazily
+    connects on the graph-capture stream and recapture hangs.  EP-only."""
+    if not _semip_ep_enabled(getattr(worker, "vllm_config", None)):
+        return {"skipped": "not_ep"}
+    mr = getattr(worker, "model_runner", None)
+    dummy = getattr(mr, "_dummy_run", None)
+    if mr is None or dummy is None:
+        return {"skipped": "no_dummy_run"}
+    from vllm.config import CUDAGraphMode
+    none_mode = CUDAGraphMode.NONE
+    try:
+        cc = (getattr(mr, "compilation_config", None)
+              or getattr(getattr(worker, "vllm_config", None),
+                         "compilation_config", None))
+        sizes = getattr(cc, "cudagraph_capture_sizes", None) or [32]
+        max_sz = int(max(sizes))
+    except Exception:  # noqa: BLE001
+        max_sz = 32
+    diag = {}
+    for name, ntok, uniform in (("mixed", max_sz, False), ("decode", 1, True)):
+        try:
+            dummy(ntok, cudagraph_runtime_mode=none_mode, uniform_decode=uniform,
+                  skip_eplb=True, remove_lora=False)
+            torch.cuda.synchronize()
+            diag[name] = "ok"
+        except Exception as e:  # noqa: BLE001
+            diag[name] = f"err: {type(e).__name__}: {e}"
+    return diag
+
+
+def _semip_recapture_graphs(worker, graph_mode=None):
+    """Repair (reuse) or rebuild (full) CUDA graphs against the live post-restore
+    state."""
+    graph_mode = graph_mode or GRAPH_MODE_REUSE
+    if graph_mode == GRAPH_MODE_REUSE:
+        return _semip_reuse_graphs(worker)
+    mr = worker.model_runner
+    cleargraph = _semip_cleargraph(worker, GRAPH_MODE_FULL)
+    _semip_connect_ep_channels_before_capture(worker)
+    torch.cuda.synchronize()
+    mr.capture_model()
+    torch.cuda.synchronize()
+    return {"ok": True, "recaptured": True, "graph_mode": graph_mode,
+            "cleargraph": cleargraph, "rank": getattr(worker, "rank", "?")}
+
+
+def vllm_child_loop(pipe_conn, instance_id, gpus, model_dir=None):
     """Runs in a spawned child process: owns CUDA and vLLM.
 
-    The main loop has two modes:
+    ``gpus`` is the physical GPU list for this instance (a single-element
+    list at TP=1).  The main loop has two modes:
     - **Idle**: blocks on pipe_conn.recv() (zero CPU).
     - **Active** (engine has unfinished requests): alternates between
       engine.step() and non-blocking pipe_conn.poll() so new generate
       requests can be submitted mid-decode.
     """
-    os.environ["CUDA_VISIBLE_DEVICES"] = str(rank)
+    if isinstance(gpus, int):
+        gpus = [gpus]
+    gpus = list(gpus)
+    rank = gpus[0]
+    if len(gpus) > 1:
+        # TP>1: keep ALL GPUs visible so tensor parallelism can span the
+        # group; each vLLM worker is placed on its physical GPU by
+        # SemipGPUWorker.init_device via SEMIP_GPU_MAP.  Any inherited
+        # CUDA_VISIBLE_DEVICES mask must be cleared first, else the physical
+        # indices in SEMIP_GPU_MAP disagree with the visible-device namespace
+        # (and it would confuse the cuda-checkpoint physical-GPU addressing).
+        os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+        os.environ["SEMIP_GPU_MAP"] = ",".join(str(g) for g in gpus)
+    else:
+        # TP1: unchanged single-GPU behavior -- pin to the one GPU so it is
+        # visible as device 0.
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(gpus[0])
     os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
     os.environ["USE_LIBUV"] = "0"
+
+    # Bind vLLM's internal rendezvous (the torch.distributed TCPStore) to
+    # loopback instead of the node's routable IP.  get_ip() otherwise picks
+    # the routable interface address, which CRIU bakes into the image as the
+    # listening socket's bound address; restoring on a different node then
+    # fails at bind() with EADDRNOTAVAIL.  127.0.0.1 exists identically on
+    # every node, so loopback makes images node-portable.
+    os.environ["VLLM_HOST_IP"] = "127.0.0.1"
+    # VLLM_HOST_IP only steers vLLM's own rendezvous.  The collective
+    # libraries pick their transport interface independently and default to
+    # the routable NIC: gloo keeps a persistent listening socket for the life
+    # of the process and NCCL opens a bootstrap listener, both of which get
+    # baked into the image bound to the capture node's IP.  Pin them to
+    # loopback so every internal socket binds to 127.0.0.1.  An instance is
+    # single-node even at TP>1 -- the TP group's ranks are local, so their
+    # NCCL bootstrap reaches across loopback fine and the data path rides
+    # NVLink/P2P rather than these sockets.
+    os.environ["NCCL_SOCKET_IFNAME"] = "lo"
+    os.environ["GLOO_SOCKET_IFNAME"] = "lo"
 
     # JIT/compile caches (Triton, vLLM torch.compile, torch inductor,
     # FlashInfer) all produce .so's that get dlopen()'d into the process.
@@ -154,7 +838,10 @@ def vllm_child_loop(pipe_conn, instance_id, rank, model_dir=None):
         # fd-0 redirect above is the part that matters for CRIU.
         pass
 
-    torch.cuda.set_device(0)
+    # TP1 pins its single GPU via CUDA_VISIBLE_DEVICES, so it is device 0
+    # here.  At TP>1 all GPUs stay visible, so address the group's first
+    # physical GPU directly.
+    torch.cuda.set_device(0 if len(gpus) == 1 else gpus[0])
 
     llm = None
     engine = None
@@ -508,6 +1195,22 @@ def vllm_child_loop(pipe_conn, instance_id, rank, model_dir=None):
                 vllm_config = dict(kwargs["vllm_config"])
                 vllm_config["enable_sleep_mode"] = True
 
+                # TP>1 only: steer the collective path onto shapes that survive
+                # a checkpoint.  Fused allreduce+RMS and NVLS/symmetric-memory
+                # allreduce keep state CRIU cannot serialize, and the MoE
+                # shared-experts side stream complicates graph capture.
+                _tp = int(vllm_config.get("tensor_parallel_size", 1) or 1)
+                if _tp >= 2:
+                    _cc = vllm_config.get("compilation_config")
+                    _cc = dict(_cc) if isinstance(_cc, dict) else {}
+                    _pc = dict(_cc.get("pass_config") or {})
+                    _pc["fuse_allreduce_rms"] = False
+                    _cc["pass_config"] = _pc
+                    vllm_config["compilation_config"] = _cc
+                    os.environ["NCCL_NVLS_ENABLE"] = "0"
+                    os.environ["VLLM_ALLREDUCE_USE_SYMM_MEM"] = "0"
+                    os.environ["VLLM_DISABLE_SHARED_EXPERTS_STREAM"] = "1"
+
                 # Per-model env vars: vllm_config["_env"] is a reserved
                 # mapping applied to os.environ before vLLM is imported,
                 # so flags vLLM reads at import time take effect.  The
@@ -518,6 +1221,13 @@ def vllm_child_loop(pipe_conn, instance_id, rank, model_dir=None):
                     "CUDA_VISIBLE_DEVICES",
                     "VLLM_ENABLE_V1_MULTIPROCESSING",
                     "USE_LIBUV",
+                    # Loopback pinning: repointing these at a routable NIC
+                    # bakes the capture node's IP into the image and breaks
+                    # restore elsewhere with EADDRNOTAVAIL.
+                    "VLLM_HOST_IP",
+                    "NCCL_SOCKET_IFNAME",
+                    "GLOO_SOCKET_IFNAME",
+                    "SEMIP_GPU_MAP",
                     # Compile-cache roots: CRIU bakes the resulting .so
                     # paths into the image, so a user override here would
                     # make the image unrestorable.
@@ -583,6 +1293,11 @@ def vllm_child_loop(pipe_conn, instance_id, rank, model_dir=None):
                     self.worker._skip_drafter_param_snapshot = True
 
                 llm.collective_rpc(_enable_semi_persistence_flags)
+
+                # Record the cold-start CustomAllreduce snapshot that the
+                # post-reinit graph rebind rewrites against (TP>=2, reuse).
+                if _tp >= 2:
+                    llm.collective_rpc(_semip_prepare_graph_reuse_snapshot)
 
             elif cmd == "attach" or cmd == "attach_pinned":
                 if llm is None:
@@ -1007,6 +1722,20 @@ def vllm_child_loop(pipe_conn, instance_id, rank, model_dir=None):
             elif cmd == "prepare_criu_dump":
                 _drain_engine()
 
+                # TP>1: each worker is a separate subprocess with its own FDs /
+                # io_uring rings / IB verbs mappings that CRIU cannot serialize.
+                # Clean them up before the tree is dumped.  Skipped at TP1, where
+                # the "worker" is this same (driver) process -- running it here
+                # would close this process's own FDs (incl. the worker pipe).
+                if llm is not None and len(gpus) > 1:
+                    try:
+                        wr = llm.collective_rpc(_prepare_worker_dump)
+                        info["worker_closed_fds"] = [r["closed_fds"] for r in wr]
+                        info["worker_unmapped"] = [r["unmapped"] for r in wr]
+                    except Exception as _e:
+                        log.warning(
+                            "  prepare_criu_dump: worker dump prep error: %s", _e)
+
                 closed_fds = []
                 unmapped = []
                 destroyed_pg = False
@@ -1117,6 +1846,72 @@ def vllm_child_loop(pipe_conn, instance_id, rank, model_dir=None):
                 log = semip_logging.child(new_id, rank)
                 info["instance_id"] = new_id
                 info["path"] = _child_log_path
+
+            elif cmd == "destroy_nccl":
+                if llm is None:
+                    raise RuntimeError("destroy_nccl requires init first")
+                graph_mode = kwargs.get("graph_mode")
+                results = llm.collective_rpc(_destroy_nccl, args=(graph_mode,))
+                info["graph_mode"] = graph_mode
+                if all(r is None for r in results):
+                    log.info("  destroy_nccl(%s): TP1 no-op", graph_mode)
+                else:
+                    log.info("  NCCL destroyed across %d workers (graph_mode=%s)",
+                             len(results), graph_mode)
+
+            elif cmd == "reinit_nccl":
+                if llm is None:
+                    raise RuntimeError("reinit_nccl requires init first")
+                from vllm.utils.network_utils import get_open_port
+                port = get_open_port()
+                results = llm.collective_rpc(_reinit_nccl, args=(port,))
+                failures = [r for r in results
+                            if isinstance(r, dict) and not r.get("ok", True)]
+                if failures:
+                    raise RuntimeError(f"NCCL reinit failed on workers: {failures}")
+                log.info("  NCCL re-initialized on port %d across %d workers",
+                         port, len(results))
+
+            elif cmd == "cleargraph":
+                if llm is None:
+                    raise RuntimeError("cleargraph requires init/load first")
+                graph_mode = kwargs.get("graph_mode")
+                results = llm.collective_rpc(_semip_cleargraph, args=(graph_mode,))
+                info["graph_mode"] = graph_mode
+                log.info("  cleargraph(%s) across %d worker(s)",
+                         graph_mode, len(results))
+
+            elif cmd == "recapture_graphs":
+                if llm is None:
+                    raise RuntimeError("recapture_graphs requires init/load first")
+                graph_mode = kwargs.get("graph_mode") or GRAPH_MODE_REUSE
+                results = llm.collective_rpc(
+                    _semip_recapture_graphs, args=(graph_mode,))
+                info["graph_mode"] = graph_mode
+                failures = [r for r in results
+                            if not (isinstance(r, dict) and r.get("ok", False))]
+                if failures:
+                    raise RuntimeError(
+                        f"semip recapture_graphs({graph_mode}) failed: {failures}")
+                log.info("  recapture_graphs(%s) across %d worker(s)",
+                         graph_mode, len(results))
+                # Reuse preserves graph topology but restore drops most
+                # cudaGraphExec handles; re-instantiate them in lockstep across
+                # ranks before live traffic by driving a few co-scheduled batches
+                # at increasing concurrency.
+                if graph_mode == GRAPH_MODE_REUSE:
+                    if engine is None:
+                        engine = llm.llm_engine
+                    from vllm import SamplingParams
+                    for nreq in (1, 2, 4, 8, 16):
+                        toklen = max(1, min(64 // nreq, 20))
+                        for _ in range(nreq):
+                            engine.add_request(
+                                _alloc_engine_id(),
+                                {"prompt_token_ids": [0] * toklen},
+                                SamplingParams(max_tokens=2, ignore_eos=True))
+                        while engine.has_unfinished_requests():
+                            engine.step()
 
             elif cmd == "save_weights":
                 if pinned_buf is None or index is None:

--- a/arctic_inference/semi_persistence/vllm_child.py
+++ b/arctic_inference/semi_persistence/vllm_child.py
@@ -14,14 +14,21 @@ to accept new generate requests (and other commands) while the engine
 is actively decoding, enabling concurrent request handling without
 asyncio or extra threads.
 
-Attach allocates pinned CPU memory sized to model.named_parameters().
-Stage snapshots the post-processed GPU parameters into the pinned
-buffer.  plan_restore_weights walks the param index once and caches
-a chunk plan (chunk_lo, chunk_hi, members) bounded by max_buffer_bytes.
+Attach allocates CPU memory sized to model.named_parameters().  Stage
+snapshots the post-processed GPU parameters into that buffer.
+plan_restore_weights walks the param index once and caches a chunk plan
+(chunk_lo, chunk_hi, members) bounded by max_buffer_bytes.
 restore_weights then loops over the cached plan: per chunk, copy a
-slice of pinned CPU into a single reused GPU staging buffer and
+slice of host memory into a single reused GPU staging buffer and
 scatter into model parameters by name.  If no plan is cached,
 restore_weights falls back to a single-chunk path.
+
+All of that state lives on each vLLM worker (``worker._semip_*``) and
+runs there via ``collective_rpc``, not in this process.  At TP>1 the
+callable is cloudpickled into every worker subprocess, so a buffer held
+here would be copied by value per worker and its writes discarded; each
+rank also owns a different shard of the parameters.  The same code path
+serves TP=1, where the single worker is in-process.
 """
 import ctypes, json, os, shutil, subprocess, sys, time
 from concurrent.futures import ThreadPoolExecutor
@@ -85,6 +92,276 @@ def _repin_buffer(buf):
     )
     if ret != 0:
         raise RuntimeError(f"cudaHostRegister failed with cudaError={ret}")
+
+
+# ---------------------------------------------------------------------------
+# Worker-local semi-persistence primitives (TP-safe).
+#
+# These run inside each vLLM worker via ``llm.collective_rpc``.  At TP>1 the
+# callable is cloudpickled and executed in every worker process, so the
+# staging buffer must live on the worker object (``worker._semip_*``), not in
+# the vllm_child process -- a captured closure over a vllm_child-local buffer
+# would be copied by value per worker and its writes discarded.  The same code
+# path works at TP=1 (a single worker, in-process).  ``worker`` is whatever
+# ``collective_rpc`` passes (the WorkerWrapperBase driver at TP=1, the real
+# Worker at TP>1); attribute reads forward to the underlying Worker either way,
+# and attribute writes persist across calls because the object is stable.
+#
+# Param names are namespaced ``main:p:`` / ``drafter:p:`` to match the layout
+# built at attach so stage/restore dispatch each entry to the right tensor.
+# ---------------------------------------------------------------------------
+def _semip_layout(worker):
+    layout = []
+    mr = worker.model_runner
+    for name, p in mr.model.named_parameters():
+        d = p.data
+        layout.append((f"main:p:{name}", d.nbytes, d.dtype, tuple(d.shape)))
+    drafter = getattr(mr, "drafter", None)
+    dm = getattr(drafter, "model", None) if drafter is not None else None
+    if dm is not None:
+        for name, p in dm.named_parameters():
+            d = p.data
+            layout.append((f"drafter:p:{name}", d.nbytes, d.dtype, tuple(d.shape)))
+    return layout
+
+
+def _semip_param_tensors(worker):
+    mr = worker.model_runner
+    t = {f"main:p:{n}": p.data for n, p in mr.model.named_parameters()}
+    drafter = getattr(mr, "drafter", None)
+    dm = getattr(drafter, "model", None) if drafter is not None else None
+    if dm is not None:
+        for n, p in dm.named_parameters():
+            t[f"drafter:p:{n}"] = p.data
+    return t
+
+
+def _semip_attach(worker):
+    layout = _semip_layout(worker)
+    total_size = sum(nb for _, nb, _, _ in layout)
+    index = {}
+    offset = 0
+    for name, nbytes, dtype, shape in layout:
+        index[name] = (offset, nbytes, dtype, shape)
+        offset += nbytes
+    worker._semip_buf = torch.empty(total_size, dtype=torch.uint8)
+    worker._semip_index = index
+    worker._semip_chunk_plan = None
+    worker._semip_chunk_size = None
+    worker._semip_pinned = False
+    return (total_size, len(layout))
+
+
+def _semip_stage(worker):
+    buf = worker._semip_buf
+    index = worker._semip_index
+    sources = _semip_param_tensors(worker)
+    for name, (offset, nbytes, dtype, shape) in index.items():
+        src = sources[name].contiguous().reshape(-1).view(torch.uint8)
+        buf[offset:offset + nbytes].copy_(src, non_blocking=True)
+    torch.cuda.synchronize()
+    return buf.numel()
+
+
+def _semip_unpin(worker):
+    # Idempotent: the attach buffer starts unpinned, so a cudaHostUnregister on
+    # an unregistered (or already-unpinned) buffer would hard-error.
+    buf = getattr(worker, "_semip_buf", None)
+    if buf is None or not getattr(worker, "_semip_pinned", False):
+        return 0
+    _unpin_buffer(buf)
+    worker._semip_pinned = False
+    return buf.numel()
+
+
+def _semip_repin(worker):
+    # Idempotent: a double cudaHostRegister would hard-error.
+    buf = getattr(worker, "_semip_buf", None)
+    if buf is None:
+        return 0
+    if getattr(worker, "_semip_pinned", False):
+        return buf.numel()
+    _repin_buffer(buf)
+    worker._semip_pinned = True
+    return buf.numel()
+
+
+def _semip_plan_load_weights(worker, max_buffer_bytes=None):
+    buf = worker._semip_buf
+    index = worker._semip_index
+    total_bytes = buf.numel()
+    cs = total_bytes if max_buffer_bytes is None else min(int(max_buffer_bytes), total_bytes)
+    plan = []
+    cur = []
+    cur_lo = 0
+    for name, (off, nbytes, dtype, shape) in index.items():
+        if nbytes > cs:
+            raise RuntimeError(f"param {name} ({nbytes}B) exceeds chunk_size ({cs}B)")
+        if cur and (off + nbytes - cur_lo) > cs:
+            cur_hi = cur[-1][1] + cur[-1][2]
+            plan.append((cur_lo, cur_hi, cur))
+            cur = []
+            cur_lo = off
+        cur.append((name, off, nbytes, dtype, shape))
+    if cur:
+        cur_hi = cur[-1][1] + cur[-1][2]
+        plan.append((cur_lo, cur_hi, cur))
+    worker._semip_chunk_plan = plan
+    worker._semip_chunk_size = cs
+    return {"bytes": total_bytes, "n_chunks": len(plan), "chunk_size": cs}
+
+
+def _semip_restore_weights(worker):
+    buf = worker._semip_buf
+    index = worker._semip_index
+    targets = _semip_param_tensors(worker)
+    total_bytes = buf.numel()
+    plan = worker._semip_chunk_plan
+    cs = worker._semip_chunk_size
+    if plan is None:
+        plan = [(0, total_bytes,
+                 [(n, o, nb, dt, sh) for n, (o, nb, dt, sh) in index.items()])]
+        cs = total_bytes
+    torch.cuda.synchronize()
+    gpu_buf = torch.empty(cs, dtype=torch.uint8, device=worker.device)
+    loaded = 0
+    for chunk_lo, chunk_hi, members in plan:
+        n = chunk_hi - chunk_lo
+        gpu_buf[:n].copy_(buf[chunk_lo:chunk_hi], non_blocking=True)
+        torch.cuda.synchronize()
+        for name, off, nbytes, dtype, shape in members:
+            start = off - chunk_lo
+            src = gpu_buf[start:start + nbytes].view(dtype).reshape(shape)
+            targets[name].copy_(src)
+            loaded += 1
+        torch.cuda.synchronize()
+    gpu_buf.storage().resize_(0)
+    del gpu_buf
+    # Return the staging buffer to the CUDA *driver*, not just to torch's
+    # caching allocator.  resize_(0)/free only hands the ~cs-byte block back
+    # to torch's pool (cudaMalloc arena); it stays reserved from the driver's
+    # point of view.  The next step, wake_up(["kv_cache"]), maps the KV cache
+    # via vLLM's cumem allocator (cuMemCreate/cuMemMap), which allocates from
+    # driver-free memory -- so a torch-cached staging block (up to the full
+    # 50+ GiB weight size at chunk_size == total) starves it and the KV map
+    # OOMs.  empty_cache() releases torch's cached blocks so cumem can map.
+    torch.cuda.empty_cache()
+    return {"bytes": total_bytes, "loaded": loaded,
+            "n_chunks": len(plan), "chunk_size": cs}
+
+
+def _semip_detach(worker):
+    buf = getattr(worker, "_semip_buf", None)
+    total = buf.numel() if buf is not None else 0
+    if buf is not None and getattr(worker, "_semip_pinned", False):
+        _unpin_buffer(buf)
+    worker._semip_buf = None
+    worker._semip_index = None
+    worker._semip_chunk_plan = None
+    worker._semip_chunk_size = None
+    worker._semip_pinned = False
+    return total
+
+
+def _semip_save_weights(worker, weights_dir, shard_bytes=None, io_workers=None):
+    buf = worker._semip_buf
+    index = worker._semip_index
+    shard_bytes = int(shard_bytes or _WEIGHTS_SHARD_BYTES)
+    workers = int(io_workers or _WEIGHTS_IO_WORKERS)
+    # TP1 keeps the flat weights/ layout; TP>1 fans out per-rank shards into
+    # weights/rank{R}/, since each rank holds a different slice of the params.
+    rank_dir = (weights_dir if _semip_tp_size(worker) <= 1
+                else os.path.join(weights_dir, f"rank{worker.rank}"))
+    if os.path.exists(rank_dir):
+        try:
+            shutil.rmtree(rank_dir)
+        except PermissionError:
+            subprocess.run(["sudo", "rm", "-rf", rank_dir], check=True)
+    os.makedirs(rank_dir, exist_ok=True)
+
+    total = buf.numel()
+    mv = memoryview(buf.numpy())
+    ranges = []
+    lo = 0
+    i = 0
+    while lo < total:
+        hi = min(lo + shard_bytes, total)
+        ranges.append((i, lo, hi))
+        lo = hi
+        i += 1
+
+    def _write_shard(i, lo, hi):
+        fd = os.open(os.path.join(rank_dir, f"shard_{i:04d}.bin"),
+                     os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+        try:
+            pos = lo
+            while pos < hi:
+                pos += os.write(fd, mv[pos:hi])
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+
+    with ThreadPoolExecutor(max_workers=max(1, min(workers, len(ranges)))) as ex:
+        for fu in [ex.submit(_write_shard, *r) for r in ranges]:
+            fu.result()
+
+    manifest = {
+        "total_bytes": total,
+        "n_params": len(index),
+        "shard_bytes": shard_bytes,
+        "shards": [{"name": f"shard_{i:04d}.bin", "offset": lo, "nbytes": hi - lo}
+                   for (i, lo, hi) in ranges],
+        "layout": [[name, off, nbytes, str(dtype), list(shape)]
+                   for name, (off, nbytes, dtype, shape) in index.items()],
+    }
+    with open(os.path.join(rank_dir, "weights_meta.json"), "w") as f:
+        json.dump(manifest, f)
+    return total
+
+
+def _semip_load_weights(worker, weights_dir, io_workers=None):
+    buf = worker._semip_buf
+    index = worker._semip_index
+    workers = int(io_workers or _WEIGHTS_IO_WORKERS)
+    rank_dir = (weights_dir if _semip_tp_size(worker) <= 1
+                else os.path.join(weights_dir, f"rank{worker.rank}"))
+    meta_path = os.path.join(rank_dir, "weights_meta.json")
+    with open(meta_path) as f:
+        manifest = json.load(f)
+
+    total = buf.numel()
+    if int(manifest["total_bytes"]) != total:
+        raise RuntimeError(
+            f"weights size mismatch: manifest {manifest['total_bytes']}B but "
+            f"attached buffer {total}B (config/model changed?)")
+    cur_layout = [[name, off, nbytes]
+                  for name, (off, nbytes, dtype, shape) in index.items()]
+    man_layout = [[row[0], row[1], row[2]] for row in manifest.get("layout", [])]
+    if man_layout and man_layout != cur_layout:
+        raise RuntimeError("weights layout mismatch between manifest and "
+                           "attached model (param order/sizes differ)")
+
+    mv = memoryview(buf.numpy())
+    shards = manifest["shards"]
+
+    def _read_shard(s):
+        lo = int(s["offset"])
+        n = int(s["nbytes"])
+        dst = mv[lo:lo + n]
+        got = 0
+        with open(os.path.join(rank_dir, s["name"]), "rb", buffering=0) as f:
+            while got < n:
+                r = f.readinto(dst[got:])
+                if r == 0:
+                    break
+                got += r
+        if got != n:
+            raise RuntimeError(f"{s['name']}: read {got} != {n}")
+
+    with ThreadPoolExecutor(max_workers=max(1, min(workers, len(shards)))) as ex:
+        for fu in [ex.submit(_read_shard, s) for s in shards]:
+            fu.result()
+    return total
 
 
 # ---------------------------------------------------------------------------
@@ -845,11 +1122,10 @@ def vllm_child_loop(pipe_conn, instance_id, gpus, model_dir=None):
 
     llm = None
     engine = None
-    pinned_buf = None
-    pinned_via_attach_pinned = False  # True iff buffer was alloc'd with pin_memory=True
-    index = None       # {name: (offset, nbytes, dtype, shape)}
-    chunk_plan = None  # list[(chunk_lo, chunk_hi, members)] from plan_restore_weights
-    chunk_size = None  # int; size of the GPU staging buffer for restore_weights
+    # The staging buffer, param index and chunk plan live on each vLLM worker
+    # (``worker._semip_*``), not here -- see the worker-local primitives above.
+    # A buffer held in this process could not be written by the workers at
+    # TP>1, where collective_rpc cloudpickles the callable into subprocesses.
 
     _active_reqs = {}     # req_id -> {"t0", "engine_ids", "finished"}
     _engine_to_req = {}   # engine_request_id -> req_id
@@ -1182,8 +1458,7 @@ def vllm_child_loop(pipe_conn, instance_id, gpus, model_dir=None):
         return len(saved), len(all_eids)
 
     def _handle_command(cmd, kwargs):
-        nonlocal llm, engine, pinned_buf, pinned_via_attach_pinned
-        nonlocal index, chunk_plan, chunk_size
+        nonlocal llm, engine
         nonlocal _paused, _dormant
         nonlocal log, _child_log_path
 
@@ -1299,99 +1574,45 @@ def vllm_child_loop(pipe_conn, instance_id, gpus, model_dir=None):
                 if _tp >= 2:
                     llm.collective_rpc(_semip_prepare_graph_reuse_snapshot)
 
-            elif cmd == "attach" or cmd == "attach_pinned":
+            elif cmd == "attach":
                 if llm is None:
-                    raise RuntimeError(f"{cmd} requires init first")
-
-                # Walk both the main model and the drafter (if it has a
-                # ``.model`` attribute -- Eagle / Medusa / DraftModel /
-                # ArcticProposer).  Non-model drafters (Ngram / Suffix)
-                # have ``drafter.model is None`` and are skipped, so the
-                # layout collapses to main params only -- no behavior
-                # change vs. ``apply_model(_compute_layout)``.
-                #
-                # Names are namespaced so ``stage`` and ``restore_weights``
-                # can dispatch each entry back to the right tensor table:
-                #   "main:p:<name>"     -> main.named_parameters()[name]
-                #   "drafter:p:<name>"  -> drafter.model.named_parameters()[name]
-                # Buffers (``named_buffers()``) are intentionally not
-                # staged -- main buffers ride stock vLLM's
-                # ``_sleep_saved_buffers`` snapshot, drafter buffers
-                # ride arctic's ``_save_module_state`` snapshot.
-                def _compute_layout_full(self):
-                    layout = []
-                    main = self.model_runner.model
-                    for name, p in main.named_parameters():
-                        d = p.data
-                        layout.append((f"main:p:{name}", d.nbytes,
-                                       d.dtype, tuple(d.shape)))
-                    drafter = getattr(self.model_runner, "drafter", None)
-                    dm = (getattr(drafter, "model", None)
-                          if drafter is not None else None)
-                    if dm is not None:
-                        for name, p in dm.named_parameters():
-                            d = p.data
-                            layout.append((f"drafter:p:{name}", d.nbytes,
-                                           d.dtype, tuple(d.shape)))
-                    return layout
-
-                layout = llm.collective_rpc(_compute_layout_full)[0]
-                total_size = sum(nbytes for _, nbytes, _, _ in layout)
-
-                # attach_pinned: pin_memory=True routes through PyTorch's
-                # CachingHostAllocator (cudaHostAlloc), so the buffer stays
-                # pinned for its entire lifetime and skips the per-cycle
-                # repin()/unpin() pattern at the cost of ~34 ms/GiB extra
-                # inside cuCheckpointProcess{Checkpoint,Restore}.
-                if cmd == "attach_pinned":
-                    pinned_buf = torch.empty(total_size, dtype=torch.uint8,
-                                             pin_memory=True)
-                    pinned_via_attach_pinned = True
-                else:
-                    pinned_buf = torch.empty(total_size, dtype=torch.uint8)
-                    pinned_via_attach_pinned = False
-
-                index = {}
-                offset = 0
-                for name, nbytes, dtype, shape in layout:
-                    index[name] = (offset, nbytes, dtype, shape)
-                    offset += nbytes
-
+                    raise RuntimeError("attach requires init first")
+                # Each worker allocates a plain (unpinned) CPU buffer sized to
+                # its own shard and records the param layout on itself; pinning
+                # is the explicit repin step.  Per-worker byte counts are
+                # reported so the instance can size the restore chunk budget by
+                # the largest worker shard (not the TP-aggregate sum).
+                results = llm.collective_rpc(_semip_attach)
+                worker_bytes = [r[0] for r in results]
+                total_size = sum(worker_bytes)
                 info["pinned_cpu_bytes"] = total_size
-                _label = ("pinned host memory (pin_memory=True)"
-                          if pinned_via_attach_pinned else "pinned memory")
-                log.info("  allocated %.2f GiB %s (%d params)",
-                         total_size / 2**30, _label, len(layout))
+                info["pinned_bytes_per_worker"] = worker_bytes
+                info["max_pinned_bytes_per_worker"] = max(worker_bytes, default=0)
+                log.info("  attached %.2f GiB across %d worker(s)",
+                         total_size / 2**30, len(results))
+
+            elif cmd == "attach_pinned":
+                raise RuntimeError(
+                    "attach_pinned is not implemented for the worker-local "
+                    "staging path; use attach -> repin instead")
 
             elif cmd == "detach":
-                if pinned_buf is not None:
-                    total = pinned_buf.numel()
-                    pinned_buf = None
-                    pinned_via_attach_pinned = False
-                    index = None
-                    chunk_plan = None
-                    chunk_size = None
+                if llm is not None:
+                    results = llm.collective_rpc(_semip_detach)
+                    total = sum(results)
                     log.info("  freed %.2f GiB pinned memory", total / 2**30)
 
             elif cmd == "unpin":
-                if pinned_buf is None:
+                if llm is None:
                     raise RuntimeError("unpin requires attach first")
-                if pinned_via_attach_pinned:
-                    raise RuntimeError(
-                        "unpin not allowed on attach_pinned() buffer; "
-                        "memory stays pinned for the buffer's lifetime")
-                _unpin_buffer(pinned_buf)
-                log.info("  unpinned %.2f GiB", pinned_buf.numel() / 2**30)
+                results = llm.collective_rpc(_semip_unpin)
+                log.info("  unpinned %.2f GiB", sum(results) / 2**30)
 
             elif cmd == "repin":
-                if pinned_buf is None:
+                if llm is None:
                     raise RuntimeError("repin requires attach first")
-                if pinned_via_attach_pinned:
-                    raise RuntimeError(
-                        "repin not allowed on attach_pinned() buffer; "
-                        "memory stays pinned for the buffer's lifetime")
-                _repin_buffer(pinned_buf)
-                log.info("  repinned %.2f GiB", pinned_buf.numel() / 2**30)
+                results = llm.collective_rpc(_semip_repin)
+                log.info("  repinned %.2f GiB", sum(results) / 2**30)
 
             elif cmd == "sleep":
                 # Invariant: while `_paused` is True, `_active_reqs`
@@ -1416,151 +1637,46 @@ def vllm_child_loop(pipe_conn, instance_id, gpus, model_dir=None):
                 _dormant = True
 
             elif cmd == "stage":
-                if pinned_buf is None:
+                if llm is None:
                     raise RuntimeError("stage requires attach first")
-                if index is None:
-                    raise RuntimeError("no index (call attach first)")
-
-                _pinned = pinned_buf
-                _index = index
-
-                # Mirror image of ``_compute_layout_full`` in attach:
-                # build a unified ``name -> tensor`` table that covers
-                # main params + drafter params (drafter only if it has
-                # a ``.model``).  Then drive copies off ``_index`` so
-                # the source set lines up exactly with what attach
-                # measured.
-                def _stage_weights(self):
-                    main = self.model_runner.model
-                    drafter = getattr(self.model_runner, "drafter", None)
-                    dm = (getattr(drafter, "model", None)
-                          if drafter is not None else None)
-                    sources = {f"main:p:{n}": p.data
-                               for n, p in main.named_parameters()}
-                    if dm is not None:
-                        for n, p in dm.named_parameters():
-                            sources[f"drafter:p:{n}"] = p.data
-                    for name, (offset, nbytes, dtype, shape) in _index.items():
-                        src = (sources[name].contiguous().reshape(-1)
-                               .view(torch.uint8))
-                        _pinned[offset:offset + nbytes].copy_(
-                            src, non_blocking=True)
-                    torch.cuda.synchronize()
-
-                llm.collective_rpc(_stage_weights)
-
-                total_bytes = pinned_buf.numel()
+                results = llm.collective_rpc(_semip_stage)
+                total_bytes = sum(results)
                 info["bytes"] = total_bytes
-                log.info("  staged %d params (%.2f GiB)",
-                         len(index), total_bytes / 2**30)
+                log.info("  staged %.2f GiB across %d worker(s)",
+                         total_bytes / 2**30, len(results))
 
             elif cmd == "wake_up_weights":
                 llm.wake_up(tags=["weights"])
 
             elif cmd == "plan_restore_weights":
-                if pinned_buf is None or index is None:
-                    raise RuntimeError(
-                        "plan_restore_weights requires attach first")
-
-                total_bytes = pinned_buf.numel()
+                if llm is None:
+                    raise RuntimeError("plan_restore_weights requires init first")
                 mb = kwargs.get("max_buffer_bytes")
-                cs = total_bytes if mb is None else min(int(mb), total_bytes)
-
-                plan = []
-                cur = []
-                cur_lo = 0
-                for name, (off, nbytes, dtype, shape) in index.items():
-                    if nbytes > cs:
-                        raise RuntimeError(
-                            f"param {name} ({nbytes}B) exceeds "
-                            f"chunk_size ({cs}B)")
-                    if cur and (off + nbytes - cur_lo) > cs:
-                        cur_hi = cur[-1][1] + cur[-1][2]
-                        plan.append((cur_lo, cur_hi, cur))
-                        cur = []
-                        cur_lo = off
-                    cur.append((name, off, nbytes, dtype, shape))
-                if cur:
-                    cur_hi = cur[-1][1] + cur[-1][2]
-                    plan.append((cur_lo, cur_hi, cur))
-
-                chunk_plan = plan
-                chunk_size = cs
-                info["n_chunks"] = len(plan)
-                info["chunk_size"] = cs
-                log.info("  planned %d chunks of <= %.2f GiB (total %.2f GiB)",
-                         len(plan), cs / 2**30, total_bytes / 2**30)
+                results = llm.collective_rpc(_semip_plan_load_weights, args=(mb,))
+                worker_bytes = [r["bytes"] for r in results]
+                chunk_bytes = [r["chunk_size"] for r in results]
+                n_chunks = [r["n_chunks"] for r in results]
+                info["bytes"] = sum(worker_bytes)
+                info["pinned_bytes_per_worker"] = worker_bytes
+                info["max_pinned_bytes_per_worker"] = max(worker_bytes, default=0)
+                info["chunk_bytes_per_worker"] = chunk_bytes
+                info["max_chunk_bytes_per_worker"] = max(chunk_bytes, default=0)
+                info["n_chunks_per_worker"] = n_chunks
+                info["n_chunks"] = max(n_chunks, default=0)
+                info["chunk_size"] = max(chunk_bytes, default=0)
+                log.info("  planned <= %d chunk(s) per worker (total %.2f GiB)",
+                         info["n_chunks"], info["bytes"] / 2**30)
 
             elif cmd == "restore_weights":
-                if pinned_buf is None or index is None:
-                    raise RuntimeError(
-                        "restore_weights requires attach+stage first")
-
-                total_bytes = pinned_buf.numel()
+                if llm is None:
+                    raise RuntimeError("restore_weights requires init first")
+                results = llm.collective_rpc(_semip_restore_weights)
+                total_bytes = sum(r["bytes"] for r in results)
+                total_loaded = sum(r["loaded"] for r in results)
                 info["bytes"] = total_bytes
-
-                # Use cached chunk plan if planned; otherwise fall back
-                # to a single-chunk plan equivalent to the prior path.
-                if chunk_plan is None:
-                    plan = [(0, total_bytes,
-                             [(n, o, nb, dt, sh)
-                              for n, (o, nb, dt, sh) in index.items()])]
-                    cs = total_bytes
-                else:
-                    plan = chunk_plan
-                    cs = chunk_size
-
-                # Drain any pending GPU work before the (potentially
-                # large) staging-buffer alloc so the cumem allocator
-                # settles on a clean contiguous block.
-                torch.cuda.synchronize(0)
-                buf_gpu = torch.empty(cs, dtype=torch.uint8,
-                                      device="cuda:0")
-                for chunk_lo, chunk_hi, members in plan:
-                    n = chunk_hi - chunk_lo
-                    buf_gpu[:n].copy_(pinned_buf[chunk_lo:chunk_hi],
-                                      non_blocking=True)
-                    torch.cuda.synchronize(0)
-
-                    _members = members
-                    _lo = chunk_lo
-                    _buf = buf_gpu
-
-                    # Mirror image of ``_compute_layout_full`` /
-                    # ``_stage_weights``: build a unified
-                    # ``name -> tensor`` table for main params + drafter
-                    # params, then dispatch each chunk member to the
-                    # right destination by namespaced name.
-                    def _scatter(self):
-                        main = self.model_runner.model
-                        drafter = getattr(self.model_runner, "drafter", None)
-                        dm = (getattr(drafter, "model", None)
-                              if drafter is not None else None)
-                        targets = {f"main:p:{n}": p.data
-                                   for n, p in main.named_parameters()}
-                        if dm is not None:
-                            for n, p in dm.named_parameters():
-                                targets[f"drafter:p:{n}"] = p.data
-                        for name, off, nbytes, dtype, shape in _members:
-                            start = off - _lo
-                            src = (_buf[start:start + nbytes]
-                                   .view(dtype).reshape(shape))
-                            targets[name].copy_(src)
-                        return len(_members)
-
-                    llm.collective_rpc(_scatter)
-                    torch.cuda.synchronize(0)
-
-                log.info("  loaded %d params in %d chunk(s) "
-                         "(chunk<= %.2f GiB, total %.2f GiB)",
-                         len(index), len(plan),
-                         cs / 2**30, total_bytes / 2**30)
-
-                # Free staging buffer through PyTorch's caching allocator
-                # so block metadata stays consistent across CRIU cycles.
-                buf_gpu.storage().resize_(0)
-                del buf_gpu
-                torch.cuda.empty_cache()
+                info["n_chunks"] = max(r["n_chunks"] for r in results)
+                log.info("  loaded %d params in <= %d chunk(s) (total %.2f GiB)",
+                         total_loaded, info["n_chunks"], total_bytes / 2**30)
 
             elif cmd == "wake_up_kv_cache":
                 llm.wake_up(tags=["kv_cache"])
@@ -1914,149 +2030,28 @@ def vllm_child_loop(pipe_conn, instance_id, gpus, model_dir=None):
                             engine.step()
 
             elif cmd == "save_weights":
-                if pinned_buf is None or index is None:
-                    raise RuntimeError(
-                        "save_weights requires attach+stage first")
-
-                weights_dir = kwargs["weights_dir"]
-                shard_bytes = int(kwargs.get("shard_bytes")
-                                  or _WEIGHTS_SHARD_BYTES)
-                workers_req = int(kwargs.get("io_workers")
-                                  or _WEIGHTS_IO_WORKERS)
-                total = pinned_buf.numel()
-                mv = memoryview(pinned_buf.numpy())
-
-                # Recreate the dir clean so stale shards from a prior
-                # (possibly larger) model can't linger.  Aborted runs may
-                # leave root-owned files -> fall back to `sudo rm -rf`
-                # (mirrors the criu_dump dir-clear in worker.py).
-                if os.path.exists(weights_dir):
-                    try:
-                        shutil.rmtree(weights_dir)
-                    except PermissionError:
-                        subprocess.run(["sudo", "rm", "-rf", weights_dir],
-                                       check=True)
-                os.makedirs(weights_dir, exist_ok=True)
-
-                ranges = []
-                _lo = 0
-                _i = 0
-                while _lo < total:
-                    _hi = min(_lo + shard_bytes, total)
-                    ranges.append((_i, _lo, _hi))
-                    _lo = _hi
-                    _i += 1
-                workers = max(1, min(workers_req, len(ranges)))
-
-                def _write_shard(i, lo, hi):
-                    fd = os.open(
-                        os.path.join(weights_dir, f"shard_{i:04d}.bin"),
-                        os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
-                    try:
-                        pos = lo
-                        while pos < hi:            # os.write may short-write
-                            pos += os.write(fd, mv[pos:hi])
-                        os.fsync(fd)
-                    finally:
-                        os.close(fd)
-                    return hi - lo
-
-                t0 = time.perf_counter()
-                with ThreadPoolExecutor(max_workers=workers) as ex:
-                    for fu in [ex.submit(_write_shard, *r) for r in ranges]:
-                        fu.result()               # re-raise worker errors
-                dt = time.perf_counter() - t0
-
-                model_name = getattr(
-                    getattr(engine, "model_config", None), "model", None)
-                manifest = {
-                    "total_bytes": total,
-                    "n_params": len(index),
-                    "model": model_name,
-                    "shard_bytes": shard_bytes,
-                    "shards": [{"name": f"shard_{i:04d}.bin",
-                                "offset": lo, "nbytes": hi - lo}
-                               for (i, lo, hi) in ranges],
-                    "layout": [[name, off, nbytes, str(dtype), list(shape)]
-                               for name, (off, nbytes, dtype, shape)
-                               in index.items()],
-                }
-                with open(os.path.join(weights_dir, "weights_meta.json"),
-                          "w") as f:
-                    json.dump(manifest, f)
-
-                info["weights_dir"] = weights_dir
+                if llm is None:
+                    raise RuntimeError("save_weights requires attach+stage first")
+                results = llm.collective_rpc(
+                    _semip_save_weights,
+                    args=(kwargs["weights_dir"], kwargs.get("shard_bytes"),
+                          kwargs.get("io_workers")))
+                total = sum(results)
+                info["weights_dir"] = kwargs["weights_dir"]
                 info["bytes"] = total
-                info["n_shards"] = len(ranges)
-                log.info("  saved weights: %d shard(s), %.2f GiB in %.2fs "
-                         "(%.2f GiB/s)", len(ranges), total / 2**30, dt,
-                         (total / 2**30) / dt if dt > 0 else 0.0)
+                log.info("  saved weights: %.2f GiB across %d worker(s)",
+                         total / 2**30, len(results))
 
             elif cmd == "load_weights":
-                if pinned_buf is None or index is None:
+                if llm is None:
                     raise RuntimeError("load_weights requires attach first")
-
-                weights_dir = kwargs["weights_dir"]
-                meta_path = os.path.join(weights_dir, "weights_meta.json")
-                if not os.path.isfile(meta_path):
-                    raise RuntimeError(
-                        f"no weights manifest at {meta_path}; "
-                        f"run save_weights first")
-                with open(meta_path) as f:
-                    manifest = json.load(f)
-
-                total = pinned_buf.numel()
-                if int(manifest["total_bytes"]) != total:
-                    raise RuntimeError(
-                        f"weights size mismatch: manifest "
-                        f"{manifest['total_bytes']}B but attached buffer "
-                        f"{total}B (config/model changed?)")
-
-                # Strict layout check against the freshly-attached index:
-                # (name, offset, nbytes) must line up exactly.
-                cur_layout = [[name, off, nbytes]
-                              for name, (off, nbytes, dtype, shape)
-                              in index.items()]
-                man_layout = [[row[0], row[1], row[2]]
-                              for row in manifest.get("layout", [])]
-                if man_layout and man_layout != cur_layout:
-                    raise RuntimeError(
-                        "weights layout mismatch between manifest and "
-                        "attached model (param order/sizes differ)")
-
-                mv = memoryview(pinned_buf.numpy())
-                shards = manifest["shards"]
-                workers = max(1, min(int(kwargs.get("io_workers")
-                                         or _WEIGHTS_IO_WORKERS), len(shards)))
-
-                def _read_shard(s):
-                    lo = int(s["offset"])
-                    n = int(s["nbytes"])
-                    dst = mv[lo:lo + n]
-                    got = 0
-                    with open(os.path.join(weights_dir, s["name"]),
-                              "rb", buffering=0) as f:
-                        while got < n:             # readinto may short-read
-                            r = f.readinto(dst[got:])
-                            if r == 0:
-                                break
-                            got += r
-                    if got != n:
-                        raise RuntimeError(
-                            f"{s['name']}: read {got} != {n}")
-                    return n
-
-                t0 = time.perf_counter()
-                with ThreadPoolExecutor(max_workers=workers) as ex:
-                    for fu in [ex.submit(_read_shard, s) for s in shards]:
-                        fu.result()               # re-raise worker errors
-                dt = time.perf_counter() - t0
-
+                results = llm.collective_rpc(
+                    _semip_load_weights,
+                    args=(kwargs["weights_dir"], kwargs.get("io_workers")))
+                total = sum(results)
                 info["bytes"] = total
-                info["n_shards"] = len(shards)
-                log.info("  loaded weights: %d shard(s), %.2f GiB in %.2fs "
-                         "(%.2f GiB/s)", len(shards), total / 2**30, dt,
-                         (total / 2**30) / dt if dt > 0 else 0.0)
+                log.info("  loaded weights: %.2f GiB across %d worker(s)",
+                         total / 2**30, len(results))
 
             else:
                 error = f"unknown command: {cmd}"
@@ -2118,7 +2113,6 @@ def vllm_child_loop(pipe_conn, instance_id, gpus, model_dir=None):
             if cmd == "exit":
                 _drain_engine()
                 log.info("exit")
-                pinned_buf = None
                 pipe_conn.send("exit_ack")
                 break
 

--- a/arctic_inference/semi_persistence/vllm_child.py
+++ b/arctic_inference/semi_persistence/vllm_child.py
@@ -71,7 +71,7 @@ def _repin_buffer(buf):
         raise RuntimeError(f"cudaHostRegister failed with cudaError={ret}")
 
 
-def vllm_child_loop(pipe_conn, instance_id, rank):
+def vllm_child_loop(pipe_conn, instance_id, rank, model_dir=None):
     """Runs in a spawned child process: owns CUDA and vLLM.
 
     The main loop has two modes:
@@ -83,6 +83,37 @@ def vllm_child_loop(pipe_conn, instance_id, rank):
     os.environ["CUDA_VISIBLE_DEVICES"] = str(rank)
     os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
     os.environ["USE_LIBUV"] = "0"
+
+    # JIT/compile caches (Triton, vLLM torch.compile, torch inductor,
+    # FlashInfer) all produce .so's that get dlopen()'d into the process.
+    # CRIU records those mappings by absolute path and requires the files
+    # to exist at restore; their defaults live in node-local dirs
+    # ($HOME/.triton, ~/.cache/vllm, /tmp/torchinductor_*), so on another
+    # node they are absent and restore fails with "Can't open file ...".
+    #
+    # When the Instance supplies a model_dir, the cache lives at
+    # <model_dir>/compilation -- embedded next to the CRIU image so the
+    # compile cache is isolated per model and travels with the image as one
+    # unit.  This makes restore-on-another-node require model_dir to exist
+    # at the same absolute path on that node (copy the whole model_dir over
+    # first).  Absent a model_dir, the caches keep their defaults, which is
+    # correct for same-node restore.
+    #
+    # Must be set before vLLM (and FlashInfer, whose env module resolves
+    # these at import) is imported.
+    if model_dir:
+        _compile_root = os.path.join(model_dir, "compilation")
+        os.environ["TRITON_CACHE_DIR"] = os.path.join(_compile_root, "triton")
+        os.environ["VLLM_CACHE_ROOT"] = os.path.join(_compile_root, "vllm")
+        os.environ["TORCHINDUCTOR_CACHE_DIR"] = os.path.join(
+            _compile_root, "inductor")
+        os.environ["FLASHINFER_WORKSPACE_BASE"] = os.path.join(
+            _compile_root, "flashinfer")
+        for _cache_dir in (os.environ["TRITON_CACHE_DIR"],
+                           os.environ["VLLM_CACHE_ROOT"],
+                           os.environ["TORCHINDUCTOR_CACHE_DIR"],
+                           os.environ["FLASHINFER_WORKSPACE_BASE"]):
+            os.makedirs(_cache_dir, exist_ok=True)
 
     semip_logging.init_process()
     log = semip_logging.child(instance_id, rank)
@@ -487,6 +518,13 @@ def vllm_child_loop(pipe_conn, instance_id, rank):
                     "CUDA_VISIBLE_DEVICES",
                     "VLLM_ENABLE_V1_MULTIPROCESSING",
                     "USE_LIBUV",
+                    # Compile-cache roots: CRIU bakes the resulting .so
+                    # paths into the image, so a user override here would
+                    # make the image unrestorable.
+                    "TRITON_CACHE_DIR",
+                    "VLLM_CACHE_ROOT",
+                    "TORCHINDUCTOR_CACHE_DIR",
+                    "FLASHINFER_WORKSPACE_BASE",
                 }
                 for k, v in (vllm_config.pop("_env", None) or {}).items():
                     if k in _RESERVED_ENV:

--- a/arctic_inference/semi_persistence/vllm_child.py
+++ b/arctic_inference/semi_persistence/vllm_child.py
@@ -33,6 +33,68 @@ serves TP=1, where the single worker is in-process.
 import ctypes, json, os, shutil, subprocess, sys, time
 from concurrent.futures import ThreadPoolExecutor
 
+
+def _drop_caps_for_portable_image():
+    """Zero this process's Linux capabilities so its CRIU image restores on
+    nodes whose capability bounding set can't grant them.
+
+    Must run in the spawned vLLM child BEFORE ``import torch`` -- torch/vLLM
+    spawn many background threads (cuda, jemalloc, hf-xet, gloo, ...) and
+    CRIU records credentials *per thread*.  A thread inherits the creating
+    thread's capabilities, so dropping here (before any are created) yields
+    an image where every task records an empty cap set; restore_creds()
+    (capset) then trivially succeeds instead of failing with EPERM on a
+    node lacking CAP_SYS_ADMIN etc.  (Dropping later, e.g. in
+    prepare_criu_dump, would only affect the main thread and leave the
+    others with full caps.)
+
+    Gated by the internal _SEMIP_CHILD_DROP_CAPS signal (set transiently by
+    the worker only across this child's spawn -- NOT a user-facing flag; the
+    user-facing switch is SEMIP_UNPRIVILEGED) so ONLY the child drops -- the
+    parent worker keeps its caps to run ``sudo criu``.  Safe for inference: host
+    pinning uses RLIMIT_MEMLOCK (unlimited on GPU nodes), not CAP_IPC_LOCK,
+    and all sockets bind to unprivileged ports.
+    """
+    try:
+        libc = ctypes.CDLL("libc.so.6", use_errno=True)
+        PR_CAPBSET_DROP = 24
+        PR_CAP_AMBIENT = 47
+        PR_CAP_AMBIENT_CLEAR_ALL = 4
+        PR_SET_DUMPABLE = 4
+        # Drop the bounding set first -- it needs CAP_SETPCAP, which the
+        # capset() below removes.  EINVAL past the last valid cap is ignored.
+        for cap in range(64):
+            libc.prctl(PR_CAPBSET_DROP, cap, 0, 0, 0)
+        libc.prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0)
+
+        class _CapHeader(ctypes.Structure):
+            _fields_ = [("version", ctypes.c_uint32), ("pid", ctypes.c_int)]
+
+        class _CapData(ctypes.Structure):
+            _fields_ = [("effective", ctypes.c_uint32),
+                        ("permitted", ctypes.c_uint32),
+                        ("inheritable", ctypes.c_uint32)]
+
+        _LINUX_CAPABILITY_VERSION_3 = 0x20080522
+        hdr = _CapHeader(_LINUX_CAPABILITY_VERSION_3, 0)
+        data = (_CapData * 2)()  # zero-initialized -> clears eff/prm/inh
+        rc = libc.capset(ctypes.byref(hdr), ctypes.byref(data))
+        # Keep the process dumpable so `sudo criu` seizes it cleanly after
+        # the credential change (capset can reset dumpable to suid_dumpable).
+        libc.prctl(PR_SET_DUMPABLE, 1, 0, 0, 0)
+        print(f"[semip] dropped capabilities for portable image "
+              f"(capset rc={rc})", flush=True)
+    except Exception as e:  # never block startup on a cap-drop failure
+        print(f"[semip] cap-drop failed (continuing): {e}", flush=True)
+
+
+# Internal signal (leading underscore): the worker sets _SEMIP_CHILD_DROP_CAPS
+# only in this spawned child's environment when running unprivileged.  It is
+# deliberately NOT the user-facing SEMIP_UNPRIVILEGED flag -- the worker itself
+# imports this module and must keep its caps to run `sudo criu`.
+if os.environ.get("_SEMIP_CHILD_DROP_CAPS") == "1":
+    _drop_caps_for_portable_image()
+
 import torch
 
 import semip_logging

--- a/arctic_inference/semi_persistence/vllm_child.py
+++ b/arctic_inference/semi_persistence/vllm_child.py
@@ -101,6 +101,28 @@ def vllm_child_loop(pipe_conn, instance_id, rank):
     _child_log_path = semip_logging.redirect_stdio_to_instance_file(
         instance_id)
 
+    # Detach from the controlling terminal before anything is captured.
+    # fd 1/2 are already the per-instance log file (above); fd 0 is still
+    # the interactive shell's pts, inherited down the spawn chain.  A pts
+    # on fd 0 makes CRIU dump the process as a --shell-job tied to an
+    # external terminal/session, which cannot be reattached when the tree
+    # is restored inside a private PID namespace (criu tty.c: TIOCSPGRP
+    # fails because the namespaced pgid can't own the host terminal).
+    # Point fd 0 at /dev/null and start a fresh session so the captured
+    # tree owns its own session and holds no controlling terminal.
+    try:
+        _devnull = os.open(os.devnull, os.O_RDONLY)
+        os.dup2(_devnull, 0)
+        os.close(_devnull)
+    except OSError:
+        pass
+    try:
+        os.setsid()
+    except OSError:
+        # Already a session/group leader (rare for a spawned child); the
+        # fd-0 redirect above is the part that matters for CRIU.
+        pass
+
     torch.cuda.set_device(0)
 
     llm = None

--- a/arctic_inference/semi_persistence/worker.py
+++ b/arctic_inference/semi_persistence/worker.py
@@ -363,7 +363,10 @@ def _worker_criu_save(child_pid, image_dir, pipe_fd, pipe_resource, rank,
         "-t", str(child_pid),
         "-D", image_dir,
         "-o", "dump.log",
-        "--shell-job",
+        # No --shell-job: the child detaches from the controlling terminal
+        # at startup (fd 0 -> /dev/null + setsid), so no tty enters the
+        # image.  A tty would be unreattachable inside the private PID
+        # namespace the restore path uses.
         "--tcp-close",
         "--ext-unix-sk",
         "--link-remap",
@@ -429,11 +432,67 @@ def _find_pid_by_pipe(pipe_inode):
     return None
 
 
+# CRIU restores every task at its *recorded* PID (via clone3(set_tid)).
+# Two images captured on the same node with their child trees alive at
+# the same time carry adjacent/interleaved PIDs, and a destructive dump
+# leaves the killed child as a zombie under its still-live worker, which
+# keeps that PID occupied.  Either way the restore fails with
+# "Can't fork for <pid>: File exists" (EEXIST) on whatever TID is already
+# taken.
+#
+# The fix is to give each restore its own PID namespace so the recorded
+# PIDs are free.  CRIU 4.2 can't ``--join-ns pid:`` an existing PID
+# namespace ("join-ns pid namespace not supported"), so instead we run
+# criu itself *inside* a fresh PID namespace: a privileged helper does
+# ``unshare(CLONE_NEWPID)`` + ``fork()`` so its child is PID 1, that PID 1
+# unshares a mount namespace and mounts a private /proc (so criu sees the
+# namespace's PID view), forks criu ``restore -d``, records criu's exit
+# code, then reaps forever so the namespace (and the detached restored
+# tree, reparented onto it) stays alive.  Everything the rest of the
+# worker touches keys off the restored root's *host* PID (found via the
+# inherited pipe), which is unaffected by the nested namespace.  The
+# holder tuple is ``(pid1_host_pid, popen)``; SIGKILLing PID 1 destroys
+# the namespace and the whole restored tree in one shot.
+
+
+def _kill_pidns_holder(holder, log=None):
+    """Tear down a restore's PID-namespace holder ``(pid1_host_pid, popen)``.
+
+    SIGKILLing PID 1 of the namespace makes the kernel kill every task in
+    it (the restored tree), so this doubles as the restored-tree cleanup.
+    """
+    if not holder:
+        return
+    host_pid, proc = holder
+    try:
+        subprocess.run(["sudo", "kill", "-9", str(host_pid)],
+                       capture_output=True)
+    except Exception:
+        pass
+    try:
+        proc.wait(timeout=5)
+    except Exception:
+        try:
+            proc.kill()
+        except OSError:
+            pass
+    if log is not None:
+        log.info("  PID-namespace holder torn down (reaper host_pid=%s)",
+                 host_pid)
+
+
 def _worker_criu_load(image_dir, new_pipe_fd):
     """Restore a vLLM child process tree from a CRIU image on disk.
 
-    Discovers the host PID by scanning /proc for the process holding
-    the inherited pipe fd.
+    Restores into a dedicated PID namespace (criu runs *inside* a fresh
+    namespace held open by a PID 1 reaper) so the image's recorded PIDs
+    can't collide with a concurrently-restored sibling's tree or with a
+    zombie left behind by the dump.  Returns ``(host_pid, meta, holder)``
+    where ``host_pid`` is the restored root's *host-visible* PID
+    (discovered by scanning /proc for the inherited pipe -- the
+    ``--pidfile`` reports the in-namespace PID, which is meaningless on
+    the host) and ``holder`` is ``(pid1_host_pid, popen)`` to hand to
+    ``_kill_pidns_holder`` at teardown.
     """
     import fcntl
 
@@ -486,7 +545,10 @@ def _worker_criu_load(image_dir, new_pipe_fd):
         "criu", "restore",
         "-D", image_dir,
         "-o", "restore.log",
-        "--shell-job",
+        # No --shell-job: images captured by the updated dump path own
+        # their session and hold no controlling terminal, so there is no
+        # external tty to reattach -- which is what would otherwise break
+        # restore inside the private PID namespace.
         "--tcp-close",
         "--inherit-fd", f"fd[{new_pipe_fd}]:{pipe_resource}",
         "--inherit-fd", "fd[1]:stdout",
@@ -496,52 +558,172 @@ def _worker_criu_load(image_dir, new_pipe_fd):
         "-d",
         "-v4",
     ]
+
+    # Runtime side-channels (on shared storage, visible from inside the
+    # helper's private mount namespace and from the host worker alike):
+    #   reaper.pid -- PID 1's host PID, published by the host-ns parent
+    #   restore.rc -- criu's exit code, published by PID 1 once criu exits
+    reaper_pidfile = os.path.join(image_dir, "reaper.pid")
+    rc_path = os.path.join(image_dir, "restore.rc")
+    # A prior run that died abnormally (SIGKILL, crash) may have left its
+    # reaper -- and thus its namespace + restored tree -- alive.  If a
+    # stale reaper.pid points at a live process, kill it before reusing
+    # this image so we don't accumulate orphaned namespaces.
+    if os.path.exists(reaper_pidfile):
+        try:
+            _stale_reaper = int(open(reaper_pidfile).read().strip())
+            if _stale_reaper > 1 and os.path.exists(f"/proc/{_stale_reaper}"):
+                subprocess.run(["sudo", "kill", "-9", str(_stale_reaper)],
+                               capture_output=True)
+        except (OSError, ValueError):
+            pass
+    for _stale in (reaper_pidfile, rc_path):
+        if os.path.exists(_stale):
+            os.remove(_stale)
+
+    # Helper (run as root via sudo).  sudo strips fds >= 3, so it first
+    # re-receives the inherited pipe fd over the SCM_RIGHTS socket, then
+    # unshares a PID namespace and forks: the host-ns parent publishes
+    # PID 1's host PID and blocks; PID 1 unshares a mount namespace with a
+    # private /proc, forks criu ``restore -d`` into the new namespace,
+    # records criu's exit code, and reaps forever so the namespace (and
+    # the detached restored tree) survives.
     helper_script = (
-        "import os, socket, array\n"
-        f"s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)\n"
+        "import os, socket, array, ctypes, signal, sys, time\n"
+        "libc = ctypes.CDLL('libc.so.6', use_errno=True)\n"
+        "CLONE_NEWPID = 0x20000000\n"
+        "CLONE_NEWNS = 0x00020000\n"
+        "MS_REC = 0x4000\n"
+        "MS_PRIVATE = 0x40000\n"
+        "s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)\n"
         f"s.connect({sock_path!r})\n"
-        f"msg, ancdata, _, _ = s.recvmsg(1, socket.CMSG_LEN(4))\n"
-        f"for cl, ct, cd in ancdata:\n"
-        f"    if cl == socket.SOL_SOCKET and ct == socket.SCM_RIGHTS:\n"
-        f"        fds = array.array('i'); fds.frombytes(cd)\n"
-        f"        received = fds[0]\n"
-        f"s.close()\n"
+        "msg, ancdata, _, _ = s.recvmsg(1, socket.CMSG_LEN(4))\n"
+        "received = None\n"
+        "for cl, ct, cd in ancdata:\n"
+        "    if cl == socket.SOL_SOCKET and ct == socket.SCM_RIGHTS:\n"
+        "        fds = array.array('i'); fds.frombytes(cd); received = fds[0]\n"
+        "s.close()\n"
         f"os.dup2(received, {new_pipe_fd})\n"
         f"if received != {new_pipe_fd}: os.close(received)\n"
-        f"os.execvp({criu_argv[0]!r}, {criu_argv!r})\n"
+        "if libc.unshare(CLONE_NEWPID) != 0:\n"
+        "    e = ctypes.get_errno()\n"
+        "    sys.stderr.write('unshare(CLONE_NEWPID): %s\\n' % os.strerror(e))\n"
+        "    os._exit(3)\n"
+        "pid1 = os.fork()\n"
+        "if pid1 > 0:\n"
+        # host-ns parent: fd belongs to the restored tree now, drop our
+        # copy so the pipe scan uniquely finds the restored root; publish
+        # PID 1's host pid; block so this process (and the sudo handle)
+        # lives as long as the namespace.
+        f"    os.close({new_pipe_fd})\n"
+        f"    open({reaper_pidfile!r}, 'w').write(str(pid1) + '\\n')\n"
+        "    try:\n"
+        "        os.waitpid(pid1, 0)\n"
+        "    except OSError:\n"
+        "        pass\n"
+        "    os._exit(0)\n"
+        "os.setsid()\n"
+        "if libc.unshare(CLONE_NEWNS) == 0:\n"
+        "    libc.mount(b'none', b'/', None, MS_REC | MS_PRIVATE, None)\n"
+        "    libc.mount(b'proc', b'/proc', b'proc', 0, None)\n"
+        "criu_pid = os.fork()\n"
+        "if criu_pid == 0:\n"
+        f"    os.execvp({criu_argv[0]!r}, {criu_argv!r})\n"
+        "    os._exit(127)\n"
+        f"os.close({new_pipe_fd})\n"
+        "_, status = os.waitpid(criu_pid, 0)\n"
+        "rc = os.waitstatus_to_exitcode(status)\n"
+        "try:\n"
+        f"    open({rc_path!r}, 'w').write(str(rc) + '\\n')\n"
+        "except OSError:\n"
+        "    pass\n"
+        "signal.signal(signal.SIGTERM, lambda *a: os._exit(0))\n"
+        "while True:\n"
+        "    try:\n"
+        "        os.waitpid(-1, 0)\n"
+        "    except ChildProcessError:\n"
+        "        time.sleep(0.2)\n"
+        "    except OSError:\n"
+        "        time.sleep(0.2)\n"
     )
     cmd = ["sudo", "python3", "-c", helper_script]
-    result = subprocess.run(
-        cmd, capture_output=True, text=True,
-    )
-    sender.join(timeout=2)
-    try:
-        os.remove(sock_path)
-    except OSError:
-        pass
-    subprocess.run(["sudo", "chown", "-R", f"{os.getuid()}:{os.getgid()}", image_dir],
-                   capture_output=True)
-    if result.returncode != 0:
-        detail = result.stderr or result.stdout or "(no output)"
-        log_path = os.path.join(image_dir, "restore.log")
-        if os.path.exists(log_path):
-            with open(log_path) as f:
-                detail += "\n--- restore.log ---\n" + f.read()[-2000:]
-        raise RuntimeError(
-            f"criu restore failed (rc={result.returncode}): {detail}")
 
-    new_pid = None
+    holder = None
+    # From here on, any failure must tear the namespace down (which also
+    # kills anything CRIU partially restored into it) so we don't leak a
+    # namespace / orphan tree per attempt.
     try:
-        with open(pidfile) as f:
-            new_pid = int(f.read().strip())
-    except (OSError, ValueError):
+        # stdout -> /dev/null: criu logs to restore.log (via -o) and we
+        # signal completion through files, so nothing must be drained from
+        # stdout; the restored process transiently inherits fd 1 there
+        # (rebind_log repoints it right after) and an undrained pipe could
+        # otherwise fill and block it.  Keep stderr for helper diagnostics.
+        proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL,
+                                stderr=subprocess.PIPE, text=True)
+
+        # Wait for PID 1's host pid and criu's exit code to appear.  criu
+        # restore of a large model tree can take a while; poll generously.
+        deadline = time.time() + 300
+        reaper_pid = None
+        rc = None
+        while time.time() < deadline:
+            if reaper_pid is None and os.path.exists(reaper_pidfile):
+                try:
+                    reaper_pid = int(open(reaper_pidfile).read().strip())
+                    holder = (reaper_pid, proc)
+                except (OSError, ValueError):
+                    reaper_pid = None
+            if os.path.exists(rc_path):
+                try:
+                    rc = int(open(rc_path).read().strip())
+                    break
+                except (OSError, ValueError):
+                    rc = None
+            if proc.poll() is not None and reaper_pid is None:
+                # Helper died before even publishing PID 1 (e.g. unshare
+                # failed); surface its stderr.
+                break
+            time.sleep(0.1)
+
+        sender.join(timeout=2)
+        try:
+            os.remove(sock_path)
+        except OSError:
+            pass
+        subprocess.run(["sudo", "chown", "-R", f"{os.getuid()}:{os.getgid()}", image_dir],
+                       capture_output=True)
+
+        if rc is None:
+            _err = ""
+            try:
+                if proc.poll() is not None:
+                    _err = (proc.stderr.read() or "")[-500:]
+            except Exception:
+                pass
+            raise RuntimeError(
+                f"criu restore did not complete (reaper_pid={reaper_pid!r}, "
+                f"helper stderr={_err!r})")
+        if rc != 0:
+            detail = f"rc={rc}"
+            log_path = os.path.join(image_dir, "restore.log")
+            if os.path.exists(log_path):
+                with open(log_path) as f:
+                    detail += "\n--- restore.log ---\n" + f.read()[-2000:]
+            raise RuntimeError(f"criu restore failed ({detail})")
+
+        # The restored root lives in the private namespace, so the
+        # ``--pidfile`` value is its in-namespace PID -- meaningless on the
+        # host.  Find its host PID by the inherited pipe instead.
         new_pid = _find_pid_by_pipe(pipe_inode)
-    if new_pid is None or new_pid == os.getpid():
-        raise RuntimeError(
-            f"failed to discover CRIU-restored root pid "
-            f"(pidfile={pidfile!r}, scan returned {new_pid!r})")
+        if new_pid is None or new_pid == os.getpid():
+            raise RuntimeError(
+                f"failed to discover CRIU-restored root host pid "
+                f"(pipe scan returned {new_pid!r})")
+    except BaseException:
+        _kill_pidns_holder(holder)
+        raise
 
-    return new_pid, meta
+    return new_pid, meta, holder
 
 
 # ---------------------------------------------------------------------------
@@ -890,6 +1072,18 @@ def worker_loop(instance_id, rank, cmd_queue, result_queue, completed_counter):
     child_proc = None
     child_queue = None
     child_thread_obj = None
+    # Set when a restore stands up a private PID namespace for the child
+    # tree; SIGKILLing its PID 1 at teardown destroys the namespace and
+    # the whole restored tree in one shot.
+    ns_holder = None
+
+    # Fallback cleanup: teardown/exit clear ns_holder after killing it, so
+    # this only fires when the worker dies abnormally (Ctrl-C, unhandled
+    # exception).  The closure reads the *current* ns_holder at exit time.
+    # SIGKILL can't run this; that case is covered by the stale-reaper
+    # sweep in _worker_criu_load on the next restore of the same image.
+    import atexit
+    atexit.register(lambda: _kill_pidns_holder(ns_holder, log))
 
     log.info("started")
 
@@ -937,7 +1131,10 @@ def worker_loop(instance_id, rank, cmd_queue, result_queue, completed_counter):
                     pipe_parent, pipe_child = mp.Pipe()
                     new_pipe_fd = pipe_child.fileno()
                     try:
-                        new_pid, meta = _worker_criu_load(image_dir, new_pipe_fd)
+                        new_pid, meta, _holder = _worker_criu_load(
+                            image_dir, new_pipe_fd)
+                        _kill_pidns_holder(ns_holder, log)
+                        ns_holder = _holder
                         pipe_child.close()
                         break
                     except RuntimeError as exc:
@@ -1018,6 +1215,8 @@ def worker_loop(instance_id, rank, cmd_queue, result_queue, completed_counter):
                     log.warning("child_proc still alive after join, force-killing")
                     _kill_process_tree(child_proc.pid)
                     child_proc.join(timeout=5)
+            _kill_pidns_holder(ns_holder, log)
+            ns_holder = None
             break
 
         if cmd == "exit":
@@ -1031,6 +1230,8 @@ def worker_loop(instance_id, rank, cmd_queue, result_queue, completed_counter):
                     log.warning("child_proc still alive after join, force-killing")
                     _kill_process_tree(child_proc.pid)
                     child_proc.join(timeout=5)
+            _kill_pidns_holder(ns_holder, log)
+            ns_holder = None
             result_queue.put(("exit", 0.0, None, {}))
             break
 

--- a/arctic_inference/semi_persistence/worker.py
+++ b/arctic_inference/semi_persistence/worker.py
@@ -1059,8 +1059,13 @@ def _child_thread(instance_id, rank, child_pid, pipe,
 # Worker main loop
 # ---------------------------------------------------------------------------
 
-def worker_loop(instance_id, rank, cmd_queue, result_queue, completed_counter):
-    """Main loop for a per-Instance worker process."""
+def worker_loop(instance_id, rank, cmd_queue, result_queue, completed_counter,
+                model_dir=None):
+    """Main loop for a per-Instance worker process.
+
+    ``model_dir`` is threaded to the vLLM child so it can point its
+    compile cache at ``<model_dir>/compilation``.
+    """
     semip_logging.init_process()
     log = semip_logging.worker(instance_id, rank)
     # Route everything this process emits (worker.N records, prints,
@@ -1101,7 +1106,7 @@ def worker_loop(instance_id, rank, cmd_queue, result_queue, completed_counter):
             spawn_ctx = mp.get_context("spawn")
             child_proc = spawn_ctx.Process(
                 target=vllm_child_loop,
-                args=(pipe_child, instance_id, rank),
+                args=(pipe_child, instance_id, rank, model_dir),
             )
             child_proc.start()
             pipe_child.close()

--- a/arctic_inference/semi_persistence/worker.py
+++ b/arctic_inference/semi_persistence/worker.py
@@ -692,7 +692,9 @@ def _worker_criu_load(image_dir, new_pipe_fd):
         "    except OSError:\n"
         "        time.sleep(0.2)\n"
     )
-    cmd = ["sudo", "python3", "-c", helper_script]
+    cmd = ["python3", "-c", helper_script]
+    if not _is_root:
+        cmd.insert(0, "sudo")
 
     holder = None
     # From here on, any failure must tear the namespace down (which also

--- a/arctic_inference/semi_persistence/worker.py
+++ b/arctic_inference/semi_persistence/worker.py
@@ -179,6 +179,10 @@ def _kill_process_tree(pid):
 
 _is_root = os.geteuid() == 0
 
+# Handed to `criu dump --libdir` so CRIU's plugin loader finds nothing there.
+# It must exist: CRIU opens it during plugin init and dies otherwise.
+_CRIU_EMPTY_LIBDIR = "/usr/lib/criu/empty"
+
 
 def _run_cuda_checkpoint(action, pid, ignore_state_err=False, device_map=None):
     """Run sudo cuda-checkpoint --action <action> --pid <pid>."""
@@ -380,6 +384,17 @@ def _worker_criu_save(child_pid, image_dir, pipe_fd, pipe_resource, gpus,
             subprocess.run(["sudo", "rm", "-rf", image_dir], check=True)
     os.makedirs(image_dir, exist_ok=True)
 
+    # Neither the CRIU PPA nor the source build creates the --libdir target,
+    # and criu dies at plugin init without it ("Unable to open directory
+    # /usr/lib/criu/empty", criu/plugin.c), so create it here instead of
+    # requiring a manual mkdir per node.  Under /usr/lib, so root-only.
+    if not os.path.isdir(_CRIU_EMPTY_LIBDIR):
+        try:
+            os.makedirs(_CRIU_EMPTY_LIBDIR, exist_ok=True)
+        except OSError:
+            subprocess.run(["sudo", "mkdir", "-p", _CRIU_EMPTY_LIBDIR],
+                           check=True)
+
     # At TP>1 the child spawns worker subprocesses whose Unix-domain IPC
     # sockets (multiproc-executor rpc / shm-broadcast) must be declared
     # --external to CRIU, so scan every descendant PID (deduped by inode), not
@@ -419,7 +434,7 @@ def _worker_criu_save(child_pid, image_dir, pipe_fd, pipe_resource, gpus,
         "--tcp-close",
         "--ext-unix-sk",
         "--link-remap",
-        "--libdir", "/usr/lib/criu/empty",
+        "--libdir", _CRIU_EMPTY_LIBDIR,
         "-v4",
     ]
     # SEMIP_UNPRIVILEGED=1: skip CRIU's network-namespace kerndat probe (which

--- a/arctic_inference/semi_persistence/worker.py
+++ b/arctic_inference/semi_persistence/worker.py
@@ -16,6 +16,18 @@ import torch.multiprocessing as mp
 import semip_logging
 
 
+def _unprivileged():
+    """CRIU runs unprivileged (dump + restore add ``--unprivileged``, and
+    restore skips the private PID namespace) when SEMIP_UNPRIVILEGED=1.
+
+    This is the single switch for running dump and restore on a
+    non-privileged pod that grants only CAP_CHECKPOINT_RESTORE +
+    CAP_SYS_PTRACE (no CAP_SYS_ADMIN).  See the "Reduced-capability
+    restore" section below for the capability rationale.
+    """
+    return os.environ.get("SEMIP_UNPRIVILEGED") == "1"
+
+
 # ---------------------------------------------------------------------------
 # Dead-child diagnostics
 # ---------------------------------------------------------------------------
@@ -410,6 +422,13 @@ def _worker_criu_save(child_pid, image_dir, pipe_fd, pipe_resource, gpus,
         "--libdir", "/usr/lib/criu/empty",
         "-v4",
     ]
+    # SEMIP_UNPRIVILEGED=1: skip CRIU's network-namespace kerndat probe (which
+    # needs CAP_SYS_ADMIN), so the dump runs on a non-privileged pod with only
+    # CAP_CHECKPOINT_RESTORE + CAP_SYS_PTRACE.  Pairs with the lowcap restore
+    # path selected by the same flag; see the "Reduced-capability restore"
+    # section below.
+    if _unprivileged():
+        cmd.append("--unprivileged")
     for ext in external_unix:
         cmd.extend(["--external", ext])
     result = subprocess.run(cmd, capture_output=True, text=True)
@@ -501,13 +520,41 @@ def _find_pid_by_pipe(pipe_inode):
 # the namespace and the whole restored tree in one shot.
 
 
-def _kill_pidns_holder(holder, log=None):
-    """Tear down a restore's PID-namespace holder ``(pid1_host_pid, popen)``.
+def _kill_restored_tree(root_pid, log=None):
+    """SIGKILL a root-owned, host-PID-namespace CRIU-restored tree.
 
-    SIGKILLing PID 1 of the namespace makes the kernel kill every task in
-    it (the restored tree), so this doubles as the restored-tree cleanup.
+    Used by the reduced-capability restore path, which has no PID namespace
+    to collapse.  The restored tasks are root-owned (restored via ``sudo
+    criu``), so kills go through ``sudo``.  The dump detaches the child into
+    its own session/process group, so we also nuke the group to catch tasks
+    that reparented away from ``root_pid``.
+    """
+    if not root_pid:
+        return
+    for p in _get_descendant_pids(root_pid) + [root_pid]:
+        subprocess.run(["sudo", "kill", "-9", str(p)], capture_output=True)
+    subprocess.run(["sudo", "kill", "-9", f"-{root_pid}"], capture_output=True)
+    if log is not None:
+        log.info("  restored tree killed (root host_pid=%s)", root_pid)
+
+
+def _kill_pidns_holder(holder, log=None):
+    """Tear down a restore's process tree.
+
+    Two holder shapes are accepted:
+
+    * ``(pid1_host_pid, popen)`` -- the namespace-based path.  SIGKILLing
+      PID 1 of the namespace makes the kernel kill every task in it (the
+      restored tree), so this doubles as the restored-tree cleanup.
+    * ``{"kind": "tree", "pid": root_host_pid}`` -- the reduced-capability
+      (host-PID-namespace) path.  There is no namespace to collapse, so the
+      restored tree is SIGKILLed directly.
     """
     if not holder:
+        return
+    if isinstance(holder, dict):
+        if holder.get("kind") == "tree":
+            _kill_restored_tree(holder.get("pid"), log=log)
         return
     host_pid, proc = holder
     try:
@@ -765,6 +812,199 @@ def _worker_criu_load(image_dir, new_pipe_fd):
             raise RuntimeError(
                 f"failed to discover CRIU-restored root host pid "
                 f"(pipe scan returned {new_pid!r})")
+    except BaseException:
+        _kill_pidns_holder(holder)
+        raise
+
+    return new_pid, meta, holder
+
+
+# ---------------------------------------------------------------------------
+# Reduced-capability restore (no private PID namespace)
+# ---------------------------------------------------------------------------
+#
+# Selected by the single SEMIP_UNPRIVILEGED=1 switch (see _unprivileged()),
+# which also makes _worker_criu_save pass --unprivileged so BOTH dump and
+# restore run on a non-privileged pod.
+#
+# The namespace-based path above needs CAP_SYS_ADMIN for two things:
+#   1. CRIU's kerndat init, which builds a throwaway *network* namespace to
+#      probe kernel features (fails with EPERM where netns creation is
+#      blocked -- see criu check / dump.log "Could not initialize kernel
+#      features detection").  This affects the dump too, which is why
+#      _worker_criu_save also passes --unprivileged in unprivileged mode.
+#   2. This worker's own unshare(CLONE_NEWPID|CLONE_NEWNS) helper, used only
+#      to avoid PID collisions between *concurrent* restores on one node.
+#
+# Neither is fundamental to restoring a single instance:
+#   * (1) is bypassed by CRIU's ``--unprivileged`` mode, which SKIPS the
+#     network-namespace kerndat probe entirely.
+#   * (2) is only needed for concurrency.  CRIU places each task at its
+#     recorded PID via clone3(set_tid), which in the *host* PID namespace is
+#     authorized by CAP_CHECKPOINT_RESTORE -- so it does NOT need to write
+#     the read-only ns_last_pid sysctl.  Dropping the namespace trades
+#     concurrent-restore safety (recorded PIDs must be free -> at most one
+#     live restore per node) for not needing CAP_SYS_ADMIN.
+#
+# Net effect: this path targets a floor of roughly
+#   CAP_CHECKPOINT_RESTORE (+ CAP_SYS_PTRACE)
+# with no unshare() calls.  The CUDA restore (cuCheckpointProcessRestore) is
+# orthogonal -- it is gated by /dev/nvidia* device access, not capabilities.
+#
+# Enable with SEMIP_UNPRIVILEGED=1.  Validate a node first with:
+#   sudo criu check --unprivileged
+# The image must record shed capabilities for restore_creds() to succeed on
+# the low-cap node -- in this mode the child drops its caps at dump
+# automatically (implied by SEMIP_UNPRIVILEGED; no separate flag).
+
+
+def _worker_criu_load_lowcap(image_dir, new_pipe_fd):
+    """Restore a vLLM child tree WITHOUT a private PID namespace.
+
+    Drop-in alternative to ``_worker_criu_load`` with the same
+    ``(host_pid, meta, holder)`` return contract, but:
+
+    * runs ``criu restore -d`` directly in the host PID namespace (no
+      unshare), so it needs no CAP_SYS_ADMIN for namespace creation;
+    * passes ``--unprivileged`` so CRIU skips the network-namespace kerndat
+      probe that otherwise aborts on nodes where netns creation is blocked;
+    * reads the restored root's host PID straight from ``--pidfile`` (with a
+      pipe-scan fallback), since without a PID namespace the recorded PID is
+      the host PID;
+    * returns ``holder = {"kind": "tree", "pid": host_pid}`` for
+      ``_kill_pidns_holder`` -> ``_kill_restored_tree`` at teardown.
+
+    Constraint: at most one live restore per node (recorded PIDs must be
+    free).  A PID collision surfaces as CRIU "File exists" in restore.log,
+    which the caller's retry loop already recognizes.
+    """
+    import fcntl, socket as _socket, tempfile, array, threading
+
+    meta_path = os.path.join(image_dir, "meta.json")
+    with open(meta_path) as f:
+        meta = json.load(f)
+    pipe_resource = meta["pipe_resource"]
+
+    pidfile = os.path.join(image_dir, "restored.pid")
+    for _stale in (pidfile, os.path.join(image_dir, "restore.log")):
+        if os.path.exists(_stale):
+            os.remove(_stale)
+
+    flags = fcntl.fcntl(new_pipe_fd, fcntl.F_GETFD)
+    fcntl.fcntl(new_pipe_fd, fcntl.F_SETFD, flags & ~fcntl.FD_CLOEXEC)
+
+    pipe_inode = os.readlink(f"/proc/self/fd/{new_pipe_fd}")
+    if pipe_inode.startswith("socket:["):
+        pipe_inode = pipe_inode.split("[")[1].rstrip("]")
+
+    # sudo strips fds >= 3, so hand the pipe fd to the (root) helper over a
+    # Unix socket via SCM_RIGHTS, same as the namespace path.
+    sock_path = os.path.join(tempfile.gettempdir(),
+                             f"criu_fd_{os.getpid()}_{new_pipe_fd}.sock")
+    if os.path.exists(sock_path):
+        os.remove(sock_path)
+    srv = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+    srv.bind(sock_path)
+    os.chmod(sock_path, 0o777)
+    srv.listen(1)
+
+    def _send_fd():
+        try:
+            conn, _ = srv.accept()
+            conn.sendmsg(
+                [b"\x00"],
+                [(_socket.SOL_SOCKET, _socket.SCM_RIGHTS,
+                  array.array("i", [new_pipe_fd]))])
+            conn.close()
+        finally:
+            srv.close()
+
+    sender = threading.Thread(target=_send_fd, daemon=True)
+    sender.start()
+
+    criu_argv = [
+        "criu", "restore",
+        "-D", image_dir,
+        "-o", "restore.log",
+        "--tcp-close",
+        "--inherit-fd", f"fd[{new_pipe_fd}]:{pipe_resource}",
+        "--inherit-fd", "fd[1]:stdout",
+        "--inherit-fd", "fd[2]:stderr",
+        "--pidfile", pidfile,
+        "--link-remap",
+        "-d",
+        "-v4",
+    ]
+    # --unprivileged makes CRIU operate within CAP_CHECKPOINT_RESTORE limits
+    # (skipping operations that would need CAP_SYS_ADMIN, e.g. the netns
+    # kerndat probe).  This path is only reached when SEMIP_UNPRIVILEGED=1, so
+    # it is always required here -- without it the restore fails on the very
+    # low-capability nodes this path exists for.
+    criu_argv.append("--unprivileged")
+
+    # Helper (root via sudo): re-receive the pipe fd, dup2 it to the number
+    # criu expects, then exec `criu restore -d` DIRECTLY -- no unshare, no
+    # new namespaces.  With -d, criu detaches the restored tree (reparented
+    # to the nearest subreaper) and exits with the restore rc, so the sudo
+    # process's exit code IS criu's rc; no long-lived reaper is required.
+    helper_script = (
+        "import os, socket, array\n"
+        "s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)\n"
+        f"s.connect({sock_path!r})\n"
+        "msg, ancdata, _, _ = s.recvmsg(1, socket.CMSG_LEN(4))\n"
+        "received = None\n"
+        "for cl, ct, cd in ancdata:\n"
+        "    if cl == socket.SOL_SOCKET and ct == socket.SCM_RIGHTS:\n"
+        "        fds = array.array('i'); fds.frombytes(cd); received = fds[0]\n"
+        "s.close()\n"
+        f"os.dup2(received, {new_pipe_fd})\n"
+        f"if received != {new_pipe_fd}: os.close(received)\n"
+        f"os.execvp({criu_argv[0]!r}, {criu_argv!r})\n"
+    )
+    cmd = ["sudo", "python3", "-c", helper_script]
+
+    holder = None
+    try:
+        # stdout/stderr -> /dev/null: criu logs everything to restore.log
+        # (via -o).  These must NOT be pipes -- with -d the restored process
+        # inherits fd 1/2 and holds them open after criu exits, so a pipe
+        # would never EOF and draining it (subprocess.run) would deadlock.
+        result = subprocess.run(cmd, stdout=subprocess.DEVNULL,
+                                stderr=subprocess.DEVNULL)
+
+        sender.join(timeout=2)
+        try:
+            os.remove(sock_path)
+        except OSError:
+            pass
+        subprocess.run(["sudo", "chown", "-R",
+                        f"{os.getuid()}:{os.getgid()}", image_dir],
+                       capture_output=True)
+
+        if result.returncode != 0:
+            detail = f"rc={result.returncode}"
+            log_path = os.path.join(image_dir, "restore.log")
+            if os.path.exists(log_path):
+                with open(log_path) as f:
+                    detail += "\n--- restore.log ---\n" + f.read()[-2000:]
+            raise RuntimeError(f"criu restore failed ({detail})")
+
+        # No PID namespace: the recorded PID *is* the host PID, so --pidfile
+        # is authoritative.  Fall back to the pipe scan if it is missing or
+        # stale.
+        new_pid = None
+        if os.path.exists(pidfile):
+            try:
+                new_pid = int(open(pidfile).read().strip())
+            except (OSError, ValueError):
+                new_pid = None
+        if not new_pid or not os.path.exists(f"/proc/{new_pid}"):
+            new_pid = _find_pid_by_pipe(pipe_inode)
+        if new_pid is None or new_pid == os.getpid():
+            raise RuntimeError(
+                "failed to discover CRIU-restored root host pid "
+                "(pidfile + pipe scan both failed)")
+        holder = {"kind": "tree", "pid": new_pid}
     except BaseException:
         _kill_pidns_holder(holder)
         raise
@@ -1180,7 +1420,27 @@ def worker_loop(instance_id, gpus, cmd_queue, result_queue, completed_counter,
                 target=vllm_child_loop,
                 args=(pipe_child, instance_id, list(gpus), model_dir),
             )
-            child_proc.start()
+            # In unprivileged mode (SEMIP_UNPRIVILEGED=1), ask ONLY the spawned
+            # child to drop its Linux capabilities (at its module import,
+            # before torch) so the CRIU image records an empty cap set and
+            # restores on low-capability nodes (restore_creds/capset succeeds).
+            # Cap-drop has no separate flag: it is implied by the same switch
+            # that adds --unprivileged to dump and picks the lowcap restore.
+            # _SEMIP_CHILD_DROP_CAPS is an internal signal (leading underscore),
+            # NOT a user flag: set it only across start() so it lands in the
+            # child's environment; the worker itself must keep its caps to run
+            # `sudo criu` (it also imports vllm_child, which drops on the flag).
+            _drop_caps = _unprivileged()
+            _prev_child_flag = os.environ.get("_SEMIP_CHILD_DROP_CAPS")
+            if _drop_caps:
+                os.environ["_SEMIP_CHILD_DROP_CAPS"] = "1"
+            try:
+                child_proc.start()
+            finally:
+                if _prev_child_flag is None:
+                    os.environ.pop("_SEMIP_CHILD_DROP_CAPS", None)
+                else:
+                    os.environ["_SEMIP_CHILD_DROP_CAPS"] = _prev_child_flag
             pipe_child.close()
             child_pid = child_proc.pid
 
@@ -1203,12 +1463,20 @@ def worker_loop(instance_id, gpus, cmd_queue, result_queue, completed_counter,
             try:
                 image_dir = kwargs["filename"]
 
+                # Reduced-capability path (no private PID namespace, no
+                # unshare) when SEMIP_UNPRIVILEGED=1 -- see
+                # _worker_criu_load_lowcap.  Defaults to the namespace-based
+                # path.
+                _load_fn = (_worker_criu_load_lowcap
+                            if _unprivileged()
+                            else _worker_criu_load)
+
                 max_retries = 5
                 for _attempt in range(max_retries):
                     pipe_parent, pipe_child = mp.Pipe()
                     new_pipe_fd = pipe_child.fileno()
                     try:
-                        new_pid, meta, _holder = _worker_criu_load(
+                        new_pid, meta, _holder = _load_fn(
                             image_dir, new_pipe_fd)
                         _kill_pidns_holder(ns_holder, log)
                         ns_holder = _holder

--- a/arctic_inference/semi_persistence/worker.py
+++ b/arctic_inference/semi_persistence/worker.py
@@ -333,7 +333,7 @@ def _worker_criu_save(child_pid, image_dir, pipe_fd, pipe_resource, rank,
     image is later restored via load().
     """
     # Clear any stale dump in the target directory so leftover files from a
-    # prior save_image() (which CRIU may not overwrite) cannot corrupt the new
+    # prior criu_dump() (which CRIU may not overwrite) cannot corrupt the new
     # image.  Files from a previously aborted dump may be root-owned, so fall
     # back to `sudo rm -rf` (sudo is already required for criu dump).
     if os.path.exists(image_dir):
@@ -571,7 +571,7 @@ def _child_thread(instance_id, rank, child_pid, pipe,
     # ack, cleared on a successful `resume` ack.  While true, the child
     # has frozen its step loop so no `generate_done` will arrive: we
     # turn `_drain_pipe_generates` into a no-op so that subsequent
-    # synchronous commands (`unpin`, `sleep`, `checkpoint_cuda`, ...)
+    # synchronous commands (`unpin`, `sleep`, `cuda_checkpoint`, ...)
     # do not deadlock waiting on completions that will not come until
     # `resume()` re-engages the engine via prefill.
     _worker_paused = False
@@ -638,12 +638,12 @@ def _child_thread(instance_id, rank, child_pid, pipe,
         _get_descendant_pids(child_pid) + [child_pid]
         if initial_state == "checkpointed" else None
     )
-    # When restore_cuda fails the child's CUDA driver state is left in
+    # When cuda_restore fails the child's CUDA driver state is left in
     # an inconsistent (locked / partially-restored) state.  Any
     # subsequent pipe-bound op (repin, generate, sleep, ...) would
     # deadlock the child in the driver.  Latch a "broken" flag so we
     # auto-fail those instead of forwarding them, until a later
-    # restore_cuda succeeds (or the worker is torn down).
+    # cuda_restore succeeds (or the worker is torn down).
     cuda_broken = False
     cuda_broken_reason = None
 
@@ -664,7 +664,7 @@ def _child_thread(instance_id, rank, child_pid, pipe,
             log.info("exited")
             break
 
-        if cmd == "checkpoint_cuda":
+        if cmd == "cuda_checkpoint":
             _drain_pipe_generates()
             t0 = time.perf_counter()
             error = None
@@ -676,12 +676,12 @@ def _child_thread(instance_id, rank, child_pid, pipe,
             except Exception as e:
                 error = f"{type(e).__name__}: {e}"
             elapsed = time.perf_counter() - t0
-            log.info("<<< checkpoint_cuda %s (%.3fs)",
+            log.info("<<< cuda_checkpoint %s (%.3fs)",
                      'OK' if error is None else 'FAILED', elapsed)
             _emit_result(cmd, elapsed, error, info)
             continue
 
-        if cmd == "restore_cuda":
+        if cmd == "cuda_restore":
             t0 = time.perf_counter()
             error = None
             target_gpu = kwargs["gpu"]
@@ -734,14 +734,14 @@ def _child_thread(instance_id, rank, child_pid, pipe,
             except Exception as e:
                 error = f"{type(e).__name__}: {e}"
                 cuda_broken = True
-                cuda_broken_reason = f"restore_cuda failed: {error}"
+                cuda_broken_reason = f"cuda_restore failed: {error}"
             elapsed = time.perf_counter() - t0
-            log.info("<<< restore_cuda %s (%.3fs)",
+            log.info("<<< cuda_restore %s (%.3fs)",
                      'OK' if error is None else 'FAILED', elapsed)
             _emit_result(cmd, elapsed, error, info)
             continue
 
-        if cmd == "save_image":
+        if cmd == "criu_dump":
             _drain_pipe_generates()
             t0 = time.perf_counter()
             error = None
@@ -780,7 +780,7 @@ def _child_thread(instance_id, rank, child_pid, pipe,
                 import traceback; traceback.print_exc()
                 error = f"{type(e).__name__}: {e}"
             elapsed = time.perf_counter() - t0
-            log.info("<<< save_image %s (%.3fs)",
+            log.info("<<< criu_dump %s (%.3fs)",
                      'OK' if error is None else 'FAILED', elapsed)
             _emit_result(cmd, elapsed, error, info)
             try:
@@ -925,7 +925,7 @@ def worker_loop(instance_id, rank, cmd_queue, result_queue, completed_counter):
             child_queue.put((cmd, kwargs))
             continue
 
-        if cmd == "load_image":
+        if cmd == "criu_restore":
             t0 = time.perf_counter()
             error = None
             info = {}
@@ -1000,9 +1000,9 @@ def worker_loop(instance_id, rank, cmd_queue, result_queue, completed_counter):
                 import traceback; traceback.print_exc()
                 error = f"{type(e).__name__}: {e}"
             elapsed = time.perf_counter() - t0
-            log.info("<<< load_image %s (%.3fs)",
+            log.info("<<< criu_restore %s (%.3fs)",
                      'OK' if error is None else 'FAILED', elapsed)
-            result_queue.put(("load_image", elapsed, error, info))
+            result_queue.put(("criu_restore", elapsed, error, info))
             with completed_counter.get_lock():
                 completed_counter.value += 1
             continue

--- a/arctic_inference/semi_persistence/worker.py
+++ b/arctic_inference/semi_persistence/worker.py
@@ -223,95 +223,116 @@ def _gpu_uuids():
     return uuids
 
 
-def _build_full_device_map(old_gpu, new_gpu):
-    """Build full GPU device map string for cuda-checkpoint --device-map.
+def _gpu_migration_permutation(old_gpus, new_gpus, n):
+    """Full ``n``-GPU bijection that pins ``old_gpus[k] -> new_gpus[k]``.
 
-    cuda-checkpoint requires a bijective mapping of ALL visible GPUs,
-    not just the pair being swapped.
-    Format: oldUuid1=newUuid1,oldUuid2=newUuid2,...
+    ``cuCheckpointProcessRestore`` needs a bijection over every visible GPU.
+    Only ``old_gpus`` hold this process's allocations; the remaining GPUs are
+    paired in order to complete the permutation (works even if the sets
+    overlap, e.g. ``[4,5,6,7] -> [0,1,4,5]``).
     """
-    uuids = _gpu_uuids()
-    if not (0 <= old_gpu < len(uuids) and 0 <= new_gpu < len(uuids)):
+    perm = dict(zip(old_gpus, new_gpus))
+    spare = iter(g for g in range(n) if g not in set(new_gpus))
+    return [perm[i] if i in perm else next(spare) for i in range(n)]
+
+
+def _build_full_device_map(old_gpus, new_gpus, old_uuids=None):
+    """Build the ``oldUuid=newUuid,...`` device map for cuda-checkpoint.
+
+    cuda-checkpoint requires a bijective mapping of ALL visible GPUs, not
+    just the ones being swapped.  ``old_uuids`` are the capture node's GPU
+    UUIDs (from meta.json, the "old" side); the "new" side is read from the
+    local restore node, which is what makes cross-node migration work.
+    """
+    if not old_uuids:
         raise ValueError(
-            f"GPU index out of range: old_gpu={old_gpu}, new_gpu={new_gpu}, "
-            f"visible GPUs=[0..{len(uuids) - 1}]")
-    pairs = []
-    for i, uuid in enumerate(uuids):
-        if i == old_gpu:
-            pairs.append(f"{uuid}={uuids[new_gpu]}")
-        elif i == new_gpu:
-            pairs.append(f"{uuid}={uuids[old_gpu]}")
-        else:
-            pairs.append(f"{uuid}={uuid}")
-    return ",".join(pairs)
+            "image is missing 'gpu_uuids' in meta.json; recapture with the "
+            "updated worker so the capture node's GPU UUIDs are recorded")
+    new_uuids = _gpu_uuids()
+    perm = _gpu_migration_permutation(old_gpus, new_gpus, len(new_uuids))
+    return ",".join(f"{old_uuids[i]}={new_uuids[perm[i]]}"
+                    for i in range(len(new_uuids)))
 
 
-def _build_restore_args(old_gpu, new_gpu):
+def _build_restore_args(old_gpus, new_gpus, old_uuids=None):
     """Build a CUcheckpointRestoreArgs ctypes buffer for GPU migration.
 
-    Layout (64-bit):
-      gpuPairs*      (8 bytes pointer)
-      gpuPairsCount  (4 bytes, unsigned int)
-      reserved       (44 bytes, zeroed)
-      reserved1      (8 bytes, zeroed)
-    Each CUcheckpointGpuPair is oldUuid(16) + newUuid(16) = 32 bytes.
+    Layout (64-bit): gpuPairs* (8), gpuPairsCount (4), reserved (52 zeroed).
+    Each CUcheckpointGpuPair is oldUuid(16) + newUuid(16).  ``old_uuids`` are
+    the capture node's GPU UUIDs (from meta.json); the "new" side is local.
     """
-    uuids_str = _gpu_uuids()
-    if not (0 <= old_gpu < len(uuids_str) and 0 <= new_gpu < len(uuids_str)):
+    if not old_uuids:
         raise ValueError(
-            f"GPU index out of range: old_gpu={old_gpu}, new_gpu={new_gpu}, "
-            f"visible GPUs=[0..{len(uuids_str) - 1}]")
-    uuids = [bytes.fromhex(u.replace("GPU-", "").replace("-", ""))
-             for u in uuids_str]
+            "image is missing 'gpu_uuids' in meta.json; recapture with the "
+            "updated worker so the capture node's GPU UUIDs are recorded")
+
+    def _to_bytes(us):
+        return [bytes.fromhex(u.replace("GPU-", "").replace("-", ""))
+                for u in us]
+
+    new_uuids = _gpu_uuids()
+    n = len(new_uuids)
+    perm = _gpu_migration_permutation(old_gpus, new_gpus, n)
+    old_bytes = _to_bytes(old_uuids)
+    new_bytes = _to_bytes(new_uuids)
 
     pairs_data = bytearray()
-    for i in range(len(uuids)):
-        old_uuid = uuids[i]
-        if i == old_gpu:
-            new_uuid = uuids[new_gpu]
-        elif i == new_gpu:
-            new_uuid = uuids[old_gpu]
-        else:
-            new_uuid = uuids[i]
-        pairs_data += old_uuid + new_uuid
+    for i in range(n):
+        pairs_data += old_bytes[i] + new_bytes[perm[i]]
 
     pairs_buf = (ctypes.c_char * len(pairs_data))(*pairs_data)
     pairs_ptr = ctypes.cast(pairs_buf, ctypes.c_void_p)
-
     args_data = bytearray(64)
     struct.pack_into("<Q", args_data, 0, pairs_ptr.value)
-    struct.pack_into("<I", args_data, 8, len(uuids))
+    struct.pack_into("<I", args_data, 8, n)
     args_buf = (ctypes.c_char * 64)(*args_data)
     return args_buf, pairs_buf
 
 
-def _worker_restore(pids, old_gpu=None, new_gpu=None):
+def _worker_restore(pids, old_gpus=None, new_gpus=None, old_uuids=None):
     """Restore CUDA context on pids.
 
     State machine: checkpointed → restore → locked → unlock → running
 
     Uses driver API directly when running as root, falls back to the
     cuda-checkpoint CLI via sudo otherwise.
+
+    ``old_gpus`` / ``new_gpus`` are the capture and restore GPU lists.  When
+    they differ, a device-map bijection remaps ``old_gpus[k] -> new_gpus[k]``
+    (TP1 and TP>1).  ``old_uuids`` (from meta.json) are the "old" side, so
+    the capture and restore nodes need not be the same machine.
+
+    Two-pass: restore ALL pids, THEN unlock ALL pids.  With a TP process tree
+    an unlocked worker could otherwise touch a still-locked sibling (NCCL/IPC)
+    and race; restoring the whole tree before unlocking any avoids that.
     """
+    migrate = bool(old_gpus and new_gpus and list(old_gpus) != list(new_gpus))
+    ordered = list(reversed(pids))
     if _is_root:
         cu = _get_cu()
         args_ptr = None
         _kept_alive = None
-        if old_gpu is not None and new_gpu is not None and old_gpu != new_gpu:
-            args_buf, pairs_buf = _build_restore_args(old_gpu, new_gpu)
+        if migrate:
+            args_buf, pairs_buf = _build_restore_args(
+                old_gpus, new_gpus, old_uuids)
             args_ptr = ctypes.cast(args_buf, ctypes.c_void_p)
             _kept_alive = (args_buf, pairs_buf)
-        for pid in reversed(pids):
-            _check_cu(f"Restore({pid})", cu.cuCheckpointProcessRestore(pid, args_ptr),
+        for pid in ordered:
+            _check_cu(f"Restore({pid})",
+                      cu.cuCheckpointProcessRestore(pid, args_ptr),
                       ignore=_CU_CHECKPOINT_ALREADY_DONE)
-            _check_cu(f"Unlock({pid})", cu.cuCheckpointProcessUnlock(pid, None),
+        for pid in ordered:
+            _check_cu(f"Unlock({pid})",
+                      cu.cuCheckpointProcessUnlock(pid, None),
                       ignore=_CU_CHECKPOINT_ALREADY_DONE)
     else:
         device_map = None
-        if old_gpu is not None and new_gpu is not None and old_gpu != new_gpu:
-            device_map = _build_full_device_map(old_gpu, new_gpu)
-        for pid in reversed(pids):
+        if migrate:
+            device_map = _build_full_device_map(
+                old_gpus, new_gpus, old_uuids)
+        for pid in ordered:
             _run_cuda_checkpoint("restore", pid, device_map=device_map)
+        for pid in ordered:
             _run_cuda_checkpoint("unlock", pid, ignore_state_err=True)
 
 
@@ -325,12 +346,16 @@ def _resolve_fd_resource(pid, fd):
     return link
 
 
-def _worker_criu_save(child_pid, image_dir, pipe_fd, pipe_resource, rank,
+def _worker_criu_save(child_pid, image_dir, pipe_fd, pipe_resource, gpus,
                       meta_extra=None):
     """Dump the vLLM child process tree to disk via CRIU (destructive).
 
+    ``gpus`` is the physical GPU list the tree currently occupies; it is
+    recorded in meta.json (with the capture node's GPU UUIDs) so a later
+    restore can build the migration device map.
+
     The child process is killed after a successful dump.  The on-disk
-    image is later restored via load().
+    image is later restored via criu_restore().
     """
     # Clear any stale dump in the target directory so leftover files from a
     # prior criu_dump() (which CRIU may not overwrite) cannot corrupt the new
@@ -343,19 +368,31 @@ def _worker_criu_save(child_pid, image_dir, pipe_fd, pipe_resource, rank,
             subprocess.run(["sudo", "rm", "-rf", image_dir], check=True)
     os.makedirs(image_dir, exist_ok=True)
 
+    # At TP>1 the child spawns worker subprocesses whose Unix-domain IPC
+    # sockets (multiproc-executor rpc / shm-broadcast) must be declared
+    # --external to CRIU, so scan every descendant PID (deduped by inode), not
+    # just the child.  nvidia fds are only recorded off the child.
     external_unix = []
     nvidia_fds = {}
-    proc_fd_dir = f"/proc/{child_pid}/fd"
-    for fd_name in os.listdir(proc_fd_dir):
+    seen_inodes = set()
+    for scan_pid in _get_descendant_pids(child_pid) + [child_pid]:
+        proc_fd_dir = f"/proc/{scan_pid}/fd"
         try:
-            link = os.readlink(f"{proc_fd_dir}/{fd_name}")
-            if link.startswith("socket:["):
-                ino = link.split("[")[1].rstrip("]")
-                external_unix.append(f"unix[{ino}]")
-            elif "/dev/nvidia" in link:
-                nvidia_fds[int(fd_name)] = link
+            fd_names = os.listdir(proc_fd_dir)
         except OSError:
-            pass
+            continue
+        for fd_name in fd_names:
+            try:
+                link = os.readlink(f"{proc_fd_dir}/{fd_name}")
+                if link.startswith("socket:["):
+                    ino = link.split("[")[1].rstrip("]")
+                    if ino not in seen_inodes:
+                        seen_inodes.add(ino)
+                        external_unix.append(f"unix[{ino}]")
+                elif scan_pid == child_pid and "/dev/nvidia" in link:
+                    nvidia_fds[int(fd_name)] = link
+            except OSError:
+                pass
 
     cmd = [
         "sudo",
@@ -387,12 +424,21 @@ def _worker_criu_save(child_pid, image_dir, pipe_fd, pipe_resource, rank,
         raise RuntimeError(
             f"criu dump failed (rc={result.returncode}): {detail}")
 
+    gpus = [gpus] if isinstance(gpus, int) else list(gpus)
     meta = {
         "child_pid": child_pid,
         "pipe_fd": pipe_fd,
         "pipe_resource": pipe_resource,
         "nvidia_fds": {str(k): v for k, v in nvidia_fds.items()},
-        "rank": rank,
+        "rank": gpus[0] if gpus else 0,
+        "gpus": gpus,
+        # Physical GPU UUIDs of the *capture* node.  Required for
+        # cross-node CUDA restore: cuCheckpointProcessRestore's device
+        # map must use the UUID baked into the checkpoint (capture node)
+        # as the "old" side; the restore node reads its own UUIDs for
+        # the "new" side.  Without this, cross-node restore fails with
+        # CUDA_ERROR_INVALID_VALUE (CUresult=1).
+        "gpu_uuids": _gpu_uuids(),
     }
     if meta_extra:
         meta.update(meta_extra)
@@ -730,17 +776,26 @@ def _worker_criu_load(image_dir, new_pipe_fd):
 # Child thread -- communicates with the vLLM child process via pipe
 # ---------------------------------------------------------------------------
 
-def _child_thread(instance_id, rank, child_pid, pipe,
+def _child_thread(instance_id, gpus, child_pid, pipe,
                   child_queue, result_queue, completed_counter,
-                  initial_state="alive"):
+                  initial_state="alive", capture_gpu_uuids=None):
     """Thread that owns the single child.  Pulls commands from child_queue,
     executes them serially, puts results on result_queue.
+
+    ``gpus`` is the physical GPU list this tree currently occupies (the
+    "old" side of a later migration); single-element at TP=1.
+    ``capture_gpu_uuids`` are the capture node's GPU UUIDs from meta.json,
+    needed to build the restore device map across nodes.
 
     Generate commands are fire-and-forget on the pipe.  The child sends
     back ("generate_done", ...) when done (new async child) or
     ("generate", ...) immediately (old CRIU-restored child with sync
     llm.generate).  The worker accepts both.
     """
+    if isinstance(gpus, int):
+        gpus = [gpus]
+    gpus = list(gpus)
+    rank = gpus[0]
     log = semip_logging.worker(instance_id, rank)
 
     def _emit_result(cmd, elapsed, error, info):
@@ -866,7 +921,13 @@ def _child_thread(instance_id, rank, child_pid, pipe,
         if cmd == "cuda_restore":
             t0 = time.perf_counter()
             error = None
-            target_gpu = kwargs["gpu"]
+            # TP>1 sends the whole placement list; a scalar gpu= is still
+            # accepted for TP=1 callers.
+            if kwargs.get("gpus") is not None:
+                target_gpus = list(kwargs["gpus"])
+            else:
+                target_gpus = [kwargs["gpu"]]
+            target_gpu = target_gpus[0]
             info = {}
             try:
                 if state == "alive":
@@ -901,12 +962,15 @@ def _child_thread(instance_id, rank, child_pid, pipe,
                         _all_settled = False
                 if _all_settled:
                     _worker_restore(checkpointed_pids,
-                                    old_gpu=rank,
-                                    new_gpu=target_gpu)
+                                    old_gpus=gpus,
+                                    new_gpus=target_gpus,
+                                    old_uuids=capture_gpu_uuids)
                 else:
                     log.info("  process still running after CRIU restore, skipping CUDA restore")
                 log.info("  restored pids: %s", checkpointed_pids)
                 info["gpu"] = target_gpu
+                info["gpus"] = list(target_gpus)
+                gpus = list(target_gpus)
                 rank = target_gpu
                 log.set_gpu(target_gpu)
                 checkpointed_pids = None
@@ -951,7 +1015,7 @@ def _child_thread(instance_id, rank, child_pid, pipe,
                 pipe_resource = _resolve_fd_resource(child_pid, child_pipe_fd)
 
                 meta = _worker_criu_save(
-                    child_pid, image_dir, child_pipe_fd, pipe_resource, rank,
+                    child_pid, image_dir, child_pipe_fd, pipe_resource, gpus,
                     meta_extra=kwargs.get("meta_extra"),
                 )
                 info["image_dir"] = image_dir
@@ -1059,13 +1123,21 @@ def _child_thread(instance_id, rank, child_pid, pipe,
 # Worker main loop
 # ---------------------------------------------------------------------------
 
-def worker_loop(instance_id, rank, cmd_queue, result_queue, completed_counter,
+def worker_loop(instance_id, gpus, cmd_queue, result_queue, completed_counter,
                 model_dir=None):
     """Main loop for a per-Instance worker process.
 
-    ``model_dir`` is threaded to the vLLM child so it can point its
-    compile cache at ``<model_dir>/compilation``.
+    ``gpus`` is the physical GPU list for this instance (single-element at
+    TP=1; a bare int is still accepted).  ``model_dir`` is threaded to the
+    vLLM child so it can point its compile cache at
+    ``<model_dir>/compilation``.
     """
+    if isinstance(gpus, int):
+        gpus = [gpus]
+    gpus = list(gpus)
+    rank = gpus[0]
+    # Capture-node GPU UUIDs, hydrated from meta.json on the restore path.
+    capture_gpu_uuids = None
     semip_logging.init_process()
     log = semip_logging.worker(instance_id, rank)
     # Route everything this process emits (worker.N records, prints,
@@ -1106,7 +1178,7 @@ def worker_loop(instance_id, rank, cmd_queue, result_queue, completed_counter,
             spawn_ctx = mp.get_context("spawn")
             child_proc = spawn_ctx.Process(
                 target=vllm_child_loop,
-                args=(pipe_child, instance_id, rank, model_dir),
+                args=(pipe_child, instance_id, list(gpus), model_dir),
             )
             child_proc.start()
             pipe_child.close()
@@ -1115,7 +1187,7 @@ def worker_loop(instance_id, rank, cmd_queue, result_queue, completed_counter,
             child_queue = queue.Queue()
             child_thread_obj = threading.Thread(
                 target=_child_thread,
-                args=(instance_id, rank, child_pid, pipe_parent,
+                args=(instance_id, list(gpus), child_pid, pipe_parent,
                       child_queue, result_queue, completed_counter),
                 daemon=True,
             )
@@ -1163,7 +1235,15 @@ def worker_loop(instance_id, rank, cmd_queue, result_queue, completed_counter,
 
                 child_pid = new_pid
                 child_proc = None
-                old_rank = meta.get("rank", rank)
+                # Placement the image was captured on: the "old" side of any
+                # subsequent migration.  Legacy images carry only "rank".
+                old_gpus = meta.get("gpus") or [meta.get("rank", gpus[0])]
+                old_gpus = list(old_gpus)
+                old_rank = old_gpus[0]
+                gpus = old_gpus
+                # Capture-node GPU UUIDs; required to build the cuda-restore
+                # device map when the restore node is not the capture node.
+                capture_gpu_uuids = meta.get("gpu_uuids")
 
                 # CRIU restored fd 1/2 onto the path that was open at dump
                 # time, which encodes the instance_id the model had then --
@@ -1184,15 +1264,16 @@ def worker_loop(instance_id, rank, cmd_queue, result_queue, completed_counter,
                 child_queue = queue.Queue()
                 child_thread_obj = threading.Thread(
                     target=_child_thread,
-                    args=(instance_id, old_rank, child_pid, pipe_parent,
+                    args=(instance_id, list(old_gpus), child_pid, pipe_parent,
                           child_queue, result_queue, completed_counter,
-                          "checkpointed"),
+                          "checkpointed", capture_gpu_uuids),
                     daemon=True,
                 )
                 child_thread_obj.start()
 
                 info["pid"] = new_pid
                 info["rank"] = old_rank
+                info["gpus"] = list(old_gpus)
                 info["image_dir"] = image_dir
                 info["child_log_path"] = semip_logging.instance_log_path(
                     instance_id)


### PR DESCRIPTION
Brings `semi_persistence` (released in #270) up to the internal tree: tensor
parallelism, cross-node restore, weights outside the CRIU image, and a
low-capability mode for unprivileged pods. 25 self-contained commits.

**TP>1** — four primitives, no-ops at TP=1: `destroy_nccl` / `reinit_nccl` for
the NCCL and CustomAllreduce state CRIU cannot serialize, `cleargraph` /
`recapture_graphs` to carry the captured decode graphs across the checkpoint and
rebind their baked addresses. Includes a correctness fix: the staging buffer lived
in the driver and was filled by a `collective_rpc` closure, so at TP>1 each
subprocess wrote into its own copy and the driver's buffer stayed empty, silently.

**Cross-node restore** — `meta.json` records the capture node's GPU UUIDs and the
restore device map pairs them against the local ones. Sockets are pinned to
loopback and the JIT caches moved under `<model_dir>/compilation` so no node
identity is baked into the image; the model directory is now the portable unit.

**Weights outside the image** — `save_weights` / `load_weights` shard into
`<model_dir>/weights` with a manifest validated on load, so the dump runs against
a detached and therefore small process image. Completes the
`{compilation, image, weights}` layout.

**Low-cap mode** — `SEMIP_UNPRIVILEGED=1` runs dump and restore with only
`CAP_CHECKPOINT_RESTORE + CAP_SYS_PTRACE`. Costs concurrent restore (one live
restore per node) and portability is fixed at dump time. Default-off.

**Restore fixes** — `Can't fork … File exists` (the destructive dump's zombie
holds the recorded PID; restore now runs in a fresh PID namespace),
`Address already in use` at TP2+ (the tree-kill's FINs park the recorded ports in
`TIME_WAIT`; sfc-gh-mhidayetoglu/ArcticInference#2, by @sfc-gh-ydu), and a
`demuxer.stop()` self-join.

**Teardown blast radius** — `_kill_restored_tree` ended with `sudo kill -9
-<root_pid>`, meant as a process-group kill; procps-ng `kill(1)` takes its
target from the first digit alone, so it ran `kill(-1, SIGKILL)` and, as root,
killed the worker and PID 1's only child. One pod burned its six retries and
returned 8 H200s to the shared pool. Not TP-specific. The kill is now scoped in
userspace against a `_tree_identity` snapshot of task ids and `/proc` start
times. No re-dump.

**Task-id collisions** — leader and thread ids share one counter, so a restore
needs its whole recorded task list free (~915 ids for a TP2 image, not 3 PIDs),
which `ps` cannot show and CRIU reports without naming the occupant. The low-cap
path now preflights and reports the occupants; `scripts/pidcheck.py` is the same
check standalone, with `--burn-to` to advance the counter before a cold start.

**Tooling and docs** — `scripts/imgdiff.py` pre-flights an image's file-backed
mappings against the local node and `scripts/pidcheck.py` its recorded task ids
(both need `crit` and root, no GPU; `--burn-to` needs neither); `test_tp2.py`,
`test_weights.py` and `reproduce/example_full.py` (the TP1/2/4/8 sweep) cover the
GPU paths. New `tp_DESIGN.md`, `semi-p_DESIGN.md`, `CROSS_NODE_RESTORE.md` (the
low-cap dump-and-restore runbook) and `TEARDOWN_SCOPING.md` (the incident record);
`CRIU_PLUMBING.md` now documents thirteen complications.

**For review:** `ca_graph_rebind.py` is 3954 of the ~6.7k new library lines — the
CUDA-graph address rebinder ported from internal, reached only on the TP>1 restore
path. `pytest arctic_inference/semi_persistence/tests/ -q` → 35 passed in ~4s, the
only GPU-free part. Commit-by-commit reads far better than the squashed diff; every
fix commit names the failure it came from.